### PR TITLE
ci(review): use Opus 4.8 and let the reviewer read source

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,4 +66,5 @@ jobs:
             issues as inline comments. Only post GitHub comments — do not emit
             review text as chat messages.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model claude-opus-4-8
+            --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## What

The automated PR review (`.github/workflows/claude-review.yml`) was running the **default model** (`claude-sonnet-4-6`) with an allowlist of only the inline-comment tool plus `gh pr comment/diff/view`.

With no `Read`/`Grep`/`Glob`, the reviewer could see **only the raw diff** — not the surrounding code. So it spent its run on permission-denied tool calls trying to open source files (e.g. 25 denials on a recent multi-file PR) and **posted nothing**, despite finishing green.

## Change

- Pin the review model to **`claude-opus-4-8`**.
- Add `Read`, `Grep`, `Glob` to `--allowedTools` so the reviewer can open source files for context. Read-only — the repo is already checked out, so this grants no new access, only the tools to use it.

## Rollout note

`claude-code-action` refuses to run when a PR's workflow differs from the default branch (security guard), so **this PR's own review is skipped** — expected. The new config applies to PRs opened/synchronized after it merges to `main`.