### PR TITLE
v0.2.2 — launch-path robustness + #16 internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-06-02
+
+### Added
+- Documented `:launch_timeout` as a ceiling (not a fixed wait) on `CDPEx.launch/1` and `CDPEx.with_page/3`, plus a "Running in containers" README section (timeout tuning, the fresh-profile cold-start cost, `/dev/shm` sizing, `--remote-allow-origins`).
+
+### Changed
+- Chrome readiness is now **polled**: `CDPEx.Chrome` checks the `DevToolsActivePort` file throughout the wait (not only at the deadline), so launch returns as soon as Chrome is reachable and `:launch_timeout` acts as a ceiling rather than a fixed cost — robust to Chrome builds that don't print the `DevTools listening on ws://…` stderr line.
+- A launch that never exposes the DevTools endpoint now returns `{:error, {:debug_url_not_found, stderr_excerpt}}` (was the bare atom `:debug_url_not_found`), carrying Chrome's captured stderr so the failure is self-diagnosing. **Migration:** code matching the bare `:debug_url_not_found` atom (e.g. a retry classifier) must match `{:debug_url_not_found, _}` instead, or that error silently stops matching.
+- `CDPEx.with_page/3`, given launch options, now contains a throwaway-browser crash: it returns `{:error, reason}` instead of letting the browser's linked exit propagate to and kill the caller. It briefly traps exits in the calling process for the duration of the call (see the `with_page/3` docs for the foreign-EXIT caveat and escape hatch).
+
+### Fixed
+- `CDPEx.Connection` no longer ignores an owning-process exit that arrives during the WebSocket upgrade — it aborts the connect at once instead of lingering until the upgrade timeout.
+- `CDPEx.Connection` now stops when a WebSocket **pong** write fails (mirroring a failed command write), rather than continuing on a dead socket until the next command notices.
+- `CDPEx.Page.navigate/3` prefers a just-arrived connection `:DOWN` over a best-effort readiness timeout when the two tie at the deadline, so a connection death surfaces as an error rather than a stale `{:ok, page}`.
+
 ## [0.2.1] - 2026-06-02
 
 ### Changed
@@ -46,7 +61,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page`: `navigate/3`, `wait_for_selector/3`, `evaluate/3`, `click/3`,
   `html/2`, `screenshot/2`.
 
-[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/patrols/cdp_ex/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/patrols/cdp_ex/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/patrols/cdp_ex/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/patrols/cdp_ex/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Connection` no longer ignores an owning-process exit that arrives during the WebSocket upgrade — it aborts the connect at once instead of lingering until the upgrade timeout.
 - `CDPEx.Connection` now stops when a WebSocket **pong** write fails (mirroring a failed command write), rather than continuing on a dead socket until the next command notices.
 - `CDPEx.Page.navigate/3` prefers a just-arrived connection `:DOWN` over a best-effort readiness timeout when the two tie at the deadline, so a connection death surfaces as an error rather than a stale `{:ok, page}`.
+- `CDPEx.Browser` no longer leaks Chrome if the browser connection drops in the window between connecting and its first subscribe — the init-time exit is caught and Chrome is reaped.
+- `CDPEx.Chrome` launch-failure cleanup waits for the OS process to exit before removing the temp profile (matching `stop/1`), closing a `kill`/`rm` race.
+- `CDPEx.Connection.call/5` and `await_event/4` return the documented timeout tuple instead of crashing the caller if the outer `GenServer.call` deadline fires first under scheduler starvation.
+- `CDPEx.Connection` accumulates WebSocket upgrade headers across response chunks instead of replacing them (defensive; dormant for single-response `101` upgrades).
 
 ## [0.2.1] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,46 @@ For reproducible setups, point it at a
 > start in many CI/container environments. If you run as root or drive untrusted
 > pages, re-enable it by overriding `:args` — see `CDPEx.Chrome`.
 
