### PR TITLE
Expand the CDPEx.Page API (Phase 2, Workstream A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `CDPEx.Page.wait_for_navigation/2` — await a navigation lifecycle milestone without issuing a navigation (e.g. after a click that navigates).
+- `CDPEx.Page.wait_for_function/3` — poll a JavaScript expression until it is truthy.
+- `CDPEx.Page.text/3`, `attribute/4`, `visible?/3` — element text / attribute / visibility helpers.
+
 ## [0.1.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.set_extra_headers/3`, `set_user_agent/3` — extra HTTP headers and User-Agent override.
 - `CDPEx.Page.set_viewport/4` — viewport / device-metrics emulation.
 - `CDPEx.Page.pdf/2` — render the page to PDF (`Page.printToPDF`); returns bytes or writes to `:path`.
+- `CDPEx.Page.call_function/4` — call a JS function with JSON-serialized arguments.
 
 ## [0.1.0] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.wait_for_navigation/2` — await a navigation lifecycle milestone without issuing a navigation (e.g. after a click that navigates).
 - `CDPEx.Page.wait_for_function/3` — poll a JavaScript expression until it is truthy.
 - `CDPEx.Page.text/3`, `attribute/4`, `visible?/3` — element text / attribute / visibility helpers.
+- `CDPEx.Page.cookies/2`, `set_cookies/3`, `clear_cookies/2` — cookie get / set / clear (lazily enables the `Network` domain).
+- `CDPEx.Page.set_extra_headers/3`, `set_user_agent/3` — extra HTTP headers and User-Agent override.
 
 ## [0.1.0] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.text/3`, `attribute/4`, `visible?/3` — element text / attribute / visibility helpers.
 - `CDPEx.Page.cookies/2`, `set_cookies/3`, `clear_cookies/2` — cookie get / set / clear (lazily enables the `Network` domain).
 - `CDPEx.Page.set_extra_headers/3`, `set_user_agent/3` — extra HTTP headers and User-Agent override.
+- `CDPEx.Page.set_viewport/4` — viewport / device-metrics emulation.
+- `CDPEx.Page.pdf/2` — render the page to PDF (`Page.printToPDF`); returns bytes or writes to `:path`.
 
 ## [0.1.0] - 2026-06-01
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -21,6 +21,7 @@ defmodule CDPEx.Page do
   @evaluate_timeout 15_000
   @selector_timeout 5_000
   @screenshot_timeout 30_000
+  @command_timeout 10_000
 
   @enforce_keys [:browser, :conn, :target_id]
   defstruct [:browser, :conn, :target_id]
@@ -299,6 +300,87 @@ defmodule CDPEx.Page do
     end
   end
 
+  @doc """
+  Returns all browser cookies as a list of CDP cookie maps.
+
+  Lazily enables the `Network` domain. Options: `:timeout` (default 10_000).
+  """
+  @spec cookies(t(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  def cookies(%__MODULE__{} = page, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @command_timeout)
+
+    with :ok <- ensure_network(page, timeout),
+         {:ok, %{"cookies" => cookies}} <-
+           Connection.call(page.conn, "Network.getAllCookies", %{}, timeout) do
+      {:ok, cookies}
+    end
+  end
+
+  @doc """
+  Sets cookies. Each is a CDP `CookieParam` map — at least `"name"`, `"value"`,
+  and a `"url"` or `"domain"`. Lazily enables `Network`. Options: `:timeout`.
+  """
+  @spec set_cookies(t(), [map()], keyword()) :: :ok | {:error, term()}
+  def set_cookies(%__MODULE__{} = page, cookies, opts \\ []) when is_list(cookies) do
+    timeout = Keyword.get(opts, :timeout, @command_timeout)
+
+    with :ok <- ensure_network(page, timeout),
+         {:ok, _} <-
+           Connection.call(page.conn, "Network.setCookies", %{"cookies" => cookies}, timeout) do
+      :ok
+    end
+  end
+
+  @doc "Clears all browser cookies. Lazily enables `Network`. Options: `:timeout`."
+  @spec clear_cookies(t(), keyword()) :: :ok | {:error, term()}
+  def clear_cookies(%__MODULE__{} = page, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @command_timeout)
+
+    with :ok <- ensure_network(page, timeout),
+         {:ok, _} <- Connection.call(page.conn, "Network.clearBrowserCookies", %{}, timeout) do
+      :ok
+    end
+  end
+
+  @doc """
+  Sets extra HTTP headers sent with every subsequent request on this page.
+
+  `headers` is a map of header name => value; set them before navigating for
+  them to apply to that navigation. Lazily enables `Network`. Options: `:timeout`.
+  """
+  @spec set_extra_headers(t(), %{optional(String.t()) => String.t()}, keyword()) ::
+          :ok | {:error, term()}
+  def set_extra_headers(%__MODULE__{} = page, headers, opts \\ []) when is_map(headers) do
+    timeout = Keyword.get(opts, :timeout, @command_timeout)
+
+    with :ok <- ensure_network(page, timeout),
+         {:ok, _} <-
+           Connection.call(
+             page.conn,
+             "Network.setExtraHTTPHeaders",
+             %{"headers" => headers},
+             timeout
+           ) do
+      :ok
+    end
+  end
+
+  @doc """
+  Overrides the page's User-Agent (`Emulation.setUserAgentOverride`).
+
+  Options: `:timeout` (default 10_000).
+  """
+  @spec set_user_agent(t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def set_user_agent(%__MODULE__{} = page, user_agent, opts \\ []) when is_binary(user_agent) do
+    timeout = Keyword.get(opts, :timeout, @command_timeout)
+    params = %{"userAgent" => user_agent}
+
+    case Connection.call(page.conn, "Emulation.setUserAgentOverride", params, timeout) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
   defp maybe_full_page(params, true), do: Map.put(params, "captureBeyondViewport", true)
   defp maybe_full_page(params, false), do: params
 
@@ -315,6 +397,15 @@ defmodule CDPEx.Page do
     case File.write(path, bytes) do
       :ok -> {:ok, path}
       {:error, reason} -> {:error, {:write_failed, reason}}
+    end
+  end
+
+  # Lazily enable the Network domain (idempotent in CDP) so cookie/header ops
+  # work without callers opting in at page creation — keeps Page stateless.
+  defp ensure_network(page, timeout) do
+    case Connection.call(page.conn, "Network.enable", %{}, timeout) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
     end
   end
 end

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -131,6 +131,29 @@ defmodule CDPEx.Page do
   end
 
   @doc """
+  Calls a JavaScript function with `args` and returns its value.
+
+  `function_declaration` is a JS function expression (e.g. `"(a, b) => a + b"`).
+  `args` must be JSON-serializable; they are encoded and applied to the function,
+  so no untrusted data is string-interpolated into code. A thrown exception is
+  `{:error, {:evaluate_exception, details}}`; non-serializable `args` return
+  `{:error, {:invalid_args, reason}}`.
+
+  Options: `:timeout` (default 15_000), `:await_promise` (default `false`).
+  """
+  @spec call_function(t(), String.t(), [term()], keyword()) :: {:ok, term()} | {:error, term()}
+  def call_function(%__MODULE__{} = page, function_declaration, args \\ [], opts \\ [])
+      when is_binary(function_declaration) and is_list(args) do
+    case Jason.encode(args) do
+      {:ok, json} ->
+        evaluate(page, "(#{function_declaration}).apply(undefined, #{json})", opts)
+
+      {:error, reason} ->
+        {:error, {:invalid_args, reason}}
+    end
+  end
+
+  @doc """
   Polls until `css` matches an element, or `timeout` elapses.
 
   Returns `:ok` or `{:error, :timeout}`. Options: `:timeout` (default 5_000),

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -330,7 +330,7 @@ defmodule CDPEx.Page do
 
     with {:ok, %{"data" => base64}} <-
            Connection.call(page.conn, "Page.captureScreenshot", params, timeout),
-         {:ok, bytes} <- decode_base64(base64) do
+         {:ok, bytes} <- decode_base64(base64, :invalid_screenshot_data) do
       write_or_return(bytes, Keyword.get(opts, :path))
     end
   end
@@ -458,7 +458,7 @@ defmodule CDPEx.Page do
 
     with {:ok, %{"data" => base64}} <-
            Connection.call(page.conn, "Page.printToPDF", params, timeout),
-         {:ok, bytes} <- decode_base64(base64) do
+         {:ok, bytes} <- decode_base64(base64, :invalid_pdf_data) do
       write_or_return(bytes, Keyword.get(opts, :path))
     end
   end
@@ -466,10 +466,10 @@ defmodule CDPEx.Page do
   defp maybe_full_page(params, true), do: Map.put(params, "captureBeyondViewport", true)
   defp maybe_full_page(params, false), do: params
 
-  defp decode_base64(base64) do
+  defp decode_base64(base64, error) do
     case Base.decode64(base64) do
       {:ok, bytes} -> {:ok, bytes}
-      :error -> {:error, :invalid_base64}
+      :error -> {:error, error}
     end
   end
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -166,8 +166,9 @@ defmodule CDPEx.Page do
   @doc """
   Polls until `css` matches an element, or `timeout` elapses.
 
-  Returns `:ok` or `{:error, :timeout}`. Options: `:timeout` (default 5_000),
-  `:interval` (poll interval ms, default 100).
+  Returns `:ok`, `{:error, :timeout}`, or `{:error, reason}` if a non-transient
+  evaluate error occurs (e.g. the connection drops). Options: `:timeout`
+  (default 5_000), `:interval` (poll interval ms, default 100).
   """
   @spec wait_for_selector(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def wait_for_selector(%__MODULE__{} = page, css, opts \\ []) when is_binary(css) do
@@ -178,8 +179,9 @@ defmodule CDPEx.Page do
   Polls a JavaScript expression until it is truthy, or `timeout` elapses.
 
   The expression is coerced with `!!(...)`, so JS truthiness applies. Returns
-  `:ok` or `{:error, :timeout}`. Options: `:timeout` (default 5_000),
-  `:interval` (poll interval ms, default 100).
+  `:ok`, `{:error, :timeout}`, or `{:error, reason}` if a non-transient evaluate
+  error occurs (e.g. a thrown exception or a dropped connection). Options:
+  `:timeout` (default 5_000), `:interval` (poll interval ms, default 100).
   """
   @spec wait_for_function(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def wait_for_function(%__MODULE__{} = page, js, opts \\ []) when is_binary(js) do
@@ -314,8 +316,8 @@ defmodule CDPEx.Page do
   @doc """
   Captures a PNG screenshot.
 
-  Returns `{:ok, png_binary}`, or `{:ok, path}` when `:path` is given (the file
-  is written and the path returned).
+  Returns `{:ok, data}` where `data` is the PNG bytes — or, when `:path` is
+  given, the written file path (also a binary).
 
   Options: `:path` (write to file), `:full_page` (capture beyond the viewport,
   default `false`), `:timeout` (default 30_000).
@@ -441,9 +443,9 @@ defmodule CDPEx.Page do
   @doc """
   Renders the page to PDF (`Page.printToPDF`).
 
-  Returns `{:ok, pdf_binary}`, or `{:ok, path}` when `:path` is given. Options:
-  `:path`, `:landscape` (default `false`), `:print_background` (default `true`),
-  `:timeout` (default 30_000).
+  Returns `{:ok, data}` where `data` is the PDF bytes — or, when `:path` is
+  given, the written file path (also a binary). Options: `:path`, `:landscape`
+  (default `false`), `:print_background` (default `true`), `:timeout` (default 30_000).
   """
   @spec pdf(t(), keyword()) :: {:ok, binary()} | {:error, term()}
   def pdf(%__MODULE__{} = page, opts \\ []) do

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -76,6 +76,31 @@ defmodule CDPEx.Page do
   defp lifecycle_name(_), do: "networkAlmostIdle"
 
   @doc """
+  Waits for a navigation lifecycle milestone, without issuing a navigation.
+
+  Useful after a `click/3` (or other in-page action) that triggers navigation.
+
+  Options:
+    * `:wait_until` — `:network_almost_idle` (default), `:load`, or `:none`
+    * `:timeout` — ms (default 30_000)
+
+  Returns `:ok`, `{:error, :timeout}`, or `{:error, reason}` if the connection
+  drops while waiting.
+  """
+  @spec wait_for_navigation(t(), keyword()) :: :ok | {:error, term()}
+  def wait_for_navigation(%__MODULE__{} = page, opts \\ []) do
+    case Keyword.get(opts, :wait_until, :network_almost_idle) do
+      :none ->
+        :ok
+
+      wait_until ->
+        name = lifecycle_name(wait_until)
+        timeout = Keyword.get(opts, :timeout, @navigate_timeout)
+        Connection.await_event(page.conn, &(&1["name"] == name), timeout)
+    end
+  end
+
+  @doc """
   Evaluates a JavaScript expression and returns its value (`returnByValue`).
 
   A thrown JS exception is `{:error, {:evaluate_exception, details}}`.
@@ -112,42 +137,119 @@ defmodule CDPEx.Page do
   """
   @spec wait_for_selector(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def wait_for_selector(%__MODULE__{} = page, css, opts \\ []) when is_binary(css) do
+    wait_for_function(page, "document.querySelector(#{Jason.encode!(css)}) !== null", opts)
+  end
+
+  @doc """
+  Polls a JavaScript expression until it is truthy, or `timeout` elapses.
+
+  The expression is coerced with `!!(...)`, so JS truthiness applies. Returns
+  `:ok` or `{:error, :timeout}`. Options: `:timeout` (default 5_000),
+  `:interval` (poll interval ms, default 100).
+  """
+  @spec wait_for_function(t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def wait_for_function(%__MODULE__{} = page, js, opts \\ []) when is_binary(js) do
     timeout = Keyword.get(opts, :timeout, @selector_timeout)
     interval = Keyword.get(opts, :interval, 100)
     deadline = System.monotonic_time(:millisecond) + timeout
-    poll_selector(page, css, interval, deadline)
+    poll_truthy(page, "!!(#{js})", interval, deadline)
   end
 
-  defp poll_selector(page, css, interval, deadline) do
-    js = "document.querySelector(#{Jason.encode!(css)}) !== null"
-
-    case probe_selector(page, js) do
-      :found ->
+  defp poll_truthy(page, js, interval, deadline) do
+    case probe_truthy(page, js) do
+      :truthy ->
         :ok
 
       {:fatal, reason} ->
         {:error, reason}
 
-      :not_found ->
+      :falsy ->
         if System.monotonic_time(:millisecond) >= deadline do
           {:error, :timeout}
         else
           Process.sleep(interval)
-          poll_selector(page, css, interval, deadline)
+          poll_truthy(page, js, interval, deadline)
         end
     end
   end
 
-  defp probe_selector(page, js) do
+  defp probe_truthy(page, js) do
     case evaluate(page, js) do
-      {:ok, true} -> :found
-      {:ok, _} -> :not_found
+      {:ok, true} ->
+        :truthy
+
+      {:ok, _falsy} ->
+        :falsy
+
       # A CDP error here is typically transient (e.g. the execution context is
       # not ready mid-navigation). Keep polling until the deadline rather than
       # failing hard — that's the point of a wait.
-      {:error, {:cdp_error, _method, _info}} -> :not_found
-      {:error, reason} -> {:fatal, reason}
+      {:error, {:cdp_error, _method, _info}} ->
+        :falsy
+
+      {:error, reason} ->
+        {:fatal, reason}
     end
+  end
+
+  @doc """
+  Returns the `textContent` of the first element matching `css`, or `nil` when
+  no element matches.
+  """
+  @spec text(t(), String.t(), keyword()) :: {:ok, String.t() | nil} | {:error, term()}
+  def text(%__MODULE__{} = page, css, opts \\ []) when is_binary(css) do
+    sel = Jason.encode!(css)
+
+    js = """
+    (() => {
+      const el = document.querySelector(#{sel});
+      return el ? el.textContent : null;
+    })()
+    """
+
+    evaluate(page, js, opts)
+  end
+
+  @doc """
+  Returns attribute `name` of the first element matching `css`, or `nil` when the
+  element or attribute is absent.
+  """
+  @spec attribute(t(), String.t(), String.t(), keyword()) ::
+          {:ok, String.t() | nil} | {:error, term()}
+  def attribute(%__MODULE__{} = page, css, name, opts \\ [])
+      when is_binary(css) and is_binary(name) do
+    sel = Jason.encode!(css)
+    attr = Jason.encode!(name)
+
+    js = """
+    (() => {
+      const el = document.querySelector(#{sel});
+      return el ? el.getAttribute(#{attr}) : null;
+    })()
+    """
+
+    evaluate(page, js, opts)
+  end
+
+  @doc """
+  Returns `{:ok, true}` when the first element matching `css` is rendered and
+  visible (has layout boxes, not `display: none` / `visibility: hidden`),
+  `{:ok, false}` otherwise — including when no element matches.
+  """
+  @spec visible?(t(), String.t(), keyword()) :: {:ok, boolean()} | {:error, term()}
+  def visible?(%__MODULE__{} = page, css, opts \\ []) when is_binary(css) do
+    sel = Jason.encode!(css)
+
+    js = """
+    (() => {
+      const el = document.querySelector(#{sel});
+      if (!el) return false;
+      const s = window.getComputedStyle(el);
+      return el.getClientRects().length > 0 && s.visibility !== "hidden" && s.display !== "none";
+    })()
+    """
+
+    evaluate(page, js, opts)
   end
 
   @doc """

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -422,7 +422,7 @@ defmodule CDPEx.Page do
   """
   @spec set_viewport(t(), pos_integer(), pos_integer(), keyword()) :: :ok | {:error, term()}
   def set_viewport(%__MODULE__{} = page, width, height, opts \\ [])
-      when is_integer(width) and is_integer(height) do
+      when is_integer(width) and width > 0 and is_integer(height) and height > 0 do
     timeout = Keyword.get(opts, :timeout, @command_timeout)
 
     params = %{

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -10,6 +10,16 @@ defmodule CDPEx.Page do
   Obtain one with `CDPEx.new_page/2`. If the underlying page dies (navigation to
   a new target, a crash), operations return `{:error, :noproc}` and you should
   open a fresh page.
+
+  ## Operations
+
+    * **Navigation** — `navigate/3`, `wait_for_navigation/2`
+    * **Evaluation** — `evaluate/3`, `call_function/4`, `html/2`
+    * **Waiting** — `wait_for_selector/3`, `wait_for_function/3`
+    * **Elements** — `text/3`, `attribute/4`, `visible?/3`, `click/3`
+    * **Capture** — `screenshot/2`, `pdf/2`
+    * **Emulation** — `set_viewport/4`, `set_user_agent/3`
+    * **Cookies & headers** — `cookies/2`, `set_cookies/3`, `clear_cookies/2`, `set_extra_headers/3`
   """
 
   alias CDPEx.Connection

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -295,7 +295,7 @@ defmodule CDPEx.Page do
 
     with {:ok, %{"data" => base64}} <-
            Connection.call(page.conn, "Page.captureScreenshot", params, timeout),
-         {:ok, bytes} <- decode_screenshot(base64) do
+         {:ok, bytes} <- decode_base64(base64) do
       write_or_return(bytes, Keyword.get(opts, :path))
     end
   end
@@ -381,13 +381,60 @@ defmodule CDPEx.Page do
     end
   end
 
+  @doc """
+  Overrides the viewport via `Emulation.setDeviceMetricsOverride`.
+
+  `width`/`height` are CSS pixels. Options: `:device_scale_factor` (default 1),
+  `:mobile` (default `false`), `:timeout`. Returns `:ok`.
+  """
+  @spec set_viewport(t(), pos_integer(), pos_integer(), keyword()) :: :ok | {:error, term()}
+  def set_viewport(%__MODULE__{} = page, width, height, opts \\ [])
+      when is_integer(width) and is_integer(height) do
+    timeout = Keyword.get(opts, :timeout, @command_timeout)
+
+    params = %{
+      "width" => width,
+      "height" => height,
+      "deviceScaleFactor" => Keyword.get(opts, :device_scale_factor, 1),
+      "mobile" => Keyword.get(opts, :mobile, false)
+    }
+
+    case Connection.call(page.conn, "Emulation.setDeviceMetricsOverride", params, timeout) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc """
+  Renders the page to PDF (`Page.printToPDF`).
+
+  Returns `{:ok, pdf_binary}`, or `{:ok, path}` when `:path` is given. Options:
+  `:path`, `:landscape` (default `false`), `:print_background` (default `true`),
+  `:timeout` (default 30_000).
+  """
+  @spec pdf(t(), keyword()) :: {:ok, binary()} | {:error, term()}
+  def pdf(%__MODULE__{} = page, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @screenshot_timeout)
+
+    params = %{
+      "landscape" => Keyword.get(opts, :landscape, false),
+      "printBackground" => Keyword.get(opts, :print_background, true)
+    }
+
+    with {:ok, %{"data" => base64}} <-
+           Connection.call(page.conn, "Page.printToPDF", params, timeout),
+         {:ok, bytes} <- decode_base64(base64) do
+      write_or_return(bytes, Keyword.get(opts, :path))
+    end
+  end
+
   defp maybe_full_page(params, true), do: Map.put(params, "captureBeyondViewport", true)
   defp maybe_full_page(params, false), do: params
 
-  defp decode_screenshot(base64) do
+  defp decode_base64(base64) do
     case Base.decode64(base64) do
       {:ok, bytes} -> {:ok, bytes}
-      :error -> {:error, :invalid_screenshot_data}
+      :error -> {:error, :invalid_base64}
     end
   end
 

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -122,6 +122,52 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, :timeout} = Page.wait_for_selector(page, "#does-not-exist", timeout: 300)
     end
 
+    test "wait_for_function resolves when truthy and times out otherwise", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+
+      assert :ok =
+               Page.wait_for_function(page, "document.title === 'CDPEx Fixture'", timeout: 2_000)
+
+      assert {:error, :timeout} =
+               Page.wait_for_function(page, "window.__never__ === 1", timeout: 300)
+    end
+
+    test "text returns element text, nil when absent", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#greeting")
+      assert {:ok, "Hello"} = Page.text(page, "#greeting")
+      assert {:ok, nil} = Page.text(page, "#does-not-exist")
+    end
+
+    test "attribute returns an element attribute, nil when absent", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#greeting")
+      assert {:ok, "greeting"} = Page.attribute(page, "#greeting", "id")
+      assert {:ok, nil} = Page.attribute(page, "#greeting", "data-nope")
+    end
+
+    test "visible? reflects element visibility", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#greeting")
+      assert {:ok, true} = Page.visible?(page, "#greeting")
+      assert {:ok, false} = Page.visible?(page, "#does-not-exist")
+    end
+
+    test "wait_for_navigation: :none is immediate, a no-nav wait times out", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.wait_for_navigation(page, wait_until: :none)
+      assert {:error, :timeout} = Page.wait_for_navigation(page, wait_until: :load, timeout: 300)
+    end
+
     test "click toggles observable DOM state", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       :ok = Page.wait_for_selector(page, "#btn")

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -196,6 +196,31 @@ defmodule CDPEx.IntegrationTest do
       assert File.exists?(path)
       File.rm(path)
     end
+
+    test "cookies round-trip: set, read, clear", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.set_cookies(page, [%{"name" => "cdpex", "value" => "42", "url" => fixture}])
+
+      assert {:ok, cookies} = Page.cookies(page)
+      assert Enum.any?(cookies, &(&1["name"] == "cdpex" and &1["value"] == "42"))
+
+      assert :ok = Page.clear_cookies(page)
+      assert {:ok, after_clear} = Page.cookies(page)
+      refute Enum.any?(after_clear, &(&1["name"] == "cdpex"))
+    end
+
+    test "set_user_agent overrides navigator.userAgent", %{page: page, fixture: fixture} do
+      assert :ok = Page.set_user_agent(page, "CDPExUA/1.0")
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:ok, "CDPExUA/1.0"} = Page.evaluate(page, "navigator.userAgent")
+    end
+
+    test "set_extra_headers are sent with the navigation request", %{page: page, fixture: fixture} do
+      assert :ok = Page.set_extra_headers(page, %{"X-CDPEx-Test" => "hello"})
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#echo-header")
+      assert {:ok, "hello"} = Page.text(page, "#echo-header")
+    end
   end
 
   describe "tracer bullet" do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -221,6 +221,26 @@ defmodule CDPEx.IntegrationTest do
       :ok = Page.wait_for_selector(page, "#echo-header")
       assert {:ok, "hello"} = Page.text(page, "#echo-header")
     end
+
+    test "set_viewport changes the reported viewport size", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.set_viewport(page, 800, 600)
+      assert {:ok, 800} = Page.evaluate(page, "window.innerWidth")
+      assert {:ok, 600} = Page.evaluate(page, "window.innerHeight")
+    end
+
+    test "pdf returns PDF bytes and can write a file", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#greeting")
+
+      assert {:ok, bytes} = Page.pdf(page)
+      assert <<"%PDF-", _rest::binary>> = bytes
+
+      path = Path.join(System.tmp_dir!(), "cdp_ex_doc_#{System.unique_integer([:positive])}.pdf")
+      assert {:ok, ^path} = Page.pdf(page, path: path)
+      assert File.exists?(path)
+      File.rm(path)
+    end
   end
 
   describe "tracer bullet" do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -113,6 +113,12 @@ defmodule CDPEx.IntegrationTest do
                Page.evaluate(page, "throw new Error('boom')")
     end
 
+    test "call_function applies JSON args and returns the result", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:ok, 5} = Page.call_function(page, "(a, b) => a + b", [2, 3])
+      assert {:ok, "HELLO"} = Page.call_function(page, "(s) => s.toUpperCase()", ["hello"])
+    end
+
     test "wait_for_selector resolves for present and times out for absent", %{
       page: page,
       fixture: fixture

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -10,17 +10,6 @@ defmodule CDPEx.FixtureServer do
   #     {:ok, %{url: url}} = FixtureServer.start()
   #     CDPEx.Page.navigate(page, url)
 
-  @html """
-  <!doctype html>
-  <html>
-    <head><title>CDPEx Fixture</title></head>
-    <body>
-      <h1 id="greeting">Hello</h1>
-      <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
-    </body>
-  </html>
-  """
-
   @spec start() :: {:ok, %{port: non_neg_integer(), url: String.t()}}
   def start do
     {:ok, listen} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
@@ -42,10 +31,14 @@ defmodule CDPEx.FixtureServer do
   end
 
   defp serve(socket) do
-    # Read (and ignore) the request line + headers, then respond.
-    _ = :gen_tcp.recv(socket, 0, 5_000)
+    # Read the request so we can reflect a header back into the page, then respond.
+    request =
+      case :gen_tcp.recv(socket, 0, 5_000) do
+        {:ok, data} -> data
+        _ -> ""
+      end
 
-    body = @html
+    body = render(request)
 
     response =
       "HTTP/1.1 200 OK\r\n" <>
@@ -55,5 +48,34 @@ defmodule CDPEx.FixtureServer do
 
     _ = :gen_tcp.send(socket, response)
     :gen_tcp.close(socket)
+  end
+
+  # Reflects the X-CDPEx-Test request header into #echo-header so integration
+  # tests can assert that extra headers were actually sent on the request.
+  defp render(request) do
+    """
+    <!doctype html>
+    <html>
+      <head><title>CDPEx Fixture</title></head>
+      <body>
+        <h1 id="greeting">Hello</h1>
+        <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
+        <div id="echo-header">#{header_value(request, "x-cdpex-test")}</div>
+      </body>
+    </html>
+    """
+  end
+
+  defp header_value(request, name) do
+    request
+    |> String.split("\r\n")
+    |> Enum.find_value("", &match_header(&1, name))
+  end
+
+  defp match_header(line, name) do
+    case String.split(line, ":", parts: 2) do
+      [k, v] -> if String.downcase(String.trim(k)) == name, do: String.trim(v)
+      _ -> nil
+    end
   end
 end

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -31,13 +31,9 @@ defmodule CDPEx.FixtureServer do
   end
 
   defp serve(socket) do
-    # Read the request so we can reflect a header back into the page, then respond.
-    request =
-      case :gen_tcp.recv(socket, 0, 5_000) do
-        {:ok, data} -> data
-        _ -> ""
-      end
-
+    # Read the full request headers (they may arrive across TCP segments) so the
+    # header reflection is deterministic, then respond.
+    request = recv_request(socket, "")
     body = render(request)
 
     response =
@@ -53,6 +49,8 @@ defmodule CDPEx.FixtureServer do
   # Reflects the X-CDPEx-Test request header into #echo-header so integration
   # tests can assert that extra headers were actually sent on the request.
   defp render(request) do
+    echo = html_escape(header_value(request, "x-cdpex-test"))
+
     """
     <!doctype html>
     <html>
@@ -60,7 +58,7 @@ defmodule CDPEx.FixtureServer do
       <body>
         <h1 id="greeting">Hello</h1>
         <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
-        <div id="echo-header">#{header_value(request, "x-cdpex-test")}</div>
+        <div id="echo-header">#{echo}</div>
       </body>
     </html>
     """
@@ -77,5 +75,31 @@ defmodule CDPEx.FixtureServer do
       [k, v] -> if String.downcase(String.trim(k)) == name, do: String.trim(v)
       _ -> nil
     end
+  end
+
+  # Read until the end-of-headers marker (or a sane cap), so a request split
+  # across TCP segments still yields the full headers for reflection.
+  defp recv_request(socket, acc) do
+    cond do
+      String.contains?(acc, "\r\n\r\n") ->
+        acc
+
+      byte_size(acc) > 65_536 ->
+        acc
+
+      true ->
+        case :gen_tcp.recv(socket, 0, 5_000) do
+          {:ok, data} -> recv_request(socket, acc <> data)
+          _ -> acc
+        end
+    end
+  end
+
+  defp html_escape(value) do
+    value
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
   end
 end


### PR DESCRIPTION
Phase 2, Workstream A of #2 — expands the `CDPEx.Page` API. (Workstream B, `sessionId` multiplexing, follows as a separate PR.)

## New `CDPEx.Page` functions
- **Navigation:** `wait_for_navigation/2`
- **Evaluation:** `call_function/4` — call a JS function with JSON-serialized args (no raw string-concat).
- **Waiting:** `wait_for_function/3` — poll a JS expression until truthy.
- **Elements:** `text/3`, `attribute/4`, `visible?/3`.
- **Cookies & headers:** `cookies/2`, `set_cookies/3`, `clear_cookies/2`, `set_extra_headers/3` (lazy, idempotent `Network.enable` keeps `Page` stateless).
- **Emulation:** `set_user_agent/3`, `set_viewport/4`.
- **Capture:** `pdf/2` (`Page.printToPDF`; bytes or `:path`).

## Refactors
- `wait_for_selector/3` now delegates to `wait_for_function/3` (generic `poll_truthy`), behavior unchanged.
- `screenshot/2` and `pdf/2` share a generalized base64 decoder.

## Tests
- +11 integration tests against the fixture server (now reflects the `X-CDPEx-Test` request header so the `set_extra_headers` test asserts the real effect; UA via `navigator.userAgent`).
- `mix ci` green (credo + Dialyzer + 50 unit tests, 0 failures); integration **24/0**, no orphan Chrome.

## Not in this PR (follow-ups)
- Hardening: `mix_audit` in the `ci` alias; the quiet-teardown log fix (subtle exit-propagation — kept separate from the API work).
- Workstream B: `sessionId` multiplexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
