### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-02
+
 ### Changed
 - `CDPEx.Browser` sets `shutdown: 10_000` in `child_spec/1` so a supervisor gives `terminate/2` enough time to reap Chrome.
 
@@ -44,6 +46,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page`: `navigate/3`, `wait_for_selector/3`, `evaluate/3`, `click/3`,
   `html/2`, `screenshot/2`.
 
-[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/patrols/cdp_ex/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/patrols/cdp_ex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/patrols/cdp_ex/releases/tag/v0.1.0

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CDPEx.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
   @source_url "https://github.com/patrols/cdp_ex"
 
   def project do


### PR DESCRIPTION
Prepares the v0.2.1 patch release — the #9 follow-up fixes (already merged to `main` via #13 + #14). **No tag/publish in this PR** — those are the your-hands steps after merge.

## What's in 0.2.1
### Changed
- `Browser` sets `shutdown: 10_000` in `child_spec/1` (gives `terminate/2` time to reap Chrome).

### Fixed
- `Protocol.parse_ws_url/1` — IPv6 hosts + a clear `ArgumentError` on malformed input.
- `Connection` no longer crashes on a negative timeout.
- `Connection` teardown fails in-flight callers with `{:error, {:ws_closed, _}}` (not `:noproc`) on `close/1`.
- `Page.navigate/3` subscribes to lifecycle events before issuing the navigate — closes the register-after-navigate race.

## This PR
- `CHANGELOG.md`: promote `[Unreleased]` → `[0.2.1] - 2026-06-02` (+ link refs)
- `mix.exs`: `@version` → `0.2.1`
- Verified: `mix ci` green (67 tests + 16 doctests, Dialyzer 0); `mix hex.build` → `cdp_ex-0.2.1.tar`; `mix docs` clean

## After merge (your steps — Hex auth)
```
gh pr merge <this> --repo patrols/cdp_ex --squash
git checkout main && git pull
git tag -a v0.2.1 -m "v0.2.1"
git push origin v0.2.1
mix hex.publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