+## Running in containers
+
+CDPEx is validated on macOS, but its defaults already target Linux containers:
+`--no-sandbox`, `--disable-dev-shm-usage`, and `--disable-setuid-sandbox` are on
+by default, so headless Chrome starts out of the box on a constrained host (e.g.
+2 vCPU / 2 GB). A few things smooth the path further:
+
+- **Tune `:launch_timeout` for cold starts.** Chrome's first launch in a fresh
+  container is slower than on a warm dev machine. `:launch_timeout` is a *ceiling*,
+  not a fixed wait (readiness is polled and returns as soon as Chrome is
+  reachable), so a generous value costs nothing on a fast launch:
+
+  ```elixir
+  CDPEx.launch(launch_timeout: 30_000)
+  ```
+
+- **Fresh-profile cost.** Each launch creates a new `--user-data-dir` (removed on
+  stop), so there's no warm disk cache between launches and the *first* navigation
+  pays a cold-start cost. For throughput, prefer one long-lived browser (`launch/1`
+  + reuse) over a throwaway `with_page([...])` per request, or pass a persistent
+  `:user_data_dir`.
+
+- **`/dev/shm` sizing.** Docker defaults `/dev/shm` to 64 MB, which Chrome can
+  exhaust (crashing tabs). CDPEx ships `--disable-dev-shm-usage` by default (Chrome
+  writes to `/tmp` instead), so it works on a small `/dev/shm` as-is. To size it up
+  instead (`--shm-size=1g`), drop that flag via a custom `:args`.
+
+- **Memory.** On a 2 GB host a single browser with a few pages is comfortable; each
+  open page and large screenshots/PDFs add transient memory. Close pages promptly,
+  or use `transport: :session` to cut per-page socket/process overhead when you
+  don't need crash isolation.
+
+- **`--remote-allow-origins`.** Some Chrome builds enforce an `Origin` check on the
+  DevTools WebSocket upgrade and may reject a CDP client with a 403. CDPEx doesn't
+  set this by default; if you hit `{:error, {:ws_upgrade, _}}` at connect, add it:
+
+  ```elixir
+  CDPEx.launch(launch_timeout: 30_000, extra_args: ["--remote-allow-origins=*"])
+  ```
+
 ## Usage
 
 ### Resource-safe (recommended)

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -40,7 +40,9 @@ defmodule CDPEx do
   Launches a headless Chrome browser and returns its process pid.
 
   Accepts the launch options documented in `CDPEx.Chrome` (e.g. `:headless`,
-  `:chrome_binary`, `:extra_args`, `:window_size`). For long-lived use, prefer
+  `:chrome_binary`, `:extra_args`, `:window_size`, `:launch_timeout`). On slow
+  cold-start hosts (e.g. headless Chrome in a constrained container) raise
+  `:launch_timeout` — it is a ceiling, not a fixed wait. For long-lived use, prefer
   putting `CDPEx.Browser` under your own supervisor with a `:shutdown` timeout.
   """
   @spec launch(keyword()) :: GenServer.on_start()
@@ -69,6 +71,16 @@ defmodule CDPEx do
   Pass an existing browser pid to reuse it, or a keyword list of launch options
   to spin up a throwaway browser for the duration of the call. Returns whatever
   `fun` returns, or `{:error, reason}` if the page/browser could not be created.
+
+  With launch options, the throwaway browser is linked but **contained**: if it
+  crashes during the call (e.g. its connection drops) `with_page` returns
+  `{:error, reason}` instead of letting the crash propagate to the caller. To do
+  that it briefly traps exits in the calling process for the duration of the call.
+  Only the browser's own `{:EXIT, _, _}` is drained — a *foreign* process linked
+  to the caller that exits during this window has its exit delivered as a message
+  left in the caller's mailbox, so a caller that links other processes and relies
+  on un-trapped exit propagation should pass a pre-launched browser pid instead.
+  On slow cold-start hosts, raise `:launch_timeout` (a ceiling, not a fixed wait).
 
       # against an existing browser
       CDPEx.with_page(browser, fn page ->
@@ -103,10 +115,26 @@ defmodule CDPEx do
   def with_page(launch_opts, fun, opts) when is_list(launch_opts) and is_function(fun, 1) do
     case launch(launch_opts) do
       {:ok, browser} ->
+        # launch/1 links `browser` to us. Trap exits for the duration of this call
+        # so a browser crash (e.g. its connection dropping mid-call) arrives as a
+        # message — `fun`'s own {:error, _} returns first and is never masked —
+        # instead of a link exit that would kill the caller, breaking with_page's
+        # resource-safe contract. We keep the link (not just a monitor) so that if
+        # the *caller* dies, the browser is still reaped via Browser.terminate/2.
+        prev_trap = Process.flag(:trap_exit, true)
+
         try do
-          with_page(browser, fun, opts)
+          try do
+            with_page(browser, fun, opts)
+          after
+            safe(fn -> stop(browser) end)
+          end
         after
-          safe(fn -> stop(browser) end)
+          # Drain the browser's queued {:EXIT, browser, _} (from its crash, or from
+          # our own stop/1) so it can't surface to the caller once we restore the
+          # prior trap_exit flag. A foreign linked process's EXIT is left as-is.
+          drain_exit(browser)
+          Process.flag(:trap_exit, prev_trap)
         end
 
       {:error, _} = error ->
@@ -122,5 +150,17 @@ defmodule CDPEx do
     _ -> :ok
   catch
     :exit, _ -> :ok
+  end
+
+  # Remove a single queued {:EXIT, browser, _} (delivered as a message because the
+  # throwaway-browser `with_page/3` clause traps exits) so it can't leak to the
+  # caller after the prior trap_exit flag is restored. At most one can exist — a
+  # process exits once.
+  defp drain_exit(browser) do
+    receive do
+      {:EXIT, ^browser, _reason} -> :ok
+    after
+      0 -> :ok
+    end
   end
 end

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -98,17 +98,28 @@ defmodule CDPEx.Browser do
         # Prune session entries when their target ends (tab closed/crashed, or our
         # own close_page) so long-lived browsers don't accumulate stale sessions —
         # parity with the dedicated path, which self-prunes on a page-conn EXIT.
-        Connection.subscribe(conn, "Target.detachedFromTarget")
+        # subscribe/2 is a GenServer.call: if the browser socket dropped in the
+        # window after start_link, it exits — and since the GenServer loop hasn't
+        # started, terminate/2 never runs, so reap Chrome (and the conn) here or
+        # leak the OS process and temp profile, same as the start_link path below.
+        try do
+          Connection.subscribe(conn, "Target.detachedFromTarget")
 
-        {:ok,
-         %__MODULE__{
-           chrome: chrome,
-           browser_conn: conn,
-           host: host,
-           port: port,
-           opts: launch_opts,
-           parent: parent_pid()
-         }}
+          {:ok,
+           %__MODULE__{
+             chrome: chrome,
+             browser_conn: conn,
+             host: host,
+             port: port,
+             opts: launch_opts,
+             parent: parent_pid()
+           }}
+        catch
+          :exit, reason ->
+            safe_close(conn)
+            Chrome.stop(chrome)
+            {:stop, reason}
+        end
 
       {:error, reason} ->
         Chrome.stop(chrome)

--- a/lib/cdp_ex/chrome.ex
+++ b/lib/cdp_ex/chrome.ex
@@ -102,9 +102,13 @@ defmodule CDPEx.Chrome do
          }}
 
       {:error, reason} ->
+        # Align with stop/1: kill -9 is async, so wait for the OS process to exit
+        # before removing the temp profile (a still-alive Chrome can recreate files
+        # between the rm and the reap), and use remove_dir/1's retry loop.
         kill(os_pid)
         close_port(port)
-        _ = if owns?, do: File.rm_rf(user_data_dir)
+        await_exit(os_pid, deadline(@stop_exit_timeout))
+        if owns?, do: remove_dir(user_data_dir)
         {:error, reason}
     end
   end

--- a/lib/cdp_ex/chrome.ex
+++ b/lib/cdp_ex/chrome.ex
@@ -19,7 +19,10 @@ defmodule CDPEx.Chrome do
       stop) when omitted. A caller-supplied dir is left in place.
     * `:extra_args` — extra flags appended to the defaults
     * `:args` — full flag list that **replaces** the defaults entirely
-    * `:launch_timeout` — ms to wait for the DevTools URL (default `15_000`)
+    * `:launch_timeout` — ms to wait for the DevTools endpoint (default
+      `15_000`). A *ceiling*, not a fixed wait: readiness is polled and returns
+      as soon as Chrome is reachable, so a generous value is free. Raise it for
+      slow cold-start hosts (e.g. headless Chrome in a constrained container).
 
   ## Default flags
 
@@ -40,6 +43,9 @@ defmodule CDPEx.Chrome do
   import Bitwise, only: [band: 2]
 
   @launch_timeout 15_000
+  # How often to poll the DevToolsActivePort file while waiting for readiness, so
+  # a fast-ready Chrome returns promptly and @launch_timeout acts as a ceiling.
+  @devtools_poll_interval 150
   @stop_exit_timeout 3_000
   @default_window_size {1280, 1024}
 
@@ -240,12 +246,16 @@ defmodule CDPEx.Chrome do
   # ── DevTools URL discovery ──────────────────────────────────────────────────
 
   # Chrome prints `DevTools listening on ws://127.0.0.1:<port>/devtools/browser/<uuid>`
-  # to stderr; if we miss it before the deadline, reconstruct from DevToolsActivePort.
+  # to stderr, but on some builds/configs (notably new-headless, or under load)
+  # that line is slow or never printed. So while waiting we also poll the
+  # DevToolsActivePort file every @devtools_poll_interval and return the instant
+  # it's readable — making @launch_timeout a ceiling rather than a fixed wait, and
+  # readiness detection robust to Chrome variants that don't print the stderr line.
   defp await_debug_url(port, dir, buffer, deadline) do
     remaining = remaining_ms(deadline)
 
     if remaining <= 0 do
-      read_devtools_file(dir)
+      read_devtools_file(dir, buffer)
     else
       receive do
         {^port, {:data, data}} ->
@@ -259,19 +269,28 @@ defmodule CDPEx.Chrome do
         {^port, {:exit_status, status}} ->
           {:error, {:chrome_exited, status, String.slice(buffer, 0, 500)}}
       after
-        remaining -> read_devtools_file(dir)
+        # A bounded tick (never past the deadline): try the file, else keep
+        # waiting and accumulating stderr. Only the `remaining <= 0` branch above
+        # surfaces an error, so a not-yet-written file here just polls again.
+        min(@devtools_poll_interval, remaining) ->
+          case read_devtools_file(dir, buffer) do
+            {:ok, url} -> {:ok, url}
+            {:error, _} -> await_debug_url(port, dir, buffer, deadline)
+          end
       end
     end
   end
 
   # DevToolsActivePort: line 1 is the port, line 2 is the /devtools/browser/<uuid> path.
-  defp read_devtools_file(dir) do
+  # On a missing file, carry the captured stderr excerpt so a launch that never
+  # exposed the endpoint is self-diagnosing instead of a context-free atom.
+  defp read_devtools_file(dir, buffer) do
     with {:ok, contents} <- File.read(Path.join(dir, "DevToolsActivePort")),
          [port_str, browser_path | _] <- String.split(String.trim(contents), "\n"),
          {port_num, _} <- Integer.parse(port_str) do
       {:ok, "ws://127.0.0.1:#{port_num}#{browser_path}"}
     else
-      {:error, _} -> {:error, :debug_url_not_found}
+      {:error, _} -> {:error, {:debug_url_not_found, String.slice(buffer, 0, 500)}}
       _ -> {:error, :devtools_file_malformed}
     end
   end

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -39,7 +39,8 @@ defmodule CDPEx.Connection do
     subscribers: %{},
     all_subscribers: MapSet.new(),
     monitors: %{},
-    waiters: []
+    waiters: [],
+    ws_send_error: nil
   ]
 
   @type t :: %__MODULE__{}
@@ -134,7 +135,6 @@ defmodule CDPEx.Connection do
 
   @impl true
   def init({ws_url, opts}) do
-    Process.flag(:trap_exit, true)
     {host, port, path} = Protocol.parse_ws_url(ws_url)
     upgrade_timeout = Keyword.get(opts, :upgrade_timeout, @upgrade_timeout)
 
@@ -144,6 +144,13 @@ defmodule CDPEx.Connection do
          {:ok, conn, ref} <- WebSocket.upgrade(:ws, conn, path, []),
          {:ok, conn, status, headers} <- recv_upgrade(conn, ref, upgrade_timeout),
          {:ok, conn, websocket} <- WebSocket.new(conn, ref, status, headers) do
+      # Trap exits only AFTER the handshake. During the upgrade, recv_upgrade's
+      # wildcard receive would otherwise swallow an owner {:EXIT} (it reaches
+      # WebSocket.stream → :unknown → loop), so a dying owner is ignored until the
+      # upgrade timeout. Deferred, a mid-handshake owner death takes this still-
+      # linked process down (aborting the connect); post-handshake we trap so an
+      # owner exit stops us cleanly via the {:EXIT, _, _} handler + terminate/2.
+      Process.flag(:trap_exit, true)
       {:ok, %__MODULE__{conn: conn, ref: ref, websocket: websocket}}
     else
       {:error, reason} -> {:stop, {:ws_connect, reason}}
@@ -299,13 +306,21 @@ defmodule CDPEx.Connection do
   # fail remaining callers with {:ws_closed, _} and stop — otherwise a graceful
   # close would be silently dropped and callers would only time out.
   defp dispatch_frames(frames, state) do
-    case Enum.split_while(frames, &(not close_frame?(&1))) do
-      {pre, []} ->
-        {:noreply, Enum.reduce(pre, state, &dispatch/2)}
+    {pre, rest} = Enum.split_while(frames, &(not close_frame?(&1)))
+    state = Enum.reduce(pre, state, &dispatch/2)
 
-      {pre, [close | _rest]} ->
-        state = Enum.reduce(pre, state, &dispatch/2)
-        stop_ws_closed(state, close_reason(close))
+    cond do
+      # A failed pong write (recorded by pong/2 during the reduce) means the
+      # socket is dead — stop now, mirroring a failed command write, rather than
+      # running on it until the next ws_send notices.
+      state.ws_send_error ->
+        stop_ws_closed(state, state.ws_send_error)
+
+      match?([_ | _], rest) ->
+        stop_ws_closed(state, close_reason(hd(rest)))
+
+      true ->
+        {:noreply, state}
     end
   end
 
@@ -463,12 +478,19 @@ defmodule CDPEx.Connection do
     case WebSocket.encode(state.websocket, {:pong, data}) do
       {:ok, websocket, frame} ->
         case WebSocket.stream_request_body(state.conn, state.ref, frame) do
-          {:ok, conn} -> %{state | websocket: websocket, conn: conn}
-          {:error, conn, _reason} -> %{state | conn: conn}
+          {:ok, conn} ->
+            %{state | websocket: websocket, conn: conn}
+
+          # A failed pong write means the socket is dead. Record it so
+          # dispatch_frames/2 stops the connection (mirroring ws_send/2's failure
+          # handling) rather than running on a broken socket until the next
+          # command write notices.
+          {:error, conn, reason} ->
+            %{state | websocket: websocket, conn: conn, ws_send_error: {:ws_send, reason}}
         end
 
-      {:error, websocket, _reason} ->
-        %{state | websocket: websocket}
+      {:error, websocket, reason} ->
+        %{state | websocket: websocket, ws_send_error: {:ws_encode, reason}}
     end
   end
 

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -80,6 +80,10 @@ defmodule CDPEx.Connection do
     :exit, {:normal, _} -> {:error, :noproc}
     :exit, {{:shutdown, {:ws_closed, reason}}, _} -> {:error, {:ws_closed, reason}}
     :exit, {:shutdown, _} -> {:error, :noproc}
+    # Under scheduler starvation the outer GenServer.call deadline (timeout + 1s)
+    # can fire before our inner {:call_timeout} reply — return the documented
+    # timeout tuple rather than letting the raw exit crash the caller.
+    :exit, {:timeout, _} -> {:error, {:timeout, method}}
   end
 
   @doc """
