### PR TITLE
ci: add Claude automated PR review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,69 @@
+name: Claude Review
+
+# Automated pull-request review by Claude. It activates once a
+# CLAUDE_CODE_OAUTH_TOKEN repository secret is set — generate one with
+# `claude setup-token` (it rides your Claude subscription, so there is no
+# per-token API bill). Until that secret exists the job is a no-op (see the gate
+# step), so adding this workflow never blocks a PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: claude review
+    runs-on: ubuntu-24.04
+    # Same-repo PRs only — forks cannot read secrets, so there is nothing to do.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Gate on the review token
+        id: gate
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "CLAUDE_CODE_OAUTH_TOKEN is not set — skipping Claude review. Add the secret to enable it." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.ready == 'true'
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        if: steps.gate.outputs.ready == 'true'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. It is an OTP-native Elixir library (a Chrome
+            DevTools Protocol client; deps are mint_web_socket + jason only).
+            Focus on:
+            - Correctness: logic errors, edge cases, race conditions.
+            - OTP/process lifecycle: supervision, teardown, resource leaks
+              (unclosed connections or OS processes), exit/message handling.
+            - Test coverage of the change (unit + integration).
+            - Security and resource safety.
+            - Public API and documentation consistency.
+
+            Be concise and specific; skip nits already enforced by the formatter
+            or credo. Post top-level feedback with `gh pr comment` and specific
+            issues as inline comments. Only post GitHub comments — do not emit
+            review text as chat messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Adds automated PR review by Claude — a replacement for the third-party review bot.

## How it works
- `anthropics/claude-code-action@v1` runs on `pull_request` (`opened`, `synchronize`) and posts top-level + inline review comments.
- **Auth: `CLAUDE_CODE_OAUTH_TOKEN`** (generate with `claude setup-token`). It rides your Claude subscription, so there's **no per-token API bill** — unlike `ANTHROPIC_API_KEY` pay-as-you-go.
- **Token gate:** until that secret exists the job is a clean no-op, so merging this **never blocks a PR**. Once the secret is set, reviews start automatically.

## Activation (your step — needs the secret)
1. Run `claude setup-token` locally and copy the token.
2. Add it as a repo secret: `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo patrols/cdp_ex` (or via Settings → Secrets → Actions).
3. Merge this PR. The next PR gets reviewed.

I'm leaving the merge to you because I can't verify the end-to-end review run without the secret. Everything else (CI, zizmor) is green.

## Security
zizmor-clean (audited locally with the same `v1.25.2 --offline`): tag-pinned actions (the repo's `ref-pin` policy), `persist-credentials: false`, minimal scoped permissions (`contents: read` + job-level `pull-requests: write`), same-repo-only guard, and `run:` blocks use env vars (no template injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
