### PR TITLE
fix: Connection :infinity timeout + owner-exit handling

### DIFF
--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -159,7 +159,7 @@ defmodule CDPEx.Connection do
 
     case ws_send(state, payload) do
       {:ok, state} ->
-        timer = Process.send_after(self(), {:call_timeout, key}, timeout)
+        timer = arm_timeout({:call_timeout, key}, timeout)
         pending = Map.put(state.pending, key, {from, method, timer})
         {:noreply, %{state | next_id: id + 1, pending: pending}}
 
@@ -196,7 +196,7 @@ defmodule CDPEx.Connection do
   end
 
   def handle_call({:await_event, matcher, timeout, session_id}, from, state) do
-    timer = Process.send_after(self(), {:waiter_timeout, from}, timeout)
+    timer = arm_timeout({:waiter_timeout, from}, timeout)
     {:noreply, %{state | waiters: [{matcher, session_id, from, timer} | state.waiters]}}
   end
 
@@ -228,6 +228,14 @@ defmodule CDPEx.Connection do
   # before the catch-all clause, which would otherwise feed it to WebSocket.stream.
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     {:noreply, drop_subscriber(state, pid)}
+  end
+
+  # A linked process — our owner (e.g. CDPEx.Browser) — went down. Stop too, so
+  # terminate/2 closes the socket. This makes cleanup unconditional even when the
+  # owner skips its own terminate/2 (a :brutal_kill, or a crash before cleanup);
+  # otherwise the connection would linger with an open socket until Chrome drops it.
+  def handle_info({:EXIT, _pid, reason}, state) do
+    {:stop, reason, state}
   end
 
   # Any other message is an inbound WebSocket transport frame.
@@ -524,6 +532,12 @@ defmodule CDPEx.Connection do
       {[], rest} -> {nil, rest}
     end
   end
+
+  # Process.send_after/3 rejects :infinity; represent "no deadline" as a nil timer,
+  # which cancel_timer/1 already tolerates. Without this, an :infinity timeout —
+  # valid per the timeout() spec — raises inside the GenServer and crashes it.
+  defp arm_timeout(_msg, :infinity), do: nil
+  defp arm_timeout(msg, timeout), do: Process.send_after(self(), msg, timeout)
 
   defp cancel_timer(nil), do: :ok
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -149,10 +149,11 @@ defmodule CDPEx.Page do
   Calls a JavaScript function with `args` and returns its value.
 
   `function_declaration` is a JS function expression (e.g. `"(a, b) => a + b"`).
-  `args` must be JSON-serializable; they are encoded and applied to the function,
-  so no untrusted data is string-interpolated into code. A thrown exception is
-  `{:error, {:evaluate_exception, details}}`; non-serializable `args` return
-  `{:error, {:invalid_args, reason}}`.
+  It is interpolated into the page script **verbatim**, so treat it as trusted
+  code — never build it from untrusted input. `args`, by contrast, are JSON-encoded
+  (not string-interpolated) before being applied, so passing data values through
+  them is safe. A thrown exception is `{:error, {:evaluate_exception, details}}`;
+  non-serializable `args` return `{:error, {:invalid_args, reason}}`.
 
   Options: `:timeout` (default 15_000), `:await_promise` (default `false`).
   """

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -37,6 +37,31 @@ defmodule CDPEx.ConnectionTest do
     assert {:ok, %{"ok" => true}} = Task.await(task)
   end
 
+  test "call/5 with an :infinity timeout doesn't crash the connection", %{conn: conn, fake: fake} do
+    ref = Process.monitor(conn)
+    task = Task.async(fn -> Connection.call(conn, "Slow.op", %{}, :infinity) end)
+    assert_receive {:fake_cdp_recv, ^fake, %{"id" => id, "method" => "Slow.op"}}, 2_000
+    # Arming the timer is where Process.send_after(:infinity) would have raised.
+    refute_received {:DOWN, ^ref, :process, ^conn, _}
+    FakeCDP.send_text(fake, ~s({"id":#{id},"result":{"ok":true}}))
+    assert {:ok, %{"ok" => true}} = Task.await(task)
+  end
+
+  test "await_event/4 with an :infinity timeout doesn't crash the connection", %{conn: conn} do
+    ref = Process.monitor(conn)
+    spawn(fn -> Connection.await_event(conn, fn _ -> false end, :infinity) end)
+    Process.sleep(50)
+    refute_received {:DOWN, ^ref, :process, ^conn, _}
+    assert Process.alive?(conn)
+  end
+
+  test "stops when a linked owner exits (so terminate/2 closes the socket)" do
+    # Connection traps exits; an owner's death must stop it rather than leave an
+    # orphaned open socket. Driven directly — the handler doesn't read state.
+    assert {:stop, :boom, %Connection{}} =
+             Connection.handle_info({:EXIT, self(), :boom}, %Connection{})
+  end
+
   test "demultiplexes concurrent callers, even when replies arrive out of order", %{
     conn: conn,
     fake: fake


### PR DESCRIPTION
Addresses the actionable findings from the first live Claude review (on #8), before v0.2.0 ships.

## Fixed
- **🔴 `:infinity` timeout crash.** `Connection.call/5` and `await_event/4` advertise `timeout()` (which includes `:infinity`) but passed it straight to `Process.send_after/3`, which rejects `:infinity` → `ArgumentError` **inside the GenServer**, crashing the shared `Connection` and every concurrent in-flight caller. New `arm_timeout/2` treats `:infinity` as "no deadline" (a `nil` timer, already handled by `cancel_timer/1`).
- **🟡 Owner-exit handling.** `Connection` traps exits but had no `{:EXIT}` clause, so a `:brutal_kill`ed or crash-before-`terminate` owner left it alive with an open socket until Chrome dropped the connection. It now stops on a linked-owner exit, so `terminate/2` closes the socket — the no-orphan guarantee becomes unconditional.
- **🔵 `call_function/4` doc.** Clarifies that `function_declaration` is interpolated **verbatim** (trusted code), while `args` are JSON-encoded (safe).

## Tests
+3 unit tests (FakeCDP + a direct `handle_info`): `call`/`await_event` survive `:infinity`; the connection stops on an owner exit. `mix ci` green — Dialyzer 0, 61 tests + 15 doctests.

## Deferred
Lower-severity findings (navigate race, `terminate` precision, `parse_ws_url` IPv6, child_spec shutdown margin, FakeCDP perf) are tracked in #9 — none are release blockers.

After this merges: rebase #8 onto `main` and add a `### Fixed` note to the `[0.2.0]` CHANGELOG, then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