@@ -119,6 +123,7 @@ defmodule CDPEx.Connection do
     :exit, {:normal, _} -> {:error, :noproc}
     :exit, {{:shutdown, {:ws_closed, reason}}, _} -> {:error, {:ws_closed, reason}}
     :exit, {:shutdown, _} -> {:error, :noproc}
+    :exit, {:timeout, _} -> {:error, :timeout}
   end
 
   @doc "Closes the WebSocket and stops the connection."
@@ -534,7 +539,7 @@ defmodule CDPEx.Connection do
   defp apply_upgrade(responses, ref, acc) do
     Enum.reduce(responses, acc, fn
       {:status, ^ref, status}, {_s, h, d} -> {status, h, d}
-      {:headers, ^ref, headers}, {s, _h, d} -> {s, headers, d}
+      {:headers, ^ref, headers}, {s, h, d} -> {s, h ++ headers, d}
       {:done, ^ref}, {s, h, _d} -> {s, h, true}
       _other, acc -> acc
     end)

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -118,10 +118,19 @@ defmodule CDPEx.Page do
         {:error, down_reason(reason)}
     after
       remaining ->
-        # The page didn't signal readiness in time — navigation was still issued,
-        # so return the page (best-effort), as documented.
-        Logger.debug("[CDPEx.Page] readiness wait (#{name}) timed out; returning best-effort")
-        {:ok, page}
+        # Exact deadline-vs-DOWN tie: a {:DOWN} may have just landed but lost the
+        # race to `after`. Prefer it over a misleading best-effort {:ok} when the
+        # connection actually died.
+        receive do
+          {:DOWN, ^ref, :process, ^conn, reason} ->
+            {:error, down_reason(reason)}
+        after
+          0 ->
+            # The page didn't signal readiness in time — navigation was still
+            # issued, so return the page (best-effort), as documented.
+            Logger.debug("[CDPEx.Page] readiness wait (#{name}) timed out; returning best-effort")
+            {:ok, page}
+        end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CDPEx.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
   @source_url "https://github.com/patrols/cdp_ex"
 
   def project do

