### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-02
+
 ### Added
 - Opt-in `sessionId` multiplexing: `CDPEx.new_page(browser, transport: :session)` drives many pages over the one browser WebSocket (default `:dedicated` = one socket per page). `CDPEx.Connection.call/5` and `await_event/4` gain a `:session_id` option.
 - `CDPEx.Page.wait_for_navigation/2` — await a navigation lifecycle milestone without issuing a navigation (e.g. after a click that navigates).
@@ -17,6 +19,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.pdf/2` — render the page to PDF (`Page.printToPDF`); returns bytes or writes to `:path`.
 - `CDPEx.Page.call_function/4` — call a JS function with JSON-serialized arguments.
 
+### Changed
+- A clean browser-connection close (its socket dropping, e.g. Chrome exiting) now stops `CDPEx.Browser` with a `:shutdown` reason rather than a crash reason — no spurious error report on expected teardown. Abnormal connection failures still surface loudly.
+
+### Fixed
+- `CDPEx.Connection.call/5` and `await_event/4` no longer crash the connection when given an `:infinity` timeout (which is valid per the `timeout()` spec).
+- `CDPEx.Connection` now stops when its owning process exits, closing the socket even if the owner skipped its own teardown (e.g. a `:brutal_kill`).
+
 ## [0.1.0] - 2026-06-01
 
 ### Added
@@ -26,5 +35,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page`: `navigate/3`, `wait_for_selector/3`, `evaluate/3`, `click/3`,
   `html/2`, `screenshot/2`.
 
-[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/patrols/cdp_ex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/patrols/cdp_ex/releases/tag/v0.1.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CDPEx.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.2.0"
   @source_url "https://github.com/patrols/cdp_ex"
 
   def project do


### PR DESCRIPTION
Prepares the v0.2.0 release. **No tag or publish in this PR** — those are the final, your-hands steps after merge (see below).

## What's in 0.2.0
Bundles Workstream A + B of #2 plus the hardening (#7):
- **Opt-in `sessionId` multiplexing** — `new_page(browser, transport: :session)` drives many pages over one browser socket; default `:dedicated` unchanged.
- **Expanded `Page` API** — `wait_for_navigation`, `wait_for_function`, `text`/`attribute`/`visible?`, cookies, `set_extra_headers`/`set_user_agent`, `set_viewport`, `pdf`, `call_function`.
- **Quieter teardown** — a clean browser-connection close stops with a `:shutdown` reason (no spurious crash report); abnormal failures stay loud.
- **CI**: `mix_audit` / `mix deps.audit` (no advisories today).

## This PR
- `CHANGELOG.md`: promote `[Unreleased]` → `[0.2.0] - 2026-06-02` (+ link refs).
- `mix.exs`: `@version` → `0.2.0`.
- Verified: `mix ci` green (58 tests + 15 doctests, Dialyzer 0, `deps.audit` clean); `mix hex.build` → `cdp_ex-0.2.0.tar`; `mix docs` clean.

## After merge (your steps — Hex auth + explicit go)
```
git checkout main && git pull
git tag -a v0.2.0 -m "v0.2.0"
git push origin v0.2.0
mix hex.publish        # finalizes 0.2.0 on Hex — immutable
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
