### PR TITLE
fix(page): wait_for_navigation reuses navigate/3 lifecycle machinery (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `CDPEx.Page.wait_for_navigation/2` now waits via the same lifecycle machinery as `navigate/3` (subscribe-before-wait, scoped to the page's session and the `Page.lifecycleEvent` method) rather than a generic event matcher — so it can no longer be falsely resolved by another event method whose params happen to carry a matching `"name"`.
+
 ## [0.2.2] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- `CDPEx.Page.navigate/3` and `wait_for_navigation/2` raise `ArgumentError` on an unknown `:wait_until` value instead of silently treating it as `:network_almost_idle`.
+
 ### Fixed
 - `CDPEx.Page.wait_for_navigation/2` now waits via the same lifecycle machinery as `navigate/3` (subscribe-before-wait, scoped to the page's session and the `Page.lifecycleEvent` method) rather than a generic event matcher — so it can no longer be falsely resolved by another event method whose params happen to carry a matching `"name"`.
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -72,10 +72,40 @@ defmodule CDPEx.Page do
   defp navigate_with_wait(page, url, wait_until, timeout) do
     name = lifecycle_name(wait_until)
 
-    # Subscribe to lifecycle events BEFORE issuing the navigate, so a fast event
-    # (e.g. `load` on a cached/local page) can't fire in the gap between the
-    # navigate reply and waiter registration — the old race. subscribe/2 is a
-    # synchronous call, so the subscription is in place before the command goes out.
+    # Issue the navigate (after subscribing — see subscribe_then_await/4) and wait
+    # for its lifecycle milestone. The readiness wait is best-effort: a timeout
+    # still returns {:ok, page} (the page may just be slow); a dead connection does not.
+    trigger = fn ->
+      case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
+        {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
+        {:ok, _result} -> :ok
+        {:error, _} = error -> error
+      end
+    end
+
+    case subscribe_then_await(page, name, timeout, trigger) do
+      :reached ->
+        {:ok, page}
+
+      :timeout ->
+        Logger.debug("[CDPEx.Page] readiness wait (#{name}) timed out; returning best-effort")
+        {:ok, page}
+
+      {:down, reason} ->
+        {:error, down_reason(reason)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # Subscribe to lifecycle events, run `trigger` (issue the navigation, or a no-op),
+  # then await the `name` milestone — always unsubscribing + draining on the way out.
+  # Subscribing BEFORE `trigger` closes the race where a fast event (e.g. `load` on
+  # a cached page) fires before the listener is in place. Returns await_lifecycle/4's
+  # outcome (`:reached` | `{:down, reason}` | `:timeout`), or `{:error, reason}` when
+  # subscription fails or `trigger` returns one.
+  defp subscribe_then_await(page, name, timeout, trigger) do
     case safe_subscribe(page.conn) do
       {:error, reason} ->
         {:error, reason}
@@ -86,9 +116,8 @@ defmodule CDPEx.Page do
         deadline = System.monotonic_time(:millisecond) + timeout
 
         try do
-          case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
-            {:ok, %{"errorText" => error}} -> {:error, {:navigate, error}}
-            {:ok, _result} -> await_lifecycle(page, name, ref, deadline)
+          case trigger.() do
+            :ok -> await_lifecycle(page, name, ref, deadline)
             {:error, _} = error -> error
           end
         after
@@ -99,37 +128,30 @@ defmodule CDPEx.Page do
     end
   end
 
-  # Block until the named lifecycle event for this page's session arrives, the
-  # connection dies, or the deadline passes. Lifecycle events for other sessions
-  # or names on a shared connection are skipped (then drained by the caller).
+  # Wait for the named lifecycle event — scoped to this page's session (`^sid`) and
+  # the `Page.lifecycleEvent` method (the subscription is method-keyed, so other
+  # methods never arrive here) — the connection dying, or the deadline. Returns
+  # `:reached` | `{:down, reason}` | `:timeout`; callers map it to their own contract.
   defp await_lifecycle(%__MODULE__{conn: conn, session_id: sid} = page, name, ref, deadline) do
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
       {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => ^name}, ^sid} ->
-        {:ok, page}
+        :reached
 
       {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _session_id} ->
         await_lifecycle(page, name, ref, deadline)
 
       {:DOWN, ^ref, :process, ^conn, reason} ->
-        # The connection died mid-navigation — surface it rather than returning a
-        # stale handle as success.
-        {:error, down_reason(reason)}
+        {:down, reason}
     after
       remaining ->
         # Exact deadline-vs-DOWN tie: a {:DOWN} may have just landed but lost the
-        # race to `after`. Prefer it over a misleading best-effort {:ok} when the
-        # connection actually died.
+        # race to `after`. Prefer it over a misleading timeout.
         receive do
-          {:DOWN, ^ref, :process, ^conn, reason} ->
-            {:error, down_reason(reason)}
+          {:DOWN, ^ref, :process, ^conn, reason} -> {:down, reason}
         after
-          0 ->
-            # The page didn't signal readiness in time — navigation was still
-            # issued, so return the page (best-effort), as documented.
-            Logger.debug("[CDPEx.Page] readiness wait (#{name}) timed out; returning best-effort")
-            {:ok, page}
+          0 -> :timeout
         end
     end
   end
@@ -180,13 +202,24 @@ defmodule CDPEx.Page do
   @spec wait_for_navigation(t(), keyword()) :: :ok | {:error, term()}
   def wait_for_navigation(%__MODULE__{} = page, opts \\ []) do
     case Keyword.get(opts, :wait_until, :network_almost_idle) do
-      :none ->
-        :ok
+      :none -> :ok
+      wait_until -> await_navigation(page, wait_until, opts)
+    end
+  end
 
-      wait_until ->
-        name = lifecycle_name(wait_until)
-        timeout = Keyword.get(opts, :timeout, @navigate_timeout)
-        do_await(page, &(&1["name"] == name), timeout)
+  # Same machinery as navigate/3 (subscribe-before-wait, scoped to this session +
+  # the Page.lifecycleEvent method) but without issuing a navigation — the caller
+  # already triggered one (e.g. a click). Unlike the previous await_event matcher,
+  # this can't be tripped by params from another event method carrying a "name".
+  defp await_navigation(page, wait_until, opts) do
+    name = lifecycle_name(wait_until)
+    timeout = Keyword.get(opts, :timeout, @navigate_timeout)
+
+    case subscribe_then_await(page, name, timeout, fn -> :ok end) do
+      :reached -> :ok
+      :timeout -> {:error, :timeout}
+      {:down, reason} -> {:error, down_reason(reason)}
+      {:error, _} = error -> error
     end
   end
 
@@ -579,9 +612,5 @@ defmodule CDPEx.Page do
   # code path serves both the one-socket-per-page and the multiplexed transports.
   defp do_call(%__MODULE__{conn: conn, session_id: session_id}, method, params, timeout) do
     Connection.call(conn, method, params, timeout, session_id: session_id)
-  end
-
-  defp do_await(%__MODULE__{conn: conn, session_id: session_id}, matcher, timeout) do
-    Connection.await_event(conn, matcher, timeout, session_id: session_id)
   end
 end

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -185,7 +185,15 @@ defmodule CDPEx.Page do
   end
 
   defp lifecycle_name(:load), do: "load"
-  defp lifecycle_name(_), do: "networkAlmostIdle"
+  defp lifecycle_name(:network_almost_idle), do: "networkAlmostIdle"
+
+  # Both navigate/3 and wait_for_navigation/2 route through here. Fail fast on an
+  # unknown value rather than silently waiting for the wrong milestone (`:none` is
+  # handled by the callers before this point).
+  defp lifecycle_name(other) do
+    raise ArgumentError,
+          "invalid :wait_until #{inspect(other)} (expected :network_almost_idle, :load, or :none)"
+  end
 
   @doc """
   Waits for a navigation lifecycle milestone, without issuing a navigation.

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -259,6 +259,19 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, :timeout} = Page.wait_for_navigation(page, wait_until: :load, timeout: 300)
     end
 
+    test "wait_for_navigation resolves on a milestone from an out-of-band navigation", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+      # Trigger a navigation WITHOUT navigate/3 (deferred so evaluate returns before
+      # the reload tears down the context), then await its lifecycle milestone — the
+      # subscribe-before-wait path. The ~50ms defer also lets wait_for_navigation
+      # subscribe before `load` fires, exercising the race fix.
+      {:ok, _} = Page.evaluate(page, "setTimeout(() => location.reload(), 50); true")
+      assert :ok = Page.wait_for_navigation(page, wait_until: :load, timeout: 5_000)
+    end
+
     test "click toggles observable DOM state", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       :ok = Page.wait_for_selector(page, "#btn")

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -1,0 +1,87 @@
+defmodule CDPEx.PageTest do
+  use ExUnit.Case, async: true
+
+  alias CDPEx.Connection
+  alias CDPEx.FakeCDP
+  alias CDPEx.Page
+
+  setup do
+    # The test process owns the linked connection (via start_link), so trap exits
+    # and tolerate an already-dying conn in teardown — same as ConnectionTest.
+    Process.flag(:trap_exit, true)
+
+    {:ok, server} = FakeCDP.start()
+    {:ok, conn} = Connection.start_link(server.url)
+    assert_receive {:fake_cdp_connected, fake}, 2_000
+
+    on_exit(fn ->
+      try do
+        if Process.alive?(conn), do: Connection.close(conn)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    %{
+      page: %Page{browser: self(), conn: conn, target_id: "T", session_id: nil},
+      conn: conn,
+      fake: fake
+    }
+  end
+
+  describe "wait_for_navigation/2" do
+    test "resolves only on a matching Page.lifecycleEvent — not another method or name", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.wait_for_navigation(page, wait_until: :load, timeout: 2_000) end)
+      wait_until_subscribed(conn, task.pid)
+
+      # The old generic await_event matcher (`&(&1["name"] == name)`) would have been
+      # tripped by either of these — a non-lifecycle method whose params carry the
+      # name, and a lifecycle event for a *different* milestone. The method-keyed
+      # subscription + name-pinned receive must ignore both.
+      FakeCDP.send_text(fake, ~s({"method":"Runtime.bindingCalled","params":{"name":"load"}}))
+      FakeCDP.send_text(fake, ~s({"method":"Page.lifecycleEvent","params":{"name":"init"}}))
+
+      refute Task.yield(task, 200), "wait_for_navigation resolved on a non-matching event"
+
+      # The real milestone resolves it.
+      FakeCDP.send_text(fake, ~s({"method":"Page.lifecycleEvent","params":{"name":"load"}}))
+      assert :ok = Task.await(task)
+    end
+
+    test "times out when the milestone never arrives", %{page: page} do
+      assert {:error, :timeout} = Page.wait_for_navigation(page, wait_until: :load, timeout: 100)
+    end
+
+    test ":none returns immediately without waiting", %{page: page} do
+      assert :ok = Page.wait_for_navigation(page, wait_until: :none)
+    end
+
+    test "raises on an unknown :wait_until value", %{page: page} do
+      assert_raise ArgumentError, ~r/invalid :wait_until :bogus/, fn ->
+        Page.wait_for_navigation(page, wait_until: :bogus)
+      end
+    end
+  end
+
+  # Poll until `pid` is registered as a Page.lifecycleEvent subscriber on `conn`, so
+  # events sent afterward are guaranteed to be delivered to it (no send/subscribe race).
+  defp wait_until_subscribed(conn, pid, retries \\ 100) do
+    subs = Map.get(:sys.get_state(conn).subscribers, "Page.lifecycleEvent", MapSet.new())
+
+    cond do
+      MapSet.member?(subs, pid) ->
+        :ok
+
+      retries == 0 ->
+        flunk("subscriber not registered in time")
+
+      true ->
+        Process.sleep(10)
+        wait_until_subscribed(conn, pid, retries - 1)
+    end
+  end
+end


### PR DESCRIPTION
Closes #18 (follow-up from the v0.2.2 review).

`CDPEx.Page.wait_for_navigation/2` used the generic `Connection.await_event` waiter, which has two gaps vs. `navigate/3`:

1. **Matcher not method-scoped** — `await_event` runs the predicate against the params of *every* event (no method name), so a non-`Page.lifecycleEvent` event whose params carry a matching `"name"` could falsely resolve the wait.
2. **Listener registered after the trigger** — the waiter was set up only after the caller had already triggered navigation (e.g. via `click/3`).

## Change
Route `wait_for_navigation/2` through the same machinery as `navigate/3`:

- New `subscribe_then_await/4` — subscribe to `Page.lifecycleEvent` **first**, monitor the conn, run an optional `trigger` (the navigate command, or a no-op), await, then always unsubscribe + drain.
- `await_lifecycle/4` now returns a 3-way outcome — `:reached | {:down, reason} | :timeout` — and each caller maps it to its own contract.

Because the subscription is **method-keyed**, only `Page.lifecycleEvent` events ever arrive, and the `receive` additionally pins the session id (`^sid`) and the milestone name (`^name`) — the false-match is structurally impossible, and subscribing first narrows the listen window.

Contracts preserved: `navigate/3` still returns best-effort `{:ok, page}` on a readiness timeout; `wait_for_navigation/2` still returns `{:error, :timeout}` on timeout. The now-unused `do_await/3` is removed.

## Testing
- `mix ci` green: format, credo, **Dialyzer 0 errors**, 71 tests + 16 doctests.
- New integration test: an out-of-band navigation (a deferred `location.reload`) followed by `wait_for_navigation(wait_until: :load)` resolving `:ok` — exercising the subscribe-before-wait path. Existing `:none`/timeout test retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