--- a/test/cdp_ex/chrome_test.exs
+++ b/test/cdp_ex/chrome_test.exs
@@ -112,6 +112,68 @@ defmodule CDPEx.ChromeTest do
       assert {:error, {:chrome_not_found, ^path}} = Chrome.launch(chrome_binary: path)
     end
 
+    @tag :tmp_dir
+    test "times out to {:debug_url_not_found, stderr} when the endpoint never appears", %{
+      tmp_dir: tmp_dir
+    } do
+      # A stand-in binary that prints to stderr and stays alive without ever
+      # exposing a DevTools endpoint (no ws:// line, no DevToolsActivePort file).
+      stub =
+        write_stub!(tmp_dir, "stub-no-endpoint", """
+        #!/bin/sh
+        # exec, so the shell flushes the buffered stderr line to the pipe before
+        # sleeping (a plain `sleep` would hold it unflushed past the timeout).
+        echo 'stub-chrome: no devtools endpoint here' 1>&2
+        exec sleep 30
+        """)
+
+      # A generous timeout: this path always waits it out (no endpoint ever
+      # appears), and the captured stderr must arrive before the deadline even
+      # under concurrent test load — a tight window races the port data delivery.
+      assert {:error, {:debug_url_not_found, excerpt}} =
+               Chrome.launch(chrome_binary: stub, launch_timeout: 2_000)
+
+      # The captured stderr is threaded into the error, so the failure is
+      # self-diagnosing rather than a context-free atom.
+      assert excerpt =~ "no devtools endpoint"
+    end
+
+    @tag :tmp_dir
+    test "returns as soon as DevToolsActivePort is readable, without the stderr line", %{
+      tmp_dir: tmp_dir
+    } do
+      # Writes a valid DevToolsActivePort into its --user-data-dir but never prints
+      # the "DevTools listening on ws://" line — the case that used to block for the
+      # full timeout. The poll must pick the file up and return promptly.
+      stub =
+        write_stub!(tmp_dir, "stub-writes-port", """
+        #!/bin/sh
+        dir=""
+        for arg in "$@"; do
+          case "$arg" in
+            --user-data-dir=*) dir="${arg#--user-data-dir=}" ;;
+          esac
+        done
+        {
+          echo '9222'
+          echo '/devtools/browser/stub-uuid'
+        } > "$dir/DevToolsActivePort"
+        echo 'stub-chrome: started without a listening line' 1>&2
+        sleep 30
+        """)
+
+      {elapsed_us, result} =
+        :timer.tc(fn -> Chrome.launch(chrome_binary: stub, launch_timeout: 5_000) end)
+
+      assert {:ok, handle} = result
+      assert handle.debug_url == "ws://127.0.0.1:9222/devtools/browser/stub-uuid"
+      # Returned on a poll tick, far under the 5s ceiling — not by waiting it out.
+      assert elapsed_us < 2_000_000
+
+      :ok = Chrome.stop(handle)
+      refute File.dir?(handle.user_data_dir)
+    end
+
     @tag :integration
     test "launches real Chrome, exposes a browser ws URL, and cleans up on stop" do
       assert {:ok, handle} = Chrome.launch([])
