### PR TITLE
fix: navigate/3 lifecycle race (closes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Protocol.parse_ws_url/1` parses IPv6 hosts and raises a clear `ArgumentError` on a malformed URL (previously a `MatchError`).
 - `CDPEx.Connection` no longer crashes when `call/5` / `await_event/4` is given a negative timeout (it fires immediately).
 - `CDPEx.Connection` teardown fails in-flight callers with `{:error, {:ws_closed, _}}` instead of `{:error, :noproc}` on `close/1`.
+- `CDPEx.Page.navigate/3` subscribes to lifecycle events before issuing the navigate, so a fast readiness event (e.g. `load` on a cached/local page) can no longer be dropped — a register-after-navigate race.
 
 ## [0.2.0] - 2026-06-02
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -76,21 +76,26 @@ defmodule CDPEx.Page do
     # (e.g. `load` on a cached/local page) can't fire in the gap between the
     # navigate reply and waiter registration — the old race. subscribe/2 is a
     # synchronous call, so the subscription is in place before the command goes out.
-    :ok = Connection.subscribe(page.conn, "Page.lifecycleEvent")
-    drain_lifecycle(page.conn)
-    ref = Process.monitor(page.conn)
-    deadline = System.monotonic_time(:millisecond) + timeout
+    case safe_subscribe(page.conn) do
+      {:error, reason} ->
+        {:error, reason}
 
-    try do
-      case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
-        {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
-        {:ok, _result} -> await_lifecycle(page, name, ref, deadline)
-        {:error, _} = error -> error
-      end
-    after
-      Process.demonitor(ref, [:flush])
-      Connection.unsubscribe(page.conn, "Page.lifecycleEvent")
-      drain_lifecycle(page.conn)
+      :ok ->
+        drain_lifecycle(page.conn)
+        ref = Process.monitor(page.conn)
+        deadline = System.monotonic_time(:millisecond) + timeout
+
+        try do
+          case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
+            {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
+            {:ok, _result} -> await_lifecycle(page, name, ref, deadline)
+            {:error, _} = error -> error
+          end
+        after
+          Process.demonitor(ref, [:flush])
+          safe_unsubscribe(page.conn)
+          drain_lifecycle(page.conn)
+        end
     end
   end
 
@@ -104,7 +109,7 @@ defmodule CDPEx.Page do
       {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => ^name}, ^sid} ->
         {:ok, page}
 
-      {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _other_sid} ->
+      {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _session_id} ->
         await_lifecycle(page, name, ref, deadline)
 
       {:DOWN, ^ref, :process, ^conn, reason} ->
@@ -122,6 +127,21 @@ defmodule CDPEx.Page do
 
   defp down_reason({:shutdown, {:ws_closed, reason}}), do: {:ws_closed, reason}
   defp down_reason(_), do: :noproc
+
+  # subscribe/unsubscribe are GenServer.calls; a connection that's already dead (or
+  # dies mid-navigation) would otherwise make them exit and crash navigate/3 —
+  # which must instead return {:error, _}. Treat (un)subscription as best-effort.
+  defp safe_subscribe(conn) do
+    Connection.subscribe(conn, "Page.lifecycleEvent")
+  catch
+    :exit, _ -> {:error, :noproc}
+  end
+
+  defp safe_unsubscribe(conn) do
+    Connection.unsubscribe(conn, "Page.lifecycleEvent")
+  catch
+    :exit, _ -> :ok
+  end
 
   # Flush lifecycle events left in our mailbox (other sessions/names, or stragglers
   # from a prior navigation) so they don't leak to the caller.

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -58,33 +58,78 @@ defmodule CDPEx.Page do
   def navigate(%__MODULE__{} = page, url, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, @navigate_timeout)
     wait_until = Keyword.get(opts, :wait_until, :network_almost_idle)
+    navigate_with_wait(page, url, wait_until, timeout)
+  end
 
+  defp navigate_with_wait(page, url, :none, timeout) do
     case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
       {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
-      {:ok, _result} -> await_navigation(page, wait_until, timeout)
+      {:ok, _result} -> {:ok, page}
       {:error, _} = error -> error
     end
   end
 
-  defp await_navigation(page, :none, _timeout), do: {:ok, page}
-
-  defp await_navigation(page, wait_until, timeout) do
+  defp navigate_with_wait(page, url, wait_until, timeout) do
     name = lifecycle_name(wait_until)
 
-    case do_await(page, &(&1["name"] == name), timeout) do
-      :ok ->
+    # Subscribe to lifecycle events BEFORE issuing the navigate, so a fast event
+    # (e.g. `load` on a cached/local page) can't fire in the gap between the
+    # navigate reply and waiter registration — the old race. subscribe/2 is a
+    # synchronous call, so the subscription is in place before the command goes out.
+    :ok = Connection.subscribe(page.conn, "Page.lifecycleEvent")
+    drain_lifecycle(page.conn)
+    ref = Process.monitor(page.conn)
+    deadline = System.monotonic_time(:millisecond) + timeout
+
+    try do
+      case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
+        {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
+        {:ok, _result} -> await_lifecycle(page, name, ref, deadline)
+        {:error, _} = error -> error
+      end
+    after
+      Process.demonitor(ref, [:flush])
+      Connection.unsubscribe(page.conn, "Page.lifecycleEvent")
+      drain_lifecycle(page.conn)
+    end
+  end
+
+  # Block until the named lifecycle event for this page's session arrives, the
+  # connection dies, or the deadline passes. Lifecycle events for other sessions
+  # or names on a shared connection are skipped (then drained by the caller).
+  defp await_lifecycle(%__MODULE__{conn: conn, session_id: sid} = page, name, ref, deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => ^name}, ^sid} ->
         {:ok, page}
 
-      {:error, :timeout} ->
-        # The page just didn't signal readiness in time — navigation was still
-        # issued, so return the page (best-effort), as documented.
+      {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _other_sid} ->
+        await_lifecycle(page, name, ref, deadline)
+
+      {:DOWN, ^ref, :process, ^conn, reason} ->
+        # The connection died mid-navigation — surface it rather than returning a
+        # stale handle as success.
+        {:error, down_reason(reason)}
+    after
+      remaining ->
+        # The page didn't signal readiness in time — navigation was still issued,
+        # so return the page (best-effort), as documented.
         Logger.debug("[CDPEx.Page] readiness wait (#{name}) timed out; returning best-effort")
         {:ok, page}
+    end
+  end
 
-      {:error, reason} ->
-        # The connection died during navigation (:noproc / {:ws_closed, _}).
-        # Surface it instead of returning a stale page handle as success.
-        {:error, reason}
+  defp down_reason({:shutdown, {:ws_closed, reason}}), do: {:ws_closed, reason}
+  defp down_reason(_), do: :noproc
+
+  # Flush lifecycle events left in our mailbox (other sessions/names, or stragglers
+  # from a prior navigation) so they don't leak to the caller.
+  defp drain_lifecycle(conn) do
+    receive do
+      {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _sid} -> drain_lifecycle(conn)
+    after
+      0 -> :ok
     end
   end
 

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -167,6 +167,16 @@ defmodule CDPEx.IntegrationTest do
       assert html =~ "CDPEx Fixture" or html =~ "greeting"
     end
 
+    test "navigate/3 with wait_until: :load resolves (race-free) on a fast page", %{
+      page: page,
+      fixture: fixture
+    } do
+      # :load fires fast on a local page — the case most exposed to the old
+      # register-after-navigate race. Subscribing before navigate must catch it.
+      assert {:ok, ^page} = Page.navigate(page, fixture, wait_until: :load)
+      assert {:ok, "Hello"} = Page.text(page, "#greeting")
+    end
+
     test "evaluate returns a JS value", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       assert {:ok, "CDPEx Fixture"} = Page.evaluate(page, "document.title")


### PR DESCRIPTION
The last #9 item — the `Page.navigate/3` lifecycle-event race.

## The race
`navigate/3` registered its `Page.lifecycleEvent` waiter *after* the navigate reply. A fast readiness event (e.g. `load` on a cached/local page) could fire in that gap and be dropped — the wait then timed out and `navigate` returned a best-effort `{:ok, page}` on a page that wasn't actually ready.

## The fix — `page.ex` only, no Connection-core change
- **Subscribe to `Page.lifecycleEvent` *before* issuing the navigate.** `subscribe/2` is synchronous, so the subscription is in place before the command goes out — the event can't slip through.
- **Monitor the connection** during the wait, so a mid-navigation drop still surfaces `{:error, {:ws_closed, _}}` / `:noproc` (preserving the readiness-vs-dead-connection distinction).
- **Drain** stray lifecycle events (other sessions/names, or stragglers from a prior navigation) from the caller's mailbox, before and after.

Chosen over a new `Connection` arm/await primitive deliberately: contained to `page.ex`, leaves the published Connection core untouched.

## Verification
`mix ci` green (67 tests + 16 doctests, Dialyzer 0); integration **28/0** (incl. a new `wait_until: :load` test — the case most exposed to the race), 0 `[error]` lines, 0 orphan Chrome.

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
