### PR TITLE
feat(pool): CDPEx.Pool — reusable warm-browser pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `CDPEx.Pool` — a fixed-size pool of reusable browsers (`checkout/2`, `checkin/2`, `with_browser/3`, `with_page/3`) that keeps Chrome warm so a per-job fetch avoids a cold launch. Lazy launch up to `:size`, blocking checkout with timeout, automatic reclaim of a crashed caller's browser, and on-demand relaunch of a crashed one.
+
 ### Changed
 - `CDPEx.Page.navigate/3` and `wait_for_navigation/2` raise `ArgumentError` on an unknown `:wait_until` value instead of silently treating it as `:network_almost_idle`.
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,27 @@ children = [
 Supervisor.start_link(children, strategy: :one_for_one)
 ```
 
+### Pooling
+
+Reuse warm browsers instead of paying a cold launch per job with `CDPEx.Pool`:
+
+```elixir
+children = [
+  {CDPEx.Pool, name: MyPool, size: 4, launch_opts: [headless: true]}
+]
+Supervisor.start_link(children, strategy: :one_for_one)
+
+# Borrow a warm browser for one fetch (a pooled drop-in for with_page/3):
+CDPEx.Pool.with_page(MyPool, fn page ->
+  {:ok, _} = CDPEx.Page.navigate(page, "https://example.com")
+  CDPEx.Page.html(page)
+end)
+```
+
+Browsers launch lazily up to `:size` and are reused; `checkout/2` blocks (up to
+`:checkout_timeout`) when all are busy. A caller that crashes returns its browser
+automatically, and a crashed browser is relaunched on demand.
+
 ## Page operations
 
 | Function | Description |

--- a/lib/cdp_ex/pool.ex
+++ b/lib/cdp_ex/pool.ex
@@ -21,6 +21,12 @@ defmodule CDPEx.Pool do
   so `:size` self-heals. Put the pool under your supervision tree; its
   `terminate/2` stops every browser, reaping Chrome.
 
+  Browser launches are **synchronous** — a browser is started inside the pool
+  process, so while one is launching (a cold Chrome can take a few seconds) the
+  pool can't serve other checkouts or checkins. A short `:checkout_timeout` is
+  therefore unreliable while the pool is still growing to `:size`; once warm,
+  checkouts are immediate.
+
   ## Options
 
     * `:size` — maximum number of browsers (default `1`)
@@ -59,9 +65,12 @@ defmodule CDPEx.Pool do
 
   @doc false
   def child_spec(opts) do
-    # terminate/2 stops every browser sequentially (each takes a few seconds to
-    # reap Chrome), so give the supervisor headroom over the GenServer 5s default.
-    %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, shutdown: 30_000}
+    # Derive a distinct id from :id/:name so several pools can run under one
+    # supervisor without colliding on the default __MODULE__ id. terminate/2 stops
+    # every browser sequentially (each takes a few seconds to reap Chrome), so give
+    # the supervisor headroom over the GenServer 5s default.
+    id = Keyword.get(opts, :id, Keyword.get(opts, :name, __MODULE__))
+    %{id: id, start: {__MODULE__, :start_link, [opts]}, shutdown: 30_000}
   end
 
   @doc """
@@ -73,10 +82,16 @@ defmodule CDPEx.Pool do
   """
   @spec checkout(GenServer.server(), timeout()) :: {:ok, pid()} | {:error, term()}
   def checkout(pool, timeout \\ @default_checkout_timeout) do
-    GenServer.call(pool, {:checkout, timeout}, checkout_deadline(timeout))
+    # Wait indefinitely on the outer call; the pool's own per-request timer is the
+    # authoritative timeout (it removes the waiter and replies {:error, :timeout}).
+    # This avoids a stale waiter when a slow launch blocks the pool past a tight
+    # outer deadline. A pool that stops mid-wait surfaces as {:error, :noproc}.
+    GenServer.call(pool, {:checkout, timeout}, :infinity)
   catch
-    :exit, {:timeout, _} -> {:error, :timeout}
     :exit, {:noproc, _} -> {:error, :noproc}
+    :exit, {:normal, _} -> {:error, :noproc}
+    :exit, {:shutdown, _} -> {:error, :noproc}
+    :exit, {{:shutdown, _}, _} -> {:error, :noproc}
   end
 
   @doc "Returns a browser borrowed with `checkout/2`."
@@ -188,6 +203,14 @@ defmodule CDPEx.Pool do
   def terminate(_reason, state) do
     Enum.each(state.available, &safe_stop/1)
     Enum.each(Map.keys(state.busy), &safe_stop/1)
+
+    # Reply to anyone still blocked in checkout/2 so they get a clean
+    # {:error, :noproc} instead of an uncaught exit as the pool goes down.
+    Enum.each(:queue.to_list(state.waiting), fn {from, timer} ->
+      _ = cancel_timer(timer)
+      GenServer.reply(from, {:error, :noproc})
+    end)
+
     :ok
   end
 
@@ -243,7 +266,14 @@ defmodule CDPEx.Pool do
 
       {{_owner, ref}, busy} ->
         Process.demonitor(ref, [:flush])
-        %{state | busy: busy, available: [browser | state.available]}
+        # Don't return an already-dead browser (its {:EXIT} may not be processed
+        # yet) to the available set, or dispatch could hand a dead pid to a waiter.
+        # Drop it instead; the {:EXIT} path reconciles anything this misses.
+        if Process.alive?(browser) do
+          %{state | busy: busy, available: [browser | state.available]}
+        else
+          %{state | busy: busy, count: state.count - 1}
+        end
     end
   end
 
@@ -282,9 +312,6 @@ defmodule CDPEx.Pool do
 
   defp cancel_timer(nil), do: :ok
   defp cancel_timer(ref), do: Process.cancel_timer(ref)
-
-  defp checkout_deadline(:infinity), do: :infinity
-  defp checkout_deadline(timeout) when is_integer(timeout), do: max(timeout, 0) + 100
 
   defp safe_stop(browser) do
     if Process.alive?(browser), do: Browser.stop(browser)

--- a/lib/cdp_ex/pool.ex
+++ b/lib/cdp_ex/pool.ex
@@ -31,7 +31,9 @@ defmodule CDPEx.Pool do
 
     * `:size` — maximum number of browsers (default `1`)
     * `:launch_opts` — options passed to each `CDPEx.Browser` (see `CDPEx.Chrome`)
-    * `:checkout_timeout` — ms to wait for a free browser (default `5_000`)
+    * `:checkout_timeout` — ms to wait for a free browser (default `5_000`). While
+      the pool is still launching browsers to `:size`, keep this above your cold
+      Chrome launch time — launches are synchronous (see below)
     * `:name` — registers the pool process
   """
 
@@ -201,16 +203,16 @@ defmodule CDPEx.Pool do
 
   @impl true
   def terminate(_reason, state) do
-    Enum.each(state.available, &safe_stop/1)
-    Enum.each(Map.keys(state.busy), &safe_stop/1)
-
-    # Reply to anyone still blocked in checkout/2 so they get a clean
-    # {:error, :noproc} instead of an uncaught exit as the pool goes down.
+    # Reply to anyone still blocked in checkout/2 first, so they get a clean
+    # {:error, :noproc} without waiting on the (possibly multi-second) serial
+    # browser teardown below.
     Enum.each(:queue.to_list(state.waiting), fn {from, timer} ->
       _ = cancel_timer(timer)
       GenServer.reply(from, {:error, :noproc})
     end)
 
+    Enum.each(state.available, &safe_stop/1)
+    Enum.each(Map.keys(state.busy), &safe_stop/1)
     :ok
   end
 

--- a/lib/cdp_ex/pool.ex
+++ b/lib/cdp_ex/pool.ex
@@ -1,0 +1,295 @@
+defmodule CDPEx.Pool do
+  @moduledoc """
+  A fixed-size pool of reusable `CDPEx.Browser` processes.
+
+  Launching Chrome is expensive — a cold start can take several seconds on a
+  constrained host, with a fresh profile each time. A pool keeps browsers warm
+  and hands them out for reuse, so a per-job fetch no longer pays a launch on
+  every call.
+
+      {:ok, pool} = CDPEx.Pool.start_link(size: 2, launch_opts: [headless: true])
+
+      CDPEx.Pool.with_page(pool, fn page ->
+        {:ok, _} = CDPEx.Page.navigate(page, "https://example.com")
+        CDPEx.Page.html(page)
+      end)
+
+  Browsers are launched **lazily** up to `:size` and reused thereafter.
+  `checkout/2` blocks (up to `:checkout_timeout`) when every browser is busy. The
+  pool is resilient: a caller that crashes while holding a browser has it returned
+  automatically, and a browser that crashes is dropped and relaunched on demand —
+  so `:size` self-heals. Put the pool under your supervision tree; its
+  `terminate/2` stops every browser, reaping Chrome.
+
+  ## Options
+
+    * `:size` — maximum number of browsers (default `1`)
+    * `:launch_opts` — options passed to each `CDPEx.Browser` (see `CDPEx.Chrome`)
+    * `:checkout_timeout` — ms to wait for a free browser (default `5_000`)
+    * `:name` — registers the pool process
+  """
+
+  use GenServer
+
+  alias CDPEx.Browser
+
+  @default_size 1
+  @default_checkout_timeout 5_000
+
+  defstruct [
+    :size,
+    :launch_opts,
+    :start_fun,
+    available: [],
+    busy: %{},
+    waiting: :queue.new(),
+    count: 0
+  ]
+
+  @type t :: %__MODULE__{}
+
+  # ── Public API ──────────────────────────────────────────────────────────────
+
+  @doc "Starts a pool. See the moduledoc for options."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    {gen_opts, pool_opts} = Keyword.split(opts, [:name])
+    GenServer.start_link(__MODULE__, pool_opts, gen_opts)
+  end
+
+  @doc false
+  def child_spec(opts) do
+    # terminate/2 stops every browser sequentially (each takes a few seconds to
+    # reap Chrome), so give the supervisor headroom over the GenServer 5s default.
+    %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, shutdown: 30_000}
+  end
+
+  @doc """
+  Borrows a browser, blocking up to `timeout` ms when all are busy.
+
+  Returns `{:ok, browser}`, `{:error, :timeout}`, or `{:error, reason}` if a
+  browser had to be launched and failed. **Always** `checkin/2` it when done — or
+  use `with_browser/3` / `with_page/3`, which do that for you.
+  """
+  @spec checkout(GenServer.server(), timeout()) :: {:ok, pid()} | {:error, term()}
+  def checkout(pool, timeout \\ @default_checkout_timeout) do
+    GenServer.call(pool, {:checkout, timeout}, checkout_deadline(timeout))
+  catch
+    :exit, {:timeout, _} -> {:error, :timeout}
+    :exit, {:noproc, _} -> {:error, :noproc}
+  end
+
+  @doc "Returns a browser borrowed with `checkout/2`."
+  @spec checkin(GenServer.server(), pid()) :: :ok
+  def checkin(pool, browser), do: GenServer.cast(pool, {:checkin, browser})
+
+  @doc """
+  Runs `fun` with a checked-out browser, returning it afterwards (even if `fun`
+  raises). Returns `fun`'s value, or `{:error, reason}` if no browser was free.
+  """
+  @spec with_browser(GenServer.server(), (pid() -> result), timeout()) ::
+          result | {:error, term()}
+        when result: var
+  def with_browser(pool, fun, timeout \\ @default_checkout_timeout) when is_function(fun, 1) do
+    case checkout(pool, timeout) do
+      {:ok, browser} ->
+        try do
+          fun.(browser)
+        after
+          checkin(pool, browser)
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Runs `fun` with a fresh page on a pooled browser, cleaning up the page and
+  returning the browser afterwards. The pooled counterpart of `CDPEx.with_page/3`
+  — it reuses a warm browser instead of launching one per call.
+
+  `opts` are forwarded to `CDPEx.with_page/3` (e.g. `:prevent_alerts`); pass
+  `:checkout_timeout` to bound the wait for a free browser. Returns `fun`'s value,
+  or `{:error, reason}`.
+  """
+  @spec with_page(GenServer.server(), (CDPEx.Page.t() -> result), keyword()) ::
+          result | {:error, term()}
+        when result: var
+  def with_page(pool, fun, opts \\ []) when is_function(fun, 1) do
+    {timeout, page_opts} = Keyword.pop(opts, :checkout_timeout, @default_checkout_timeout)
+    with_browser(pool, fn browser -> CDPEx.with_page(browser, fun, page_opts) end, timeout)
+  end
+
+  @doc "Stops the pool, stopping every browser (and reaping Chrome)."
+  @spec stop(GenServer.server()) :: :ok
+  def stop(pool), do: GenServer.stop(pool, :normal)
+
+  # ── GenServer callbacks ─────────────────────────────────────────────────────
+
+  @impl true
+  def init(opts) do
+    # Trap exits: browsers are start_linked, so a browser crash arrives as an
+    # {:EXIT, _, _} we handle (drop + relaunch on demand) rather than taking the
+    # pool down, and terminate/2 runs to reap Chrome.
+    Process.flag(:trap_exit, true)
+
+    {:ok,
+     %__MODULE__{
+       size: Keyword.get(opts, :size, @default_size),
+       launch_opts: Keyword.get(opts, :launch_opts, []),
+       start_fun: Keyword.get(opts, :start_fun, &Browser.start_link/1)
+     }}
+  end
+
+  @impl true
+  def handle_call({:checkout, timeout}, from, state) do
+    # Enqueue then dispatch: a request is served at once if there's capacity,
+    # otherwise it waits in the queue for a checkin/crash to free a browser.
+    timer = arm_timeout(from, timeout)
+    {:noreply, dispatch(%{state | waiting: :queue.in({from, timer}, state.waiting)})}
+  end
+
+  @impl true
+  def handle_cast({:checkin, browser}, state) do
+    {:noreply, state |> release(browser) |> dispatch()}
+  end
+
+  @impl true
+  def handle_info({:checkout_timeout, from}, state) do
+    case remove_waiter(state.waiting, from) do
+      {:ok, _timer, waiting} ->
+        GenServer.reply(from, {:error, :timeout})
+        {:noreply, %{state | waiting: waiting}}
+
+      :error ->
+        # Served between the timer firing and now — nothing to do.
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _owner, _reason}, state) do
+    # A checkout owner died without checking in — reclaim its browser.
+    case find_busy_by_ref(state.busy, ref) do
+      nil -> {:noreply, state}
+      browser -> {:noreply, state |> release(browser) |> dispatch()}
+    end
+  end
+
+  def handle_info({:EXIT, browser, _reason}, state) do
+    # A pooled browser stopped/crashed. Drop it; capacity frees up, so dispatch
+    # can serve a waiting caller by launching a replacement.
+    {:noreply, state |> drop(browser) |> dispatch()}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, state) do
+    Enum.each(state.available, &safe_stop/1)
+    Enum.each(Map.keys(state.busy), &safe_stop/1)
+    :ok
+  end
+
+  # ── pool mechanics ──────────────────────────────────────────────────────────
+
+  # Serve queued waiters while there is capacity (a free browser, or room to launch).
+  defp dispatch(state) do
+    case :queue.out(state.waiting) do
+      {:empty, _} -> state
+      {{:value, waiter}, rest} -> dispatch_to(state, waiter, rest)
+    end
+  end
+
+  defp dispatch_to(%__MODULE__{available: [browser | rest_avail]} = state, waiter, rest) do
+    %{state | available: rest_avail, waiting: rest}
+    |> assign(browser, waiter)
+    |> dispatch()
+  end
+
+  defp dispatch_to(%__MODULE__{count: count, size: size} = state, {from, timer}, rest)
+       when count < size do
+    case state.start_fun.(state.launch_opts) do
+      {:ok, browser} ->
+        %{state | count: count + 1, waiting: rest}
+        |> assign(browser, {from, timer})
+        |> dispatch()
+
+      {:error, reason} ->
+        _ = cancel_timer(timer)
+        GenServer.reply(from, {:error, reason})
+        dispatch(%{state | waiting: rest})
+    end
+  end
+
+  # No capacity — leave the queue intact (state.waiting still holds the waiter).
+  defp dispatch_to(state, _waiter, _rest), do: state
+
+  # Mark `browser` busy for the waiter, monitor the owner (auto-checkin on its
+  # death), cancel the wait timer, and reply.
+  defp assign(state, browser, {from, timer}) do
+    _ = cancel_timer(timer)
+    owner = elem(from, 0)
+    ref = Process.monitor(owner)
+    GenServer.reply(from, {:ok, browser})
+    %{state | busy: Map.put(state.busy, browser, {owner, ref})}
+  end
+
+  # Return a busy browser to the available set (a checkin, or an owner's death).
+  defp release(state, browser) do
+    case Map.pop(state.busy, browser) do
+      {nil, _busy} ->
+        state
+
+      {{_owner, ref}, busy} ->
+        Process.demonitor(ref, [:flush])
+        %{state | busy: busy, available: [browser | state.available]}
+    end
+  end
+
+  # Remove a dead browser from wherever it is and shrink the count.
+  defp drop(state, browser) do
+    cond do
+      Map.has_key?(state.busy, browser) ->
+        {{_owner, ref}, busy} = Map.pop(state.busy, browser)
+        Process.demonitor(ref, [:flush])
+        %{state | busy: busy, count: state.count - 1}
+
+      browser in state.available ->
+        %{state | available: List.delete(state.available, browser), count: state.count - 1}
+
+      true ->
+        state
+    end
+  end
+
+  defp find_busy_by_ref(busy, ref) do
+    Enum.find_value(busy, fn {browser, {_owner, r}} -> if r == ref, do: browser end)
+  end
+
+  defp remove_waiter(waiting, from) do
+    case List.keytake(:queue.to_list(waiting), from, 0) do
+      {{^from, timer}, rest} -> {:ok, timer, :queue.from_list(rest)}
+      nil -> :error
+    end
+  end
+
+  defp arm_timeout(_from, :infinity), do: nil
+
+  defp arm_timeout(from, timeout) when is_integer(timeout) do
+    Process.send_after(self(), {:checkout_timeout, from}, max(timeout, 0))
+  end
+
+  defp cancel_timer(nil), do: :ok
+  defp cancel_timer(ref), do: Process.cancel_timer(ref)
+
+  defp checkout_deadline(:infinity), do: :infinity
+  defp checkout_deadline(timeout) when is_integer(timeout), do: max(timeout, 0) + 100
+
+  defp safe_stop(browser) do
+    if Process.alive?(browser), do: Browser.stop(browser)
+    :ok
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -13,6 +13,7 @@ defmodule CDPEx.IntegrationTest do
   alias CDPEx.Connection
   alias CDPEx.FixtureServer
   alias CDPEx.Page
+  alias CDPEx.Pool
 
   @moduletag :integration
   # Real Chrome launches are slower than the default 60s in aggregate.
@@ -397,12 +398,51 @@ defmodule CDPEx.IntegrationTest do
     end
   end
 
+  describe "pool" do
+    test "with_page reuses a warm pooled browser across calls", %{fixture: fixture} do
+      {:ok, pool} = Pool.start_link(size: 1)
+      on_exit(fn -> stop_pool_quietly(pool) end)
+
+      used = fn ->
+        Pool.with_page(pool, fn page ->
+          {:ok, _} = Page.navigate(page, fixture)
+          page.browser
+        end)
+      end
+
+      b1 = used.()
+      b2 = used.()
+      assert is_pid(b1)
+      assert b1 == b2, "expected the pooled browser to be reused across with_page calls"
+      assert :sys.get_state(pool).count == 1
+    end
+
+    test "with_page runs on a pooled browser and returns the fun's value", %{fixture: fixture} do
+      {:ok, pool} = Pool.start_link(size: 1)
+      on_exit(fn -> stop_pool_quietly(pool) end)
+
+      result =
+        Pool.with_page(pool, fn page ->
+          {:ok, _} = Page.navigate(page, fixture)
+          Page.text(page, "#greeting")
+        end)
+
+      assert {:ok, "Hello"} = result
+    end
+  end
+
   # Teardown helper. The browser is linked to (and watches) the test process, so
   # by the time on_exit runs it may already be stopping on its own — racing this
   # call. Tolerate an exit from the stop so a teardown race never fails a test
   # whose body already passed.
   defp stop_quietly(browser) do
     if Process.alive?(browser), do: CDPEx.stop(browser)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp stop_pool_quietly(pool) do
+    if Process.alive?(pool), do: Pool.stop(pool)
   catch
     :exit, _ -> :ok
   end

--- a/test/cdp_ex/pool_test.exs
+++ b/test/cdp_ex/pool_test.exs
@@ -1,0 +1,125 @@
+defmodule CDPEx.PoolTest do
+  use ExUnit.Case, async: true
+
+  alias CDPEx.Pool
+
+  # A stand-in for CDPEx.Browser: a trivial GenServer (so Pool's Browser.stop/1 —
+  # a GenServer.stop — works) injected via the :start_fun option, letting us drive
+  # the whole pool without launching Chrome.
+  defmodule FakeBrowser do
+    @moduledoc false
+    use GenServer
+
+    def start_link(_opts \\ []), do: GenServer.start_link(__MODULE__, :ok)
+    @impl true
+    def init(:ok), do: {:ok, :ok}
+  end
+
+  setup do
+    # The pool is start_linked to the test process; trap exits so a pool stop in
+    # teardown can't take the test down.
+    Process.flag(:trap_exit, true)
+    :ok
+  end
+
+  test "checkout lazily launches up to size, then reuses warm browsers" do
+    pool = start_pool(size: 2)
+
+    {:ok, b1} = Pool.checkout(pool)
+    {:ok, b2} = Pool.checkout(pool)
+    assert b1 != b2
+    assert :sys.get_state(pool).count == 2
+
+    :ok = Pool.checkin(pool, b1)
+    # Reuses the freed browser instead of launching a third.
+    assert {:ok, ^b1} = Pool.checkout(pool)
+    assert :sys.get_state(pool).count == 2
+  end
+
+  test "checkout blocks when the pool is exhausted and is served on checkin" do
+    pool = start_pool(size: 1)
+    {:ok, b1} = Pool.checkout(pool)
+
+    task = Task.async(fn -> Pool.checkout(pool, 1_000) end)
+    refute Task.yield(task, 100), "checkout should block while the pool is exhausted"
+
+    :ok = Pool.checkin(pool, b1)
+    assert {:ok, ^b1} = Task.await(task)
+  end
+
+  test "checkout times out when no browser frees up in time" do
+    pool = start_pool(size: 1)
+    {:ok, _b1} = Pool.checkout(pool)
+    assert {:error, :timeout} = Pool.checkout(pool, 100)
+  end
+
+  test "with_browser returns the fun's value and checks the browser back in" do
+    pool = start_pool(size: 1)
+    assert :hello = Pool.with_browser(pool, fn _b -> :hello end)
+    assert {:ok, _b} = Pool.checkout(pool, 500)
+  end
+
+  test "with_browser checks the browser back in even when the fun raises" do
+    pool = start_pool(size: 1)
+    assert_raise RuntimeError, fn -> Pool.with_browser(pool, fn _b -> raise "boom" end) end
+    assert {:ok, _b} = Pool.checkout(pool, 500)
+  end
+
+  test "a checkout owner that crashes has its browser reclaimed" do
+    pool = start_pool(size: 1)
+    parent = self()
+
+    {owner, _ref} =
+      spawn_monitor(fn ->
+        {:ok, b} = Pool.checkout(pool)
+        send(parent, {:checked_out, b})
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:checked_out, b1}, 1_000
+    # Pool exhausted (size 1; the owner holds b1). Kill the owner.
+    Process.exit(owner, :kill)
+    # The pool reclaims b1 via the owner monitor, so it can be checked out again.
+    assert {:ok, ^b1} = Pool.checkout(pool, 1_000)
+  end
+
+  test "a crashed browser is dropped and replaced on the next checkout" do
+    pool = start_pool(size: 1)
+    {:ok, b1} = Pool.checkout(pool)
+    :ok = Pool.checkin(pool, b1)
+
+    Process.exit(b1, :kill)
+    assert eventually(fn -> :sys.get_state(pool).count == 0 end)
+
+    assert {:ok, b2} = Pool.checkout(pool, 1_000)
+    assert b2 != b1
+  end
+
+  defp start_pool(opts) do
+    {:ok, pool} =
+      opts |> Keyword.put_new(:start_fun, &FakeBrowser.start_link/1) |> Pool.start_link()
+
+    on_exit(fn -> stop_quietly(pool) end)
+    pool
+  end
+
+  defp stop_quietly(pool) do
+    if Process.alive?(pool), do: Pool.stop(pool)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp eventually(fun, retries \\ 100) do
+    cond do
+      fun.() ->
+        true
+
+      retries == 0 ->
+        false
+
+      true ->
+        Process.sleep(10)
+        eventually(fun, retries - 1)
+    end
+  end
+end

--- a/test/cdp_ex/pool_test.exs
+++ b/test/cdp_ex/pool_test.exs
@@ -95,6 +95,23 @@ defmodule CDPEx.PoolTest do
     assert b2 != b1
   end
 
+  test "stopping the pool replies to blocked waiters instead of crashing them" do
+    pool = start_pool(size: 1)
+    {:ok, _b1} = Pool.checkout(pool)
+
+    task = Task.async(fn -> Pool.checkout(pool, 5_000) end)
+    refute Task.yield(task, 100), "the second checkout should be blocked"
+
+    Pool.stop(pool)
+    assert {:error, :noproc} = Task.await(task)
+  end
+
+  test "child_spec derives its id from :id or :name so multiple pools can be supervised" do
+    assert Pool.child_spec([]).id == Pool
+    assert Pool.child_spec(name: :fast).id == :fast
+    assert Pool.child_spec(id: :custom, name: :fast).id == :custom
+  end
+
   defp start_pool(opts) do
     {:ok, pool} =
       opts |> Keyword.put_new(:start_fun, &FakeBrowser.start_link/1) |> Pool.start_link()

--- a/test/cdp_ex/pool_test.exs
+++ b/test/cdp_ex/pool_test.exs
@@ -65,6 +65,13 @@ defmodule CDPEx.PoolTest do
     assert {:ok, _b} = Pool.checkout(pool, 500)
   end
 
+  test "with_browser checks the browser back in even when the fun exits" do
+    pool = start_pool(size: 1)
+    # `after` runs on an exit too, so the browser is still returned.
+    catch_exit(Pool.with_browser(pool, fn _b -> exit(:boom) end))
+    assert {:ok, _b} = Pool.checkout(pool, 500)
+  end
+
   test "a checkout owner that crashes has its browser reclaimed" do
     pool = start_pool(size: 1)
     parent = self()


### PR DESCRIPTION
Priority-1 of the v0.3.0 roadmap (#3): a reusable warm-browser pool. This is the throughput lever from field feedback — a throwaway `with_page([opts], …)` per fetch pays a full Chrome cold start (several seconds, fresh profile) every call; a pool keeps browsers warm and reuses them.

## API
- `start_link/1` + `child_spec/1` — supervised (`{CDPEx.Pool, name: MyPool, size: 4, launch_opts: […]}`)
- `checkout/2` → `{:ok, browser} | {:error, :timeout | reason}` — blocking, with timeout
- `checkin/2`
- `with_browser/3` — checkout → `fun.(browser)` → checkin (even on raise)
- `with_page/3` — checkout → `CDPEx.with_page(browser, fun)` → checkin (**the pooled drop-in for `CDPEx.with_page/3`**)

Options: `:size` (default 1), `:launch_opts`, `:checkout_timeout` (default 5s), `:name`.

## Mechanics
Hand-rolled GenServer — **no pool dependency** (deps stay `mint_web_socket` + `jason`):
- **Lazy launch** up to `:size`, then reuse warm browsers.
- **Unified enqueue-then-dispatch** checkout: served immediately if there's capacity, else queued and handed off on the next checkin/free.
- **Owner-monitored** — a caller that crashes mid-job has its browser auto-returned (no silent pool shrink).
- **Crash-replaced** — browsers are `start_link`ed; a crash is dropped and relaunched on demand, so `:size` self-heals.
- **`terminate/2` reaps all** browsers (Chrome cleanup), like `Browser` does for connections.

## Testing
- `mix ci` green — **Dialyzer 0**, 82 tests + 16 doctests.
- Chrome-free unit suite (`pool_test.exs`) via an injectable `:start_fun` (a fake browser GenServer): lazy launch/reuse, exhaustion-blocks-then-served, checkout timeout, `with_browser` value + raise-still-checks-in, owner-crash reclaim, browser-crash replace.
- Real-Chrome integration: `with_page` reuses one warm browser across calls (asserts same browser pid, `count == 1`); returns the fun's value.

Part of v0.3.0 (`[Unreleased]`); PR B (Network) and PR C (error-taxonomy, breaking) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