@@ -124,5 +186,14 @@ defmodule CDPEx.ChromeTest do
       # Temp profile dir we created is gone after stop.
       refute File.dir?(handle.user_data_dir)
     end
+  end
+
+  # Write an executable stand-in "chrome" script into a tmp dir for launch/1 tests
+  # that exercise the readiness path without a real browser.
+  defp write_stub!(dir, name, body) do
+    path = Path.join(dir, name)
+    File.write!(path, body)
+    File.chmod!(path, 0o755)
+    path
   end
 end

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -336,6 +336,39 @@ defmodule CDPEx.ConnectionTest do
     refute Map.has_key?(:sys.get_state(conn).monitors, self())
   end
 
+  test "an owner death during the upgrade brings the connection down promptly" do
+    # A stalling server accepts the socket but never finishes the upgrade, so the
+    # connection sits in recv_upgrade. With trap_exit deferred past the handshake,
+    # the owner's death (via the link) aborts the connect at once. The regressed
+    # version trapped during the handshake and swallowed the {:EXIT}, lingering
+    # until the (here generous) upgrade timeout.
+    {:ok, server} = FakeCDP.start_stalling()
+
+    owner =
+      spawn(fn ->
+        Connection.start_link(server.url, upgrade_timeout: 10_000)
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:fake_cdp_stalled, _fake}, 2_000
+    Process.exit(owner, :kill)
+    assert_receive {:fake_cdp_client_gone, _fake}, 2_000
+  end
+
+  test "a server ping then an abrupt drop stops the connection (never runs on a dead socket)", %{
+    conn: conn,
+    fake: fake
+  } do
+    # Exercises the ping → pong path on a failing socket. A failed pong write now
+    # stops the connection (mirroring ws_send/2); and even if the write wins the
+    # race before the drop, the close still tears it down. Either way it must not
+    # be left running on a dead socket.
+    ref = Process.monitor(conn)
+    FakeCDP.send_ping(fake, "ka")
+    FakeCDP.hard_close(fake)
+    assert_receive {:DOWN, ^ref, :process, ^conn, {:shutdown, {:ws_closed, _}}}, 2_000
+  end
+
   # Poll until `fun` returns true, or fail — for asserting an async state change
   # (here: the connection processing a subscriber's :DOWN) without a fixed sleep.
   defp eventually(fun, retries \\ 100) do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -42,6 +42,14 @@ defmodule CDPEx.IntegrationTest do
       assert_receive {:DOWN, ^ref, :process, ^browser, _}, 5_000
     end
 
