### PR TITLE
fix: v0.2.1 cleanups (#9 small follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- `CDPEx.Browser` sets `shutdown: 10_000` in `child_spec/1` so a supervisor gives `terminate/2` enough time to reap Chrome.
+
+### Fixed
+- `CDPEx.Protocol.parse_ws_url/1` parses IPv6 hosts and raises a clear `ArgumentError` on a malformed URL (previously a `MatchError`).
+- `CDPEx.Connection` no longer crashes when `call/5` / `await_event/4` is given a negative timeout (it fires immediately).
+- `CDPEx.Connection` teardown fails in-flight callers with `{:error, {:ws_closed, _}}` instead of `{:error, :noproc}` on `close/1`.
+
 ## [0.2.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ You also need Chrome or Chromium installed. CDPEx finds it via, in order: the
 For reproducible setups, point it at a
 [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/) binary.
 
+> #### Sandbox {: .warning}
+>
+> CDPEx launches Chrome with `--no-sandbox` by default, since the sandbox can't
+> start in many CI/container environments. If you run as root or drive untrusted
+> pages, re-enable it by overriding `:args` — see `CDPEx.Chrome`.
+
 ## Usage
 
 ### Resource-safe (recommended)

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -40,6 +40,14 @@ defmodule CDPEx.Browser do
     GenServer.start_link(__MODULE__, launch_opts, gen_opts)
   end
 
+  @doc false
+  def child_spec(opts) do
+    # terminate/2 reaps Chrome (kill + busy-poll + temp-dir cleanup, up to ~3.5s);
+    # give it headroom over the GenServer default (5s) so a supervisor never
+    # :brutal_kills mid-teardown and orphans Chrome.
+    %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, shutdown: 10_000}
+  end
+
   @doc """
   Opens a new page (tab) and returns a `CDPEx.Page` handle.
 

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -261,7 +261,13 @@ defmodule CDPEx.Connection do
   end
 
   @impl true
-  def terminate(_reason, state) do
+  def terminate(reason, state) do
+    # Single fail point for every stop path (socket drop, close/1, owner exit):
+    # reply to in-flight callers/waiters with the documented {:ws_closed, _} shape
+    # (not the less precise :noproc they'd otherwise get from the dying process)
+    # and cancel their timers so none fire into a dead mailbox.
+    fail_all_pending(state, ws_closed_reason(reason))
+
     # Best-effort graceful close; the socket may already be gone.
     with %{websocket: ws, conn: conn, ref: ref} when not is_nil(ws) <- state,
          {:ok, _ws, data} <- WebSocket.encode(ws, :close),
@@ -274,12 +280,15 @@ defmodule CDPEx.Connection do
     _ -> :ok
   end
 
+  # Map a stop reason to the {:ws_closed, _} reason reported to in-flight callers.
+  defp ws_closed_reason({:shutdown, {:ws_closed, reason}}), do: {:ws_closed, reason}
+  defp ws_closed_reason(_), do: {:ws_closed, :closed}
+
   # A dropped socket is a controlled end of this connection's life, not a crash:
-  # fail pending callers with the clean `{:ws_closed, reason}` shape, then stop
-  # under `:shutdown` so OTP doesn't emit a crash report. The owning Browser sees
-  # the reason via its monitor and decides whether it's worth logging.
+  # stop under `:shutdown` (so OTP emits no crash report) carrying the clean
+  # `{:ws_closed, reason}` shape — terminate/2 is the single place that fails the
+  # pending callers. The owning Browser sees the reason via its monitor.
   defp stop_ws_closed(state, reason) do
-    fail_all_pending(state, {:ws_closed, reason})
     {:stop, {:shutdown, {:ws_closed, reason}}, state}
   end
 
@@ -533,10 +542,15 @@ defmodule CDPEx.Connection do
     end
   end
 
-  # Process.send_after/3 rejects :infinity; represent "no deadline" as a nil timer,
-  # which cancel_timer/1 already tolerates. Without this, an :infinity timeout —
-  # valid per the timeout() spec — raises inside the GenServer and crashes it.
+  # Process.send_after/3 only accepts a non-negative integer delay. Map :infinity
+  # to "no deadline" (a nil timer, which cancel_timer/1 tolerates) and a negative
+  # delay (an already-elapsed computed deadline) to an immediate 0 — so no
+  # bad-but-plausible timeout value can raise inside the GenServer and crash it.
   defp arm_timeout(_msg, :infinity), do: nil
+
+  defp arm_timeout(msg, timeout) when is_integer(timeout) and timeout < 0,
+    do: Process.send_after(self(), msg, 0)
+
   defp arm_timeout(msg, timeout), do: Process.send_after(self(), msg, timeout)
 
   defp cancel_timer(nil), do: :ok

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -149,11 +149,15 @@ defmodule CDPEx.Page do
   Calls a JavaScript function with `args` and returns its value.
 
   `function_declaration` is a JS function expression (e.g. `"(a, b) => a + b"`).
-  It is interpolated into the page script **verbatim**, so treat it as trusted
-  code — never build it from untrusted input. `args`, by contrast, are JSON-encoded
-  (not string-interpolated) before being applied, so passing data values through
-  them is safe. A thrown exception is `{:error, {:evaluate_exception, details}}`;
-  non-serializable `args` return `{:error, {:invalid_args, reason}}`.
+  `args` are JSON-encoded (not string-interpolated) before being applied, so
+  passing data values through them is safe. A thrown exception is
+  `{:error, {:evaluate_exception, details}}`; non-serializable `args` return
+  `{:error, {:invalid_args, reason}}`.
+
+  > #### Trusted input {: .warning}
+  >
+  > `function_declaration` is interpolated into the page script **verbatim** —
+  > treat it as trusted code and never build it from untrusted input.
 
   Options: `:timeout` (default 15_000), `:await_promise` (default `false`).
   """

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -179,18 +179,30 @@ defmodule CDPEx.Protocol do
   def evaluate_result(other), do: {:error, {:unexpected_evaluate, other}}
 
   @doc """
-  Splits a Chrome DevTools websocket URL into `{host, port, path}`.
+  Splits a Chrome DevTools `ws://` (or `wss://`) URL into `{host, port, path}`.
+
+  Uses `URI.parse/1`, so IPv6 hosts, explicit ports, and paths are handled
+  correctly; a non-`ws(s)://` URL or one missing a host/port raises `ArgumentError`.
 
   ## Examples
 
       iex> CDPEx.Protocol.parse_ws_url("ws://127.0.0.1:9222/devtools/browser/abc-123")
       {"127.0.0.1", 9222, "/devtools/browser/abc-123"}
+
+      iex> CDPEx.Protocol.parse_ws_url("ws://[::1]:9222/devtools/browser/abc")
+      {"::1", 9222, "/devtools/browser/abc"}
   """
   @spec parse_ws_url(String.t()) :: {String.t(), pos_integer(), String.t()}
