### PR TITLE
ci: SHA-pin actions + Dependabot (strict hash-pin)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current. Grouped into one PR per run to
+  # keep the noise down; the `# vX` comment on each pin tells Dependabot the
+  # version line to track.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,17 @@ jobs:
           - elixir: "1.19.5"
             otp: "28.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
 
       - name: Cache deps and _build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             deps
@@ -48,7 +48,7 @@ jobs:
           restore-keys: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
 
       - name: Cache Dialyzer PLT
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: priv/plts
           key: ${{ runner.os }}-plt-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
@@ -62,23 +62,23 @@ jobs:
     name: integration (real Chrome)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
           otp-version: "28.0"
           elixir-version: "1.19.5"
 
       - name: Install Chrome
         id: setup-chrome
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2
         with:
           chrome-version: stable
 
       - name: Cache deps and _build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             deps
@@ -100,11 +100,11 @@ jobs:
     name: workflow audit (zizmor)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,13 +40,13 @@ jobs:
             echo "CLAUDE_CODE_OAUTH_TOKEN is not set — skipping Claude review. Add the secret to enable it." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: steps.gate.outputs.ready == 'true'
         with:
           persist-credentials: false
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         if: steps.gate.outputs.ready == 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,13 +1,12 @@
 # zizmor configuration (https://docs.zizmor.sh).
 #
-# These workflows pin actions to release tags (e.g. @v4), not commit SHAs.
-# That is a deliberate, proportionate choice for this repository: CI runs with
-# `contents: read`, uses no secrets, and never deploys or uploads artifacts, so
-# the blast radius of an upstream tag-move is minimal. `ref-pin` still rejects
-# mutable *branch* refs (e.g. @main), and every other (higher-value) audit —
-# template injection, dangerous triggers, excessive permissions — stays on.
+# Actions are pinned to commit SHAs in the workflows; Dependabot
+# (.github/dependabot.yml) bumps the pins. This enforces zizmor's strict default
+# `hash-pin` policy explicitly — every `uses:` must be a full commit SHA, not a
+# mutable tag or branch. All other audits (template injection, dangerous
+# triggers, excessive permissions) stay on.
 rules:
   unpinned-uses:
     config:
       policies:
-        "*": ref-pin
+        "*": hash-pin


### PR DESCRIPTION
The optional supply-chain hardening from #2. **Repo/CI infra only — not part of the Hex package**, so it doesn't change what v0.2.0 publishes.

## What changed
- **SHA-pinned every action** in `ci.yml` and `claude-review.yml` to a full commit SHA with a `# vX` comment (checkout, setup-beam, cache, setup-chrome, setup-python, claude-code-action). A moved tag can no longer inject action code.
- **`.github/dependabot.yml`** — `github-actions` ecosystem, weekly, grouped into one PR, so the pins stay current automatically (the `# vX` comments tell Dependabot what to track).
- **`.github/zizmor.yml`** — flipped from the `ref-pin` allowance to the strict default **`hash-pin`** policy (every `uses:` must be a SHA). All other audits stay on.

## Verification
zizmor (`v1.25.2`, CI-style) passes locally with no findings. This PR's own CI is the live test that all six pinned SHAs resolve and run correctly.

Closes the last (optional) box in #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