+    test "launch/1 returns well under the timeout ceiling (readiness is polled)" do
+      {elapsed_us, {:ok, browser}} = :timer.tc(fn -> CDPEx.launch() end)
+      on_exit(fn -> stop_quietly(browser) end)
+      # Real Chrome is reachable in ~1s locally; :launch_timeout (15s default) is a
+      # ceiling, not a fixed wait. Assert comfortably under it (loose, non-flaky).
+      assert elapsed_us < 10_000_000
+    end
+
     test "new_page/2 then close_page/2" do
       {:ok, browser} = CDPEx.launch()
       on_exit(fn -> stop_quietly(browser) end)
@@ -350,6 +358,29 @@ defmodule CDPEx.IntegrationTest do
       # No orphaned Chrome from the raising run is asserted at the suite level
       # (see the no-orphan check in the test command); here we just confirm the
       # raise propagates rather than being swallowed.
+    end
+
+    test "with_page contains a browser crash without killing a non-trapping caller" do
+      parent = self()
+
+      # A caller that does NOT trap exits. Pre-fix, with_page linked the throwaway
+      # browser to it, so killing Chrome would take this process down with the
+      # browser's exit. The fix traps inside with_page, so the caller instead gets
+      # {:error, _} and exits :normal.
+      {caller, ref} =
+        spawn_monitor(fn ->
+          result =
+            CDPEx.with_page([], fn page ->
+              %{chrome: %{os_pid: os_pid}} = :sys.get_state(page.browser)
+              System.cmd("kill", ["-9", to_string(os_pid)])
+              Page.evaluate(page, "1 + 1")
+            end)
+
+          send(parent, {:with_page_result, result})
+        end)
+
+      assert_receive {:with_page_result, {:error, _}}, 30_000
+      assert_receive {:DOWN, ^ref, :process, ^caller, :normal}, 5_000
     end
   end
 