-  def parse_ws_url("ws://" <> rest) do
-    [host_port | path_parts] = String.split(rest, "/", parts: 2)
-    [host, port] = String.split(host_port, ":")
-    {host, String.to_integer(port), "/" <> (List.first(path_parts) || "")}
+  def parse_ws_url(ws_url) when is_binary(ws_url) do
+    case URI.parse(ws_url) do
+      %URI{scheme: scheme, host: host, port: port, path: path}
+      when scheme in ["ws", "wss"] and is_binary(host) and host != "" and is_integer(port) ->
+        {host, port, path || "/"}
+
+      _ ->
+        raise ArgumentError,
+              "expected a ws:// or wss:// URL with a host and port, got: #{inspect(ws_url)}"
+    end
   end
 
   @doc """

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -2,6 +2,7 @@ defmodule CDPEx.BrowserTest do
   use ExUnit.Case, async: true
 
   alias CDPEx.Browser
+  alias CDPEx.Page
 
   describe "new_page/2 transport validation" do
     test "an unsupported :transport returns a structured error instead of crashing" do
@@ -50,6 +51,34 @@ defmodule CDPEx.BrowserTest do
 
       assert {:stop, {:browser_connection_down, :boom}, ^state} =
                Browser.handle_info({:EXIT, conn, :boom}, state)
+    end
+  end
+
+  describe "close_page rejection paths" do
+    test "rejects a dedicated handle this browser doesn't own" do
+      # The reject branch does no I/O, so it's drivable directly; the match branch
+      # (close_target + safe_close) is exercised by the integration suite.
+      page = %Page{browser: self(), conn: self(), target_id: "T1"}
+      state = %Browser{browser_conn: self(), pages: %{}}
+
+      assert {:reply, {:error, :unknown_page}, ^state} =
+               Browser.handle_call({:close_page, page}, {self(), make_ref()}, state)
+    end
+
+    test "rejects a second close of an already-pruned session page" do
+      # After Target.detachedFromTarget prunes a session (or a prior close), closing
+      # the stale handle again must be refused, not detach an unrelated target.
+      page = %Page{browser: self(), conn: self(), target_id: "T1", session_id: "S1"}
+      state = %Browser{browser_conn: self(), sessions: %{}}
+
+      assert {:reply, {:error, :unknown_page}, ^state} =
+               Browser.handle_call({:close_page, page}, {self(), make_ref()}, state)
+    end
+  end
+
+  describe "child_spec" do
+    test "sets a generous :shutdown so terminate/2 can reap Chrome" do
+      assert %{shutdown: 10_000} = Browser.child_spec([])
     end
   end
 end

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -62,6 +62,30 @@ defmodule CDPEx.ConnectionTest do
              Connection.handle_info({:EXIT, self(), :boom}, %Connection{})
   end
 
+  test "an owner exit with :normal stops the connection quietly" do
+    assert {:stop, :normal, %Connection{}} =
+             Connection.handle_info({:EXIT, self(), :normal}, %Connection{})
+  end
+
+  test "call/5 with a negative (elapsed) timeout fires immediately, not a crash", %{conn: conn} do
+    ref = Process.monitor(conn)
+    # Process.send_after rejects negatives; arm_timeout clamps to an immediate 0.
+    assert {:error, {:timeout, "Late.op"}} = Connection.call(conn, "Late.op", %{}, -1)
+    refute_received {:DOWN, ^ref, :process, ^conn, _}
+  end
+
+  test "close/1 fails an in-flight caller with {:ws_closed, _}, not :noproc", %{
+    conn: conn,
+    fake: fake
+  } do
+    # terminate/2 drains pending callers with the precise {:ws_closed, _} shape
+    # rather than letting them fall back to :noproc from the dying process.
+    task = Task.async(fn -> Connection.call(conn, "Hang.forever", %{}) end)
+    assert_receive {:fake_cdp_recv, ^fake, %{"method" => "Hang.forever"}}, 2_000
+    Connection.close(conn)
+    assert {:error, {:ws_closed, _}} = Task.await(task)
+  end
+
   test "demultiplexes concurrent callers, even when replies arrive out of order", %{
     conn: conn,
     fake: fake

--- a/test/support/fake_cdp.ex
+++ b/test/support/fake_cdp.ex
@@ -65,7 +65,7 @@ defmodule CDPEx.FakeCDP do
   defp accept_loop(listen, controller) do
     case :gen_tcp.accept(listen) do
       {:ok, socket} ->
-        pid = spawn(fn -> serve(socket, controller) end)
+        pid = spawn_link(fn -> serve(socket, controller) end)
         _ = :gen_tcp.controlling_process(socket, pid)
         send(pid, :go)
         accept_loop(listen, controller)
@@ -204,12 +204,14 @@ defmodule CDPEx.FakeCDP do
   end
 
   defp unmask(payload, mask) do
-    mask = :binary.bin_to_list(mask)
+    # elem/2 on a 4-tuple is O(1); Enum.at/2 on a list is O(n), making unmask
+    # O(payload x 4) — negligible for tiny unit frames, slow for large ones.
+    mask = mask |> :binary.bin_to_list() |> List.to_tuple()
 
     payload
     |> :binary.bin_to_list()
     |> Enum.with_index()
-    |> Enum.map(fn {byte, i} -> bxor(byte, Enum.at(mask, rem(i, 4))) end)
+    |> Enum.map(fn {byte, i} -> bxor(byte, elem(mask, rem(i, 4))) end)
     |> :erlang.list_to_binary()
   end
 


### PR DESCRIPTION
Addresses the small (non-`navigate`-race) follow-ups in #9.

## Fixed
- `Protocol.parse_ws_url/1` → `URI.parse` (handles IPv6 hosts; raises a clear `ArgumentError` on malformed input instead of a `MatchError`)
- `Connection` no longer crashes on a negative timeout (`arm_timeout` clamps to an immediate 0)
- `Connection.terminate/2` is now the single point that fails in-flight callers — with `{:error, {:ws_closed, _}}` instead of `:noproc` on `close/1`

## Changed
- `Browser.child_spec/1` sets `shutdown: 10_000` so a supervisor gives `terminate/2` time to reap Chrome

## Docs / test infra
- README `--no-sandbox` warning; `call_function/4` trusted-input callout
- `FakeCDP.unmask` uses `elem/2`; per-connection handlers are `spawn_link`'d

## Tests
+6 unit tests (close_page reject paths, child_spec, owner `:normal` exit, negative timeout, `close/1` teardown). `mix ci` green (67 tests + 16 doctests, Dialyzer 0); integration **27/0, 0 orphan Chrome**.

Remaining in #9 after this: only the `navigate/3` lifecycle race, which gets its own PR (it needs a new `Connection` arm-then-await primitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
