### PR TITLE
Opt-in sessionId multiplexing (Phase 2, Workstream B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- Opt-in `sessionId` multiplexing: `CDPEx.new_page(browser, transport: :session)` drives many pages over the one browser WebSocket (default `:dedicated` = one socket per page). `CDPEx.Connection.call/5` and `await_event/4` gain a `:session_id` option.
 - `CDPEx.Page.wait_for_navigation/2` — await a navigation lifecycle milestone without issuing a navigation (e.g. after a click that navigates).
 - `CDPEx.Page.wait_for_function/3` — poll a JavaScript expression until it is truthy.
 - `CDPEx.Page.text/3`, `attribute/4`, `visible?/3` — element text / attribute / visibility helpers.

--- a/README.md
+++ b/README.md
@@ -39,9 +39,12 @@ you don't want a ChromeDriver process or a Node sidecar — that's the gap CDPEx
 
 > #### Status {: .info}
 >
-> **v0.1** is single-browser, one-WebSocket-per-page, headless Chrome only.
-> Connection pooling, `sessionId` multiplexing, network interception, and stealth
-> are intentionally out of scope for this release.
+> **Transports:** pages default to one WebSocket each (strong crash isolation).
+> Opt into `sessionId` multiplexing — many pages over the one browser socket —
+> with `new_page(browser, transport: :session)`; the trade-off is shared fate (a
+> dropped browser connection drops all of its session pages).
+>
+> Connection pooling, network interception, and stealth remain out of scope for now.
 
 ## Installation
 

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -27,9 +27,10 @@ defmodule CDPEx do
 
   > #### Status {: .info}
   >
-  > v0.1 is single-browser, one-WebSocket-per-page, headless-Chrome only.
-  > Connection pooling, `sessionId` multiplexing, and network interception are
-  > out of scope for this release.
+  > Pages default to one WebSocket each (strong crash isolation); opt into
+  > `sessionId` multiplexing (many pages over the one browser socket) with
+  > `new_page(browser, transport: :session)`, trading isolation for fewer sockets.
+  > Connection pooling, network interception, and stealth remain out of scope.
   """
 
   alias CDPEx.Browser

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -47,7 +47,8 @@ defmodule CDPEx.Browser do
     * `:transport` — `:dedicated` (default, one WebSocket per page, strong crash
       isolation) or `:session` (multiplexed over the browser socket via a
       flattened CDP session — fewer sockets, but all session pages share the
-      browser connection's fate: if it drops, they all go)
+      browser connection's fate: if it drops, they all go). Any other value
+      returns `{:error, {:invalid_transport, value}}`.
     * `:prevent_alerts` — inject no-op `alert`/`confirm`/`prompt` (default `true`)
   """
   @spec new_page(GenServer.server(), keyword()) :: {:ok, Page.t()} | {:error, term()}
@@ -118,6 +119,7 @@ defmodule CDPEx.Browser do
     case Keyword.get(opts, :transport, :dedicated) do
       :dedicated -> reply_dedicated_page(state, opts)
       :session -> reply_session_page(state, opts)
+      other -> {:reply, {:error, {:invalid_transport, other}}, state}
     end
   end
 

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -87,6 +87,11 @@ defmodule CDPEx.Browser do
 
     case Connection.start_link(chrome.debug_url) do
       {:ok, conn} ->
+        # Prune session entries when their target ends (tab closed/crashed, or our
+        # own close_page) so long-lived browsers don't accumulate stale sessions —
+        # parity with the dedicated path, which self-prunes on a page-conn EXIT.
+        Connection.subscribe(conn, "Target.detachedFromTarget")
+
         {:ok,
          %__MODULE__{
            chrome: chrome,
@@ -177,6 +182,16 @@ defmodule CDPEx.Browser do
     # A page connection exited (closed or crashed). Drop it; the page handle the
     # caller holds becomes stale and its next op returns {:error, :noproc}.
     {:noreply, %{state | pages: drop_conn(state.pages, pid)}}
+  end
+
+  def handle_info(
+        {:cdp_event, conn, "Target.detachedFromTarget", params, _session_id},
+        %{browser_conn: conn} = state
+      ) do
+    # A flattened session ended. Drop its entry so it doesn't linger for the life
+    # of the browser. Idempotent: our own close_page may have removed it already,
+    # and a targetId we don't track is simply a no-op delete.
+    {:noreply, %{state | sessions: Map.delete(state.sessions, params["targetId"])}}
   end
 
   def handle_info(_msg, state), do: {:noreply, state}

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -27,7 +27,7 @@ defmodule CDPEx.Browser do
   @create_timeout 10_000
   @bootstrap_timeout 10_000
 
-  defstruct [:chrome, :browser_conn, :host, :port, :opts, :parent, pages: %{}]
+  defstruct [:chrome, :browser_conn, :host, :port, :opts, :parent, pages: %{}, sessions: %{}]
 
   @type t :: %__MODULE__{}
 
@@ -44,6 +44,10 @@ defmodule CDPEx.Browser do
   Opens a new page (tab) and returns a `CDPEx.Page` handle.
 
   Options:
+    * `:transport` — `:dedicated` (default, one WebSocket per page, strong crash
+      isolation) or `:session` (multiplexed over the browser socket via a
+      flattened CDP session — fewer sockets, but all session pages share the
+      browser connection's fate: if it drops, they all go)
     * `:prevent_alerts` — inject no-op `alert`/`confirm`/`prompt` (default `true`)
   """
   @spec new_page(GenServer.server(), keyword()) :: {:ok, Page.t()} | {:error, term()}
@@ -111,12 +115,24 @@ defmodule CDPEx.Browser do
 
   @impl true
   def handle_call({:new_page, opts}, _from, state) do
-    case open_page(state, opts) do
-      {:ok, page} ->
-        {:reply, {:ok, page}, %{state | pages: Map.put(state.pages, page.target_id, page.conn)}}
+    case Keyword.get(opts, :transport, :dedicated) do
+      :dedicated -> reply_dedicated_page(state, opts)
+      :session -> reply_session_page(state, opts)
+    end
+  end
 
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+  def handle_call({:close_page, %Page{target_id: tid, session_id: sid}}, _from, state)
+      when not is_nil(sid) do
+    case Map.get(state.sessions, tid) do
+      ^sid ->
+        # The page rides the shared browser connection; detach the session and
+        # close the tab, but NEVER close that connection (other sessions use it).
+        detach_session(state.browser_conn, sid)
+        close_target(state.browser_conn, tid)
+        {:reply, :ok, %{state | sessions: Map.delete(state.sessions, tid)}}
+
+      _ ->
+        {:reply, {:error, :unknown_page}, state}
     end
   end
 
@@ -177,6 +193,27 @@ defmodule CDPEx.Browser do
 
   # ── page creation ───────────────────────────────────────────────────────────
 
+  defp reply_dedicated_page(state, opts) do
+    case open_page(state, opts) do
+      {:ok, page} ->
+        {:reply, {:ok, page}, %{state | pages: Map.put(state.pages, page.target_id, page.conn)}}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  defp reply_session_page(state, opts) do
+    case open_session_page(state, opts) do
+      {:ok, page} ->
+        sessions = Map.put(state.sessions, page.target_id, page.session_id)
+        {:reply, {:ok, page}, %{state | sessions: sessions}}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
   defp open_page(state, opts) do
     case Connection.call(
            state.browser_conn,
@@ -213,30 +250,80 @@ defmodule CDPEx.Browser do
     end
   end
 
-  defp bootstrap_page(conn, opts) do
-    with {:ok, _} <- Connection.call(conn, "Page.enable", %{}, @bootstrap_timeout),
-         {:ok, _} <- Connection.call(conn, "Runtime.enable", %{}, @bootstrap_timeout),
-         {:ok, _} <-
-           Connection.call(
-             conn,
-             "Page.setLifecycleEventsEnabled",
-             %{"enabled" => true},
-             @bootstrap_timeout
-           ) do
-      maybe_prevent_alerts(conn, opts)
+  # The session transport: create a target, attach with `flatten: true` (its
+  # frames then arrive on the browser connection tagged with the sessionId), and
+  # bootstrap it over that shared connection. On any failure NEVER `safe_close`
+  # browser_conn — it is shared by every other session.
+  defp open_session_page(state, opts) do
+    case Connection.call(
+           state.browser_conn,
+           "Target.createTarget",
+           %{"url" => "about:blank"},
+           @create_timeout
+         ) do
+      {:ok, %{"targetId" => tid}} -> attach_session(state, tid, opts)
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp maybe_prevent_alerts(conn, opts) do
+  defp attach_session(state, tid, opts) do
+    case Connection.call(
+           state.browser_conn,
+           "Target.attachToTarget",
+           %{"targetId" => tid, "flatten" => true},
+           @create_timeout
+         ) do
+      {:ok, %{"sessionId" => sid}} ->
+        case bootstrap_page(state.browser_conn, sid, opts) do
+          :ok ->
+            {:ok, %Page{browser: self(), conn: state.browser_conn, target_id: tid, session_id: sid}}
+
+          {:error, reason} ->
+            detach_session(state.browser_conn, sid)
+            close_target(state.browser_conn, tid)
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        close_target(state.browser_conn, tid)
+        {:error, reason}
+    end
+  end
+
+  # Detach a session on the browser connection, ignoring failures.
+  defp detach_session(browser_conn, session_id) do
+    _ =
+      Connection.call(
+        browser_conn,
+        "Target.detachFromTarget",
+        %{"sessionId" => session_id},
+        @create_timeout
+      )
+
+    :ok
+  end
+
+  defp bootstrap_page(conn, opts), do: bootstrap_page(conn, nil, opts)
+
+  defp bootstrap_page(conn, session_id, opts) do
+    with {:ok, _} <- bcall(conn, session_id, "Page.enable", %{}),
+         {:ok, _} <- bcall(conn, session_id, "Runtime.enable", %{}),
+         {:ok, _} <-
+           bcall(conn, session_id, "Page.setLifecycleEventsEnabled", %{"enabled" => true}) do
+      maybe_prevent_alerts(conn, session_id, opts)
+    end
+  end
+
+  # One bootstrap CDP call, scoped to `session_id` (nil for a dedicated page).
+  defp bcall(conn, session_id, method, params) do
+    Connection.call(conn, method, params, @bootstrap_timeout, session_id: session_id)
+  end
+
+  defp maybe_prevent_alerts(conn, session_id, opts) do
     if Keyword.get(opts, :prevent_alerts, true) do
       params = %{"source" => Protocol.prevent_alerts_js()}
 
-      case Connection.call(
-             conn,
-             "Page.addScriptToEvaluateOnNewDocument",
-             params,
-             @bootstrap_timeout
-           ) do
+      case bcall(conn, session_id, "Page.addScriptToEvaluateOnNewDocument", params) do
         {:ok, _} -> :ok
         error -> error
       end

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -62,13 +62,16 @@ defmodule CDPEx.Connection do
   Returns `{:ok, result}`, `{:error, {:cdp_error, method, error}}` on a protocol
   error, `{:error, {:timeout, method}}`, or `{:error, {:ws_closed, reason}}` /
   `{:error, :noproc}` if the connection drops or is already gone.
+
+  Pass `opts` with `session_id: sid` to address a flattened CDP session.
   """
-  @spec call(GenServer.server(), String.t(), map(), timeout()) ::
+  @spec call(GenServer.server(), String.t(), map(), timeout(), keyword()) ::
           {:ok, map()} | {:error, term()}
-  def call(conn, method, params \\ %{}, timeout \\ @default_call_timeout) do
+  def call(conn, method, params \\ %{}, timeout \\ @default_call_timeout, opts \\ []) do
+    session_id = Keyword.get(opts, :session_id)
     # Outer GenServer deadline is slightly longer than the CDP timeout so our own
     # `{:timeout, method}` reply wins over a raw GenServer.call timeout.
-    GenServer.call(conn, {:cdp_call, method, params, timeout}, call_deadline(timeout))
+    GenServer.call(conn, {:cdp_call, method, params, timeout, session_id}, call_deadline(timeout))
   catch
     :exit, {:noproc, _} -> {:error, :noproc}
     :exit, {:normal, _} -> {:error, :noproc}
@@ -79,7 +82,8 @@ defmodule CDPEx.Connection do
   @doc """
   Subscribes the calling process to a CDP event method (e.g.
   `"Page.lifecycleEvent"`) or to `:all` events. Delivered as
-  `{:cdp_event, conn_pid, method, params}`.
+  `{:cdp_event, conn_pid, method, params, session_id}` — `session_id` is `nil`
+  for browser/page-level events.
 
   The subscription is removed automatically if the subscribing process exits, so
   a crashed subscriber can't accumulate in the connection.
@@ -98,11 +102,15 @@ defmodule CDPEx.Connection do
   `{:error, reason}` where reason is `:timeout` (no matching event in time) or
   `:noproc` / `{:ws_closed, _}` (the connection itself went away) — callers must
   be able to tell those apart.
+
+  Pass `opts` with `session_id: sid` to only match events from that session.
   """
-  @spec await_event(GenServer.server(), (map() -> boolean()), timeout()) ::
+  @spec await_event(GenServer.server(), (map() -> boolean()), timeout(), keyword()) ::
           :ok | {:error, :timeout | :noproc | {:ws_closed, term()}}
-  def await_event(conn, matcher, timeout \\ @default_call_timeout) when is_function(matcher, 1) do
-    GenServer.call(conn, {:await_event, matcher, timeout}, call_deadline(timeout))
+  def await_event(conn, matcher, timeout \\ @default_call_timeout, opts \\ [])
+      when is_function(matcher, 1) do
+    session_id = Keyword.get(opts, :session_id)
+    GenServer.call(conn, {:await_event, matcher, timeout, session_id}, call_deadline(timeout))
   catch
     :exit, {:noproc, _} -> {:error, :noproc}
     :exit, {:normal, _} -> {:error, :noproc}
@@ -142,14 +150,15 @@ defmodule CDPEx.Connection do
   end
 
   @impl true
-  def handle_call({:cdp_call, method, params, timeout}, from, state) do
+  def handle_call({:cdp_call, method, params, timeout, session_id}, from, state) do
     id = state.next_id
-    payload = Protocol.encode(method, params, id)
+    payload = Protocol.encode(method, params, id, session_id)
+    key = {id, session_id}
 
     case ws_send(state, payload) do
       {:ok, state} ->
-        timer = Process.send_after(self(), {:call_timeout, id}, timeout)
-        pending = Map.put(state.pending, id, {from, method, timer})
+        timer = Process.send_after(self(), {:call_timeout, key}, timeout)
+        pending = Map.put(state.pending, key, {from, method, timer})
         {:noreply, %{state | next_id: id + 1, pending: pending}}
 
       {:error, state, reason} ->
@@ -184,14 +193,14 @@ defmodule CDPEx.Connection do
     {:reply, :ok, demonitor_if_orphaned(state, pid)}
   end
 
-  def handle_call({:await_event, matcher, timeout}, from, state) do
+  def handle_call({:await_event, matcher, timeout, session_id}, from, state) do
     timer = Process.send_after(self(), {:waiter_timeout, from}, timeout)
-    {:noreply, %{state | waiters: [{matcher, from, timer} | state.waiters]}}
+    {:noreply, %{state | waiters: [{matcher, session_id, from, timer} | state.waiters]}}
   end
 
   @impl true
-  def handle_info({:call_timeout, id}, state) do
-    case Map.pop(state.pending, id) do
+  def handle_info({:call_timeout, key}, state) do
+    case Map.pop(state.pending, key) do
       {nil, _} ->
         {:noreply, state}
 
@@ -288,15 +297,15 @@ defmodule CDPEx.Connection do
 
   defp dispatch(frame, state) do
     case Protocol.classify(frame) do
-      {:reply, id, result} -> dispatch_reply(id, result, state)
-      {:event, method, params} -> dispatch_event(method, params, state)
+      {:reply, id, session_id, result} -> dispatch_reply({id, session_id}, result, state)
+      {:event, method, session_id, params} -> dispatch_event(method, session_id, params, state)
       {:ping, data} -> pong(state, data)
       :ignore -> state
     end
   end
 
-  defp dispatch_reply(id, result, state) do
-    case Map.pop(state.pending, id) do
+  defp dispatch_reply(key, result, state) do
+    case Map.pop(state.pending, key) do
       {nil, _} ->
         state
 
@@ -310,17 +319,19 @@ defmodule CDPEx.Connection do
   defp normalize_reply({:ok, result}, _method), do: {:ok, result}
   defp normalize_reply({:error, error}, method), do: {:error, {:cdp_error, method, error}}
 
-  defp dispatch_event(method, params, state) do
+  defp dispatch_event(method, session_id, params, state) do
     state
-    |> notify_waiters(params)
-    |> notify_subscribers(method, params)
+    |> notify_waiters(session_id, params)
+    |> notify_subscribers(method, session_id, params)
   end
 
-  defp notify_waiters(state, params) do
+  defp notify_waiters(state, event_session_id, params) do
     {matched, kept} =
-      Enum.split_with(state.waiters, fn {matcher, _from, _timer} -> safe_match(matcher, params) end)
+      Enum.split_with(state.waiters, fn {matcher, want_session_id, _from, _timer} ->
+        session_match?(want_session_id, event_session_id) and safe_match(matcher, params)
+      end)
 
-    Enum.each(matched, fn {_matcher, from, timer} ->
+    Enum.each(matched, fn {_matcher, _sid, from, timer} ->
       cancel_timer(timer)
       GenServer.reply(from, :ok)
     end)
@@ -328,12 +339,18 @@ defmodule CDPEx.Connection do
     %{state | waiters: kept}
   end
 
-  defp notify_subscribers(state, method, params) do
+  # A session-less waiter (`nil`) matches any event — preserving the default
+  # behavior; a session-scoped waiter only matches its own session's events.
+  defp session_match?(nil, _event_session_id), do: true
+  defp session_match?(session_id, session_id), do: true
+  defp session_match?(_want, _event), do: false
+
+  defp notify_subscribers(state, method, session_id, params) do
     method_subs = Map.get(state.subscribers, method, MapSet.new())
 
     method_subs
     |> MapSet.union(state.all_subscribers)
-    |> Enum.each(fn pid -> send(pid, {:cdp_event, self(), method, params}) end)
+    |> Enum.each(fn pid -> send(pid, {:cdp_event, self(), method, params, session_id}) end)
 
     state
   end
@@ -485,7 +502,7 @@ defmodule CDPEx.Connection do
   # ── helpers ─────────────────────────────────────────────────────────────────
 
   defp fail_all_pending(state, reason) do
-    Enum.each(state.pending, fn {_id, {from, _method, timer}} ->
+    Enum.each(state.pending, fn {_key, {from, _method, timer}} ->
       cancel_timer(timer)
       GenServer.reply(from, {:error, reason})
     end)
@@ -493,14 +510,14 @@ defmodule CDPEx.Connection do
     # Reply waiters with the real failure reason (e.g. {:ws_closed, _}), not
     # {:error, :timeout} — a dropped socket must be distinguishable from a page
     # that simply never fired the awaited event.
-    Enum.each(state.waiters, fn {_matcher, from, timer} ->
+    Enum.each(state.waiters, fn {_matcher, _session_id, from, timer} ->
       cancel_timer(timer)
       GenServer.reply(from, {:error, reason})
     end)
   end
 
   defp pop_waiter(waiters, from) do
-    case Enum.split_with(waiters, fn {_m, f, _t} -> f == from end) do
+    case Enum.split_with(waiters, fn {_m, _sid, f, _t} -> f == from end) do
       {[waiter | _], rest} -> {waiter, rest}
       {[], rest} -> {nil, rest}
     end

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -14,7 +14,9 @@ defmodule CDPEx.Connection do
       if the socket drops — no caller is left hanging.
 
   One connection backs one socket: the browser endpoint, or a page endpoint at
-  `/devtools/page/<targetId>`. `CDPEx.Browser` starts and monitors these.
+  `/devtools/page/<targetId>`. A single connection may carry both untagged
+  browser/page frames and many flattened sessions' frames, demultiplexed by
+  `sessionId`. `CDPEx.Browser` starts and monitors these.
   """
 
   use GenServer, restart: :temporary

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -34,9 +34,14 @@ defmodule CDPEx.Page do
   @command_timeout 10_000
 
   @enforce_keys [:browser, :conn, :target_id]
-  defstruct [:browser, :conn, :target_id]
+  defstruct [:browser, :conn, :target_id, :session_id]
 
-  @type t :: %__MODULE__{browser: pid(), conn: pid(), target_id: String.t()}
+  @type t :: %__MODULE__{
+          browser: pid(),
+          conn: pid(),
+          target_id: String.t(),
+          session_id: String.t() | nil
+        }
 
   @doc """
   Navigates to `url` and (by default) waits until the network is almost idle.
@@ -54,7 +59,7 @@ defmodule CDPEx.Page do
     timeout = Keyword.get(opts, :timeout, @navigate_timeout)
     wait_until = Keyword.get(opts, :wait_until, :network_almost_idle)
 
-    case Connection.call(page.conn, "Page.navigate", %{"url" => url}, timeout) do
+    case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
       {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
       {:ok, _result} -> await_navigation(page, wait_until, timeout)
       {:error, _} = error -> error
@@ -66,7 +71,7 @@ defmodule CDPEx.Page do
   defp await_navigation(page, wait_until, timeout) do
     name = lifecycle_name(wait_until)
 
-    case Connection.await_event(page.conn, &(&1["name"] == name), timeout) do
+    case do_await(page, &(&1["name"] == name), timeout) do
       :ok ->
         {:ok, page}
 
@@ -107,7 +112,7 @@ defmodule CDPEx.Page do
       wait_until ->
         name = lifecycle_name(wait_until)
         timeout = Keyword.get(opts, :timeout, @navigate_timeout)
-        Connection.await_event(page.conn, &(&1["name"] == name), timeout)
+        do_await(page, &(&1["name"] == name), timeout)
     end
   end
 
@@ -128,7 +133,7 @@ defmodule CDPEx.Page do
       "awaitPromise" => Keyword.get(opts, :await_promise, false)
     }
 
-    case Connection.call(page.conn, "Runtime.evaluate", params, timeout) do
+    case do_call(page, "Runtime.evaluate", params, timeout) do
       {:ok, result} -> Protocol.evaluate_result(result)
       {:error, _} = error -> error
     end
@@ -329,7 +334,7 @@ defmodule CDPEx.Page do
     params = maybe_full_page(%{"format" => "png"}, Keyword.get(opts, :full_page, false))
 
     with {:ok, %{"data" => base64}} <-
-           Connection.call(page.conn, "Page.captureScreenshot", params, timeout),
+           do_call(page, "Page.captureScreenshot", params, timeout),
          {:ok, bytes} <- decode_base64(base64, :invalid_screenshot_data) do
       write_or_return(bytes, Keyword.get(opts, :path))
     end
@@ -346,7 +351,7 @@ defmodule CDPEx.Page do
 
     with :ok <- ensure_network(page, timeout),
          {:ok, %{"cookies" => cookies}} <-
-           Connection.call(page.conn, "Network.getAllCookies", %{}, timeout) do
+           do_call(page, "Network.getAllCookies", %{}, timeout) do
       {:ok, cookies}
     end
   end
@@ -361,7 +366,7 @@ defmodule CDPEx.Page do
 
     with :ok <- ensure_network(page, timeout),
          {:ok, _} <-
-           Connection.call(page.conn, "Network.setCookies", %{"cookies" => cookies}, timeout) do
+           do_call(page, "Network.setCookies", %{"cookies" => cookies}, timeout) do
       :ok
     end
   end
@@ -372,7 +377,7 @@ defmodule CDPEx.Page do
     timeout = Keyword.get(opts, :timeout, @command_timeout)
 
     with :ok <- ensure_network(page, timeout),
-         {:ok, _} <- Connection.call(page.conn, "Network.clearBrowserCookies", %{}, timeout) do
+         {:ok, _} <- do_call(page, "Network.clearBrowserCookies", %{}, timeout) do
       :ok
     end
   end
@@ -390,8 +395,8 @@ defmodule CDPEx.Page do
 
     with :ok <- ensure_network(page, timeout),
          {:ok, _} <-
-           Connection.call(
-             page.conn,
+           do_call(
+             page,
              "Network.setExtraHTTPHeaders",
              %{"headers" => headers},
              timeout
@@ -410,7 +415,7 @@ defmodule CDPEx.Page do
     timeout = Keyword.get(opts, :timeout, @command_timeout)
     params = %{"userAgent" => user_agent}
 
-    case Connection.call(page.conn, "Emulation.setUserAgentOverride", params, timeout) do
+    case do_call(page, "Emulation.setUserAgentOverride", params, timeout) do
       {:ok, _} -> :ok
       {:error, _} = error -> error
     end
@@ -434,7 +439,7 @@ defmodule CDPEx.Page do
       "mobile" => Keyword.get(opts, :mobile, false)
     }
 
-    case Connection.call(page.conn, "Emulation.setDeviceMetricsOverride", params, timeout) do
+    case do_call(page, "Emulation.setDeviceMetricsOverride", params, timeout) do
       {:ok, _} -> :ok
       {:error, _} = error -> error
     end
@@ -457,7 +462,7 @@ defmodule CDPEx.Page do
     }
 
     with {:ok, %{"data" => base64}} <-
-           Connection.call(page.conn, "Page.printToPDF", params, timeout),
+           do_call(page, "Page.printToPDF", params, timeout),
          {:ok, bytes} <- decode_base64(base64, :invalid_pdf_data) do
       write_or_return(bytes, Keyword.get(opts, :path))
     end
@@ -485,9 +490,19 @@ defmodule CDPEx.Page do
   # Lazily enable the Network domain (idempotent in CDP) so cookie/header ops
   # work without callers opting in at page creation — keeps Page stateless.
   defp ensure_network(page, timeout) do
-    case Connection.call(page.conn, "Network.enable", %{}, timeout) do
+    case do_call(page, "Network.enable", %{}, timeout) do
       {:ok, _} -> :ok
       {:error, _} = error -> error
     end
+  end
+
+  # Page ops thread the page's session id (`nil` for a dedicated page) so the same
+  # code path serves both the one-socket-per-page and the multiplexed transports.
+  defp do_call(%__MODULE__{conn: conn, session_id: session_id}, method, params, timeout) do
+    Connection.call(conn, method, params, timeout, session_id: session_id)
+  end
+
+  defp do_await(%__MODULE__{conn: conn, session_id: session_id}, matcher, timeout) do
+    Connection.await_event(conn, matcher, timeout, session_id: session_id)
   end
 end

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -24,8 +24,9 @@ defmodule CDPEx.Protocol do
 
   @typedoc "The result of classifying a single decoded frame."
   @type classification ::
-          {:reply, id :: pos_integer(), {:ok, map()} | {:error, map()}}
-          | {:event, method :: String.t(), params :: map()}
+          {:reply, id :: pos_integer(), session_id :: String.t() | nil,
+           {:ok, map()} | {:error, map()}}
+          | {:event, method :: String.t(), session_id :: String.t() | nil, params :: map()}
           | {:ping, binary()}
           | {:close, code :: integer() | nil, reason :: binary()}
           | :ignore
@@ -93,7 +94,8 @@ defmodule CDPEx.Protocol do
   Classifies one decoded frame into a CDP-level action.
 
   Text frames are parsed as JSON and split into replies (by `"id"`) and events
-  (by `"method"`). Ping frames surface so the connection can pong, and a peer
+  (by `"method"`), each carrying any `"sessionId"` (from flattened CDP sessions)
+  so the connection can route per session. Ping frames surface so the connection can pong, and a peer
   `close` frame surfaces so the connection can shut down and fail pending
   callers. Everything else (`pong`, unrecognised JSON) is `:ignore`.
 
@@ -103,16 +105,19 @@ defmodule CDPEx.Protocol do
   ## Examples
 
       iex> CDPEx.Protocol.classify({:text, ~s({"id":1,"result":{"frameId":"A"}})})
-      {:reply, 1, {:ok, %{"frameId" => "A"}}}
+      {:reply, 1, nil, {:ok, %{"frameId" => "A"}}}
 
       iex> CDPEx.Protocol.classify({:text, ~s({"id":2,"error":{"code":-32000,"message":"boom"}})})
-      {:reply, 2, {:error, %{"code" => -32000, "message" => "boom"}}}
+      {:reply, 2, nil, {:error, %{"code" => -32000, "message" => "boom"}}}
 
       iex> CDPEx.Protocol.classify({:text, ~s({"method":"Page.loadEventFired","params":{"t":1}})})
-      {:event, "Page.loadEventFired", %{"t" => 1}}
+      {:event, "Page.loadEventFired", nil, %{"t" => 1}}
 
       iex> CDPEx.Protocol.classify({:text, ~s({"method":"Inspector.detached"})})
-      {:event, "Inspector.detached", %{}}
+      {:event, "Inspector.detached", nil, %{}}
+
+      iex> CDPEx.Protocol.classify({:text, ~s({"method":"Page.lifecycleEvent","sessionId":"S","params":{"x":1}})})
+      {:event, "Page.lifecycleEvent", "S", %{"x" => 1}}
 
       iex> CDPEx.Protocol.classify({:ping, "hi"})
       {:ping, "hi"}
@@ -126,10 +131,17 @@ defmodule CDPEx.Protocol do
   @spec classify(frame()) :: classification()
   def classify({:text, text}) do
     case Jason.decode(text) do
-      {:ok, %{"id" => id, "result" => result}} -> {:reply, id, {:ok, result}}
-      {:ok, %{"id" => id, "error" => error}} -> {:reply, id, {:error, error}}
-      {:ok, %{"method" => method} = msg} -> {:event, method, Map.get(msg, "params", %{})}
-      _other -> :ignore
+      {:ok, %{"id" => id, "result" => result} = msg} ->
+        {:reply, id, Map.get(msg, "sessionId"), {:ok, result}}
+
+      {:ok, %{"id" => id, "error" => error} = msg} ->
+        {:reply, id, Map.get(msg, "sessionId"), {:error, error}}
+
+      {:ok, %{"method" => method} = msg} ->
+        {:event, method, Map.get(msg, "sessionId"), Map.get(msg, "params", %{})}
+
+      _other ->
+        :ignore
     end
   end
 

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -15,4 +15,19 @@ defmodule CDPEx.BrowserTest do
                Browser.handle_call({:new_page, [transport: :bogus]}, {self(), make_ref()}, state)
     end
   end
+
+  describe "session pruning" do
+    test "a Target.detachedFromTarget event drops that session, keeping siblings" do
+      # The Browser subscribes to this event on its browser_conn; the handler must
+      # prune the ended session so long-lived browsers don't leak stale entries.
+      conn = self()
+      state = %Browser{browser_conn: conn, sessions: %{"T1" => "S1", "T2" => "S2"}}
+
+      event =
+        {:cdp_event, conn, "Target.detachedFromTarget", %{"sessionId" => "S1", "targetId" => "T1"},
+         nil}
+
+      assert {:noreply, %Browser{sessions: %{"T2" => "S2"}}} = Browser.handle_info(event, state)
+    end
+  end
 end

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -1,0 +1,18 @@
+defmodule CDPEx.BrowserTest do
+  use ExUnit.Case, async: true
+
+  alias CDPEx.Browser
+
+  describe "new_page/2 transport validation" do
+    test "an unsupported :transport returns a structured error instead of crashing" do
+      # The validation runs before any Chrome/connection I/O, so we can drive the
+      # callback directly: a bad arg must yield a {:reply, ...} (the browser stays
+      # up), not a raised CaseClauseError (which would take the GenServer — and
+      # every page it owns — down).
+      state = %Browser{}
+
+      assert {:reply, {:error, {:invalid_transport, :bogus}}, ^state} =
+               Browser.handle_call({:new_page, [transport: :bogus]}, {self(), make_ref()}, state)
+    end
+  end
+end

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -80,14 +80,69 @@ defmodule CDPEx.ConnectionTest do
     :ok = Connection.subscribe(conn, "Page.lifecycleEvent")
     FakeCDP.send_text(fake, ~s({"method":"Page.lifecycleEvent","params":{"name":"load"}}))
 
-    assert_receive {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => "load"}}, 2_000
+    assert_receive {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => "load"}, nil}, 2_000
   end
 
   test ":all subscribers receive every event", %{conn: conn, fake: fake} do
     :ok = Connection.subscribe(conn, :all)
     FakeCDP.send_text(fake, ~s({"method":"Network.requestWillBeSent","params":{"x":1}}))
 
-    assert_receive {:cdp_event, ^conn, "Network.requestWillBeSent", %{"x" => 1}}, 2_000
+    assert_receive {:cdp_event, ^conn, "Network.requestWillBeSent", %{"x" => 1}, nil}, 2_000
+  end
+
+  test "demultiplexes two sessions' replies on one connection", %{conn: conn, fake: fake} do
+    a = Task.async(fn -> Connection.call(conn, "Page.enable", %{}, 2_000, session_id: "A") end)
+    b = Task.async(fn -> Connection.call(conn, "Page.enable", %{}, 2_000, session_id: "B") end)
+
+    ids =
+      for _ <- 1..2, into: %{} do
+        assert_receive {:fake_cdp_recv, ^fake, %{"id" => id, "sessionId" => sid}}, 2_000
+        {sid, id}
+      end
+
+    # Reply scrambled, each tagged with its own session.
+    FakeCDP.send_text(fake, ~s({"id":#{ids["B"]},"sessionId":"B","result":{"who":"B"}}))
+    FakeCDP.send_text(fake, ~s({"id":#{ids["A"]},"sessionId":"A","result":{"who":"A"}}))
+
+    assert {:ok, %{"who" => "A"}} = Task.await(a)
+    assert {:ok, %{"who" => "B"}} = Task.await(b)
+  end
+
+  test "events carry their sessionId to subscribers", %{conn: conn, fake: fake} do
+    :ok = Connection.subscribe(conn, "Page.lifecycleEvent")
+
+    FakeCDP.send_text(
+      fake,
+      ~s({"method":"Page.lifecycleEvent","sessionId":"A","params":{"name":"load"}})
+    )
+
+    assert_receive {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => "load"}, "A"}, 2_000
+  end
+
+  test "await_event with a session gate ignores other sessions", %{conn: conn, fake: fake} do
+    # A waiter scoped to session A must NOT resolve on a matching event from B.
+    task =
+      Task.async(fn -> Connection.await_event(conn, &(&1["name"] == "x"), 300, session_id: "A") end)
+
+    FakeCDP.send_text(
+      fake,
+      ~s({"method":"Page.lifecycleEvent","sessionId":"B","params":{"name":"x"}})
+    )
+
+    assert {:error, :timeout} = Task.await(task)
+
+    # The same matcher resolves when the event is from session A.
+    task2 =
+      Task.async(fn ->
+        Connection.await_event(conn, &(&1["name"] == "x"), 2_000, session_id: "A")
+      end)
+
+    FakeCDP.send_text(
+      fake,
+      ~s({"method":"Page.lifecycleEvent","sessionId":"A","params":{"name":"x"}})
+    )
+
+    assert :ok = Task.await(task2)
   end
 
   test "await_event resolves when a matching event arrives", %{conn: conn, fake: fake} do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -10,6 +10,7 @@ defmodule CDPEx.IntegrationTest do
   """
   use ExUnit.Case, async: false
 
+  alias CDPEx.Connection
   alias CDPEx.FixtureServer
   alias CDPEx.Page
 
@@ -124,6 +125,28 @@ defmodule CDPEx.IntegrationTest do
 
       # p1 is detached; p2 still works on the shared connection.
       assert {:error, _} = Page.evaluate(p1, "1 + 1")
+      assert {:ok, 4} = Page.evaluate(p2, "2 + 2")
+    end
+
+    test "an externally-closed session target is pruned from state.sessions", %{fixture: fixture} do
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, p1} = CDPEx.new_page(browser, transport: :session)
+      {:ok, p2} = CDPEx.new_page(browser, transport: :session)
+      {:ok, _} = Page.navigate(p1, fixture)
+      {:ok, _} = Page.navigate(p2, fixture)
+      assert map_size(:sys.get_state(browser).sessions) == 2
+
+      # Close p1's target OUT OF BAND — directly on the browser connection, NOT via
+      # close_page. Chrome emits Target.detachedFromTarget; the Browser must act on
+      # it to prune the dead session, or it leaks for the life of the browser.
+      browser_conn = :sys.get_state(browser).browser_conn
+      {:ok, _} = Connection.call(browser_conn, "Target.closeTarget", %{"targetId" => p1.target_id})
+
+      assert eventually(fn -> map_size(:sys.get_state(browser).sessions) == 1 end)
+
+      # The surviving session is unaffected.
       assert {:ok, 4} = Page.evaluate(p2, "2 + 2")
     end
   end
@@ -328,5 +351,21 @@ defmodule CDPEx.IntegrationTest do
     if Process.alive?(browser), do: CDPEx.stop(browser)
   catch
     :exit, _ -> :ok
+  end
+
+  # Poll until `fun` is true or the deadline passes — for event-driven state (e.g.
+  # a CDP event pruning a map) that settles asynchronously after the triggering call.
+  defp eventually(fun, retries \\ 50) do
+    cond do
+      fun.() ->
+        true
+
+      retries == 0 ->
+        false
+
+      true ->
+        Process.sleep(20)
+        eventually(fun, retries - 1)
+    end
   end
 end

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -84,6 +84,50 @@ defmodule CDPEx.IntegrationTest do
     end
   end
 
+  describe "session transport" do
+    test "two session pages share one browser connection and stay isolated", %{fixture: fixture} do
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, p1} = CDPEx.new_page(browser, transport: :session)
+      {:ok, p2} = CDPEx.new_page(browser, transport: :session)
+
+      # Both ride the SAME browser connection, with distinct session ids.
+      browser_conn = :sys.get_state(browser).browser_conn
+      assert p1.conn == browser_conn and p2.conn == browser_conn
+      assert is_binary(p1.session_id) and is_binary(p2.session_id)
+      assert p1.session_id != p2.session_id
+      assert map_size(:sys.get_state(browser).sessions) == 2
+
+      {:ok, _} = Page.navigate(p1, fixture)
+      {:ok, _} = Page.navigate(p2, fixture)
+
+      # Separate execution contexts: a global set in one session is invisible to
+      # the other (no cross-talk on the shared socket).
+      assert {:ok, "one"} = Page.evaluate(p1, "window.__id = 'one'; window.__id")
+      assert {:ok, "two"} = Page.evaluate(p2, "window.__id = 'two'; window.__id")
+      assert {:ok, "one"} = Page.evaluate(p1, "window.__id")
+      assert {:ok, "Hello"} = Page.text(p1, "#greeting")
+    end
+
+    test "closing a session page detaches it without harming siblings", %{fixture: fixture} do
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, p1} = CDPEx.new_page(browser, transport: :session)
+      {:ok, p2} = CDPEx.new_page(browser, transport: :session)
+      {:ok, _} = Page.navigate(p1, fixture)
+      {:ok, _} = Page.navigate(p2, fixture)
+
+      assert :ok = CDPEx.close_page(browser, p1)
+      assert map_size(:sys.get_state(browser).sessions) == 1
+
+      # p1 is detached; p2 still works on the shared connection.
+      assert {:error, _} = Page.evaluate(p1, "1 + 1")
+      assert {:ok, 4} = Page.evaluate(p2, "2 + 2")
+    end
+  end
+
   describe "page operations" do
     setup do
       {:ok, browser} = CDPEx.launch()

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -28,26 +28,37 @@ defmodule CDPEx.ProtocolTest do
   describe "classify/1" do
     test "ok reply" do
       assert Protocol.classify({:text, ~s({"id":10,"result":{"k":"v"}})}) ==
-               {:reply, 10, {:ok, %{"k" => "v"}}}
+               {:reply, 10, nil, {:ok, %{"k" => "v"}}}
     end
 
     test "error reply returns the raw CDP error object" do
       frame = {:text, ~s({"id":11,"error":{"code":-32000,"message":"nope"}})}
 
       assert Protocol.classify(frame) ==
-               {:reply, 11, {:error, %{"code" => -32_000, "message" => "nope"}}}
+               {:reply, 11, nil, {:error, %{"code" => -32_000, "message" => "nope"}}}
     end
 
     test "event with params" do
       frame = {:text, ~s({"method":"Page.lifecycleEvent","params":{"name":"networkAlmostIdle"}})}
 
       assert Protocol.classify(frame) ==
-               {:event, "Page.lifecycleEvent", %{"name" => "networkAlmostIdle"}}
+               {:event, "Page.lifecycleEvent", nil, %{"name" => "networkAlmostIdle"}}
     end
 
     test "event without params defaults to an empty map" do
       assert Protocol.classify({:text, ~s({"method":"Inspector.detached"})}) ==
-               {:event, "Inspector.detached", %{}}
+               {:event, "Inspector.detached", nil, %{}}
+    end
+
+    test "surfaces the sessionId from flattened-session frames" do
+      reply = {:text, ~s({"id":5,"sessionId":"S1","result":{"ok":true}})}
+      assert Protocol.classify(reply) == {:reply, 5, "S1", {:ok, %{"ok" => true}}}
+
+      event =
+        {:text, ~s({"method":"Page.lifecycleEvent","sessionId":"S1","params":{"name":"load"}})}
+
+      assert Protocol.classify(event) ==
+               {:event, "Page.lifecycleEvent", "S1", %{"name" => "load"}}
     end
 
     test "a reply is never misread as an event even if it lacks result/error" do


### PR DESCRIPTION
Workstream B of #2 — opt-in CDP `sessionId` multiplexing. (Workstream A, the expanded Page API, merged in #4.) The default transport is unchanged.

## What
`new_page(browser, transport: :session)` drives many pages over the **one** browser WebSocket via `Target.attachToTarget {flatten: true}`, addressed by `sessionId`. The default `transport: :dedicated` (one socket per page, strong crash isolation) is byte-for-byte the prior behavior.

## How (commit by commit)
- **`Protocol.classify/1`** surfaces `sessionId`: `{:reply, id, session_id, result}` / `{:event, method, session_id, params}`.
- **`Connection`** keys `pending` by `{id, session_id}`; `call/5` + `await_event/4` take a `:session_id` opt; subscriber events become a 5-tuple `{:cdp_event, conn, method, params, session_id}`; waiters gain a session gate (`nil` matches any → default path unchanged).
- **`Page`** gains a `:session_id` field; all ops thread it via private `do_call`/`do_await` wrappers.
- **`Browser`** adds the `:session` transport (createTarget + attachToTarget, a `sessions` map, session `close_page` = detach + closeTarget — **never** closes the shared `browser_conn`).
- Docs: README + moduledocs describe the transports and the shared-fate trade-off.

## Tests
- +4 FakeCDP unit tests: two sessions' replies demux on one connection, events carry their `sessionId`, `await_event` session gate, protocol extraction.
- +2 real-Chrome integration tests: two session pages share one `browser_conn` with **isolated execution contexts** (no cross-talk); session `close_page` detaches without harming siblings.
- `mix ci` green (credo + Dialyzer 0 + 54 unit tests); integration **26/0**, no orphan Chrome.

## Trade-off
`:dedicated` (default) — own socket per page, a page-socket drop kills only that page. `:session` — one socket, fewer FDs, but a `browser_conn` drop drops all session pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