--- a/test/support/fake_cdp.ex
+++ b/test/support/fake_cdp.ex
@@ -36,6 +36,19 @@ defmodule CDPEx.FakeCDP do
     {:ok, %{port: port, url: "ws://127.0.0.1:#{port}/devtools/browser/fake", listen: listen}}
   end
 
+  # Like start/1, but the server accepts the connection and reads the upgrade
+  # request, then never sends the 101 — leaving CDPEx.Connection blocked in
+  # recv_upgrade. Notifies the controller {:fake_cdp_stalled, conn_pid} once the
+  # request is in, and {:fake_cdp_client_gone, conn_pid} when the client socket
+  # closes (how a Connection that died mid-handshake surfaces).
+  @spec start_stalling(pid()) :: {:ok, %{port: non_neg_integer(), url: String.t(), listen: port()}}
+  def start_stalling(controller \\ self()) do
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(listen)
+    spawn_link(fn -> accept_loop_stalling(listen, controller) end)
+    {:ok, %{port: port, url: "ws://127.0.0.1:#{port}/devtools/browser/fake", listen: listen}}
+  end
+
   @spec send_text(pid(), iodata()) :: :ok
   def send_text(conn, text) do
     send(conn, {:send_frame, 0x1, IO.iodata_to_binary(text)})
@@ -84,6 +97,39 @@ defmodule CDPEx.FakeCDP do
     send(controller, {:fake_cdp_connected, self()})
     _ = :inet.setopts(socket, active: :once)
     loop(socket, controller, <<>>)
+  end
+
+  defp accept_loop_stalling(listen, controller) do
+    case :gen_tcp.accept(listen) do
+      {:ok, socket} ->
+        pid = spawn_link(fn -> serve_stalling(socket, controller) end)
+        _ = :gen_tcp.controlling_process(socket, pid)
+        send(pid, :go)
+        accept_loop_stalling(listen, controller)
+
+      {:error, :closed} ->
+        :ok
+    end
+  end
+
+  defp serve_stalling(socket, controller) do
+    receive do
+      :go -> :ok
+    end
+
+    {:ok, _request} = recv_request(socket, "")
+    send(controller, {:fake_cdp_stalled, self()})
+
+    # Never send the 101. Watch for the client's TCP socket closing — which is how
+    # a CDPEx.Connection that died mid-handshake (its owner exited) surfaces.
+    _ = :inet.setopts(socket, active: :once)
+
+    receive do
+      {:tcp_closed, ^socket} -> send(controller, {:fake_cdp_client_gone, self()})
+      :hard_close -> :gen_tcp.close(socket)
+    after
+      30_000 -> :gen_tcp.close(socket)
+    end
   end
 
   defp loop(socket, controller, buffer) do


### PR DESCRIPTION
Hardening release driven by field use on constrained Linux containers, plus the three pre-existing internals tracked in #16.

## Group L — launch-path robustness
- **L1 — diagnosable launch failures.** A launch that never exposes the DevTools endpoint now returns `{:error, {:debug_url_not_found, stderr_excerpt}}` instead of a bare atom, carrying Chrome's captured stderr so the failure is self-diagnosing.
  - ⚠️ **Breaking (error shape):** code matching the bare `:debug_url_not_found` atom (e.g. a retry classifier) must match `{:debug_url_not_found, _}` instead, or that error silently stops matching.
- **L2 — polled readiness.** `CDPEx.Chrome` now polls the `DevToolsActivePort` file every 150ms during the wait (not only at the deadline), so launch returns as soon as Chrome is reachable and `:launch_timeout` is a *ceiling*, not a fixed cost — robust to builds that print the `DevTools listening on ws://…` stderr line slowly or not at all.
- **L3 — `with_page/3` crash containment.** The throwaway-browser form no longer kills its caller when the browser crashes mid-call; it returns `{:error, reason}`. It briefly traps exits in the caller for the call's duration (only the browser's own `{:EXIT}` is drained — see the docstring for the foreign-EXIT caveat and the pre-launched-browser escape hatch). `launch/1`'s link semantics are unchanged.
- **L4** — `:launch_timeout` documented as a ceiling on `launch/1` / `with_page/3`.
- **L5** — new "Running in containers" README section (timeout tuning, fresh-profile cold start, `/dev/shm`, `--remote-allow-origins`).

## Group I — #16 internals
- **I1** — `Connection.init/1` no longer swallows an owner `{:EXIT}` arriving during the WS upgrade (defer `trap_exit` past the handshake, so a dying owner aborts the connect at once instead of lingering to the upgrade timeout).
- **I2** — a failed WebSocket **pong** write now stops the connection (mirrors `ws_send/2`) rather than running on a dead socket until the next command notices.
- **I3** — `Page.navigate/3` prefers a just-arrived connection `:DOWN` over a best-effort readiness timeout on an exact deadline tie.

Closes #16.

## Testing
- `mix ci` green: format, credo, **Dialyzer 0 errors**, 71 tests + 16 doctests.
- L1/L2 covered by Chrome-free stub-script tests; I1 by a new `FakeCDP` stalling-upgrade mode; I2 by a ping-then-drop test.
- New real-Chrome integration tests: L2 fast-readiness and L3 crash-containment (a non-trapping caller survives a mid-call Chrome kill and gets `{:error, _}`). I3 is by-inspection (untestable timing tie).

Commits are split by concern (chrome launch path · with_page · README · connection internals · page · release) for commit-by-commit review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
