### PR TITLE
feat(fetch): owner-tied interception lifecycle + non-blocking auth init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-- `CDPEx.Page` request interception no longer bricks the page when its owner dies: `CDPEx.Browser` now monitors the process that called `enable_request_interception/2` and auto-`Fetch.disable`s the page if that process exits without disabling — a crashed or forgetful caller can't leave every request paused with no resolver (#30).
-- `CDPEx.Page.authenticate/4` no longer blocks the `CDPEx.Browser` GenServer for the duration of `Fetch.enable`: the per-page Fetch handler now arms asynchronously and signals readiness, so the browser keeps serving other pages while a page authenticates. `authenticate/4` still returns only once interception is armed, preserving the "armed before `navigate/3`" guarantee (#36).
+### Breaking
+- Request interception ↔ `authenticate/4` mutual exclusion is now **enforced** (it previously failed silently — returning a misleading `:ok` while breaking the page, since both drive the `Fetch` domain). On the same page: `enable_request_interception/2` returns `{:error, {:conflict, :authenticated}}` when the page is authenticated, `authenticate/4` returns `{:error, {:conflict, :intercepting}}` when it's intercepting, and re-enabling interception returns `{:error, :already_intercepting}` (was `:ok`). Interception also now rejects a `:session`-transport page with `{:error, {:unsupported_transport, :session}}`, matching `authenticate/4`. Update any caller that only matched `:ok` on these paths (#30).
 
-### Changed
-- Request interception and `authenticate/4` are now **mutually exclusive per page**, enforced rather than failing silently (both drive the `Fetch` domain): enabling interception on an authenticated page returns `{:error, {:conflict, :authenticated}}`, `authenticate/4` on an intercepting page returns `{:error, {:conflict, :intercepting}}`, and re-enabling interception returns `{:error, :already_intercepting}`. Interception now also rejects a `:session`-transport page with `{:error, {:unsupported_transport, :session}}`, matching `authenticate/4` (#30).
+### Fixed
+- `CDPEx.Page` request interception no longer bricks the page when its owner dies: `CDPEx.Browser` now monitors the process that called `enable_request_interception/2` and auto-`Fetch.disable`s the page (off the Browser process, so a hung connection can't stall other pages) if that process exits without disabling — a crashed or forgetful caller can't leave every request paused with no resolver (#30).
+- `CDPEx.Page.authenticate/4` no longer blocks the `CDPEx.Browser` GenServer for the duration of `Fetch.enable`: the per-page Fetch handler now arms asynchronously and signals readiness, so the browser keeps serving other pages while a page authenticates. `authenticate/4` still returns only once interception is armed, preserving the "armed before `navigate/3`" guarantee (#36).
 
 ## [0.3.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `CDPEx.Page` request interception no longer bricks the page when its owner dies: `CDPEx.Browser` now monitors the process that called `enable_request_interception/2` and auto-`Fetch.disable`s the page if that process exits without disabling — a crashed or forgetful caller can't leave every request paused with no resolver (#30).
+- `CDPEx.Page.authenticate/4` no longer blocks the `CDPEx.Browser` GenServer for the duration of `Fetch.enable`: the per-page Fetch handler now arms asynchronously and signals readiness, so the browser keeps serving other pages while a page authenticates. `authenticate/4` still returns only once interception is armed, preserving the "armed before `navigate/3`" guarantee (#36).
+
+### Changed
+- Request interception and `authenticate/4` are now **mutually exclusive per page**, enforced rather than failing silently (both drive the `Fetch` domain): enabling interception on an authenticated page returns `{:error, {:conflict, :authenticated}}`, `authenticate/4` on an intercepting page returns `{:error, {:conflict, :intercepting}}`, and re-enabling interception returns `{:error, :already_intercepting}`. Interception now also rejects a `:session`-transport page with `{:error, {:unsupported_transport, :session}}`, matching `authenticate/4` (#30).
+
 ## [0.3.0] - 2026-06-03
 
 ### Added

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -44,8 +44,9 @@ defmodule CDPEx do
   method, an exit status, a stderr/contents excerpt) are open and may gain detail.
 
   The only bare, context-free reasons are `:noproc`, the high-level `:timeout`,
-  `:unknown_page`, and `:already_authenticated` — self-describing control-flow
-  outcomes with no payload to carry, the way GenServer uses `:noproc`. Validation
+  `:unknown_page`, `:already_authenticated`, and `:already_intercepting` —
+  self-describing control-flow outcomes with no payload to carry, the way GenServer
+  uses `:noproc`. Validation
   failures that *do* have offending data to surface are tagged instead
   (`{:invalid_response_body, excerpt}`, `{:invalid_pdf_data, excerpt}`,
   `{:invalid_screenshot_data, excerpt}`).
@@ -73,7 +74,9 @@ defmodule CDPEx do
           | :timeout
           | :unknown_page
           | :already_authenticated
+          | :already_intercepting
           | {:timeout, :await_event}
+          | {:conflict, :authenticated | :intercepting}
           | {:navigate, String.t()}
           | {:selector_not_found, String.t()}
           | {:evaluate_exception, term()}

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -46,9 +46,8 @@ defmodule CDPEx do
   The only bare, context-free reasons are `:noproc`, the high-level `:timeout`,
   `:unknown_page`, `:already_authenticated`, and `:already_intercepting` —
   self-describing control-flow outcomes with no payload to carry, the way GenServer
-  uses `:noproc`. Validation
-  failures that *do* have offending data to surface are tagged instead
-  (`{:invalid_response_body, excerpt}`, `{:invalid_pdf_data, excerpt}`,
+  uses `:noproc`. Validation failures that *do* have offending data to surface are
+  tagged instead (`{:invalid_response_body, excerpt}`, `{:invalid_pdf_data, excerpt}`,
   `{:invalid_screenshot_data, excerpt}`).
 
   Only part of this union is machine-checked: `t:CDPEx.Connection.call_error/0` and

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -100,13 +100,21 @@ defmodule CDPEx.Browser do
   @doc false
   @spec reserve_interception(GenServer.server(), Page.t()) :: :ok | {:error, term()}
   def reserve_interception(browser, %Page{} = page) do
-    GenServer.call(browser, {:reserve_interception, page})
+    GenServer.call(browser, {:reserve_interception, page}, 15_000)
+  catch
+    # A stalled or dead Browser must not crash the caller's interception-owner process
+    # with a raw exit — surface it as an error like the other page ops do.
+    :exit, _ -> {:error, :noproc}
   end
 
   @doc false
   @spec release_interception(GenServer.server(), Page.t()) :: :ok
   def release_interception(browser, %Page{} = page) do
-    GenServer.call(browser, {:release_interception, page})
+    GenServer.call(browser, {:release_interception, page}, 15_000)
+  catch
+    # Best-effort: if the Browser is gone or stalled there's nothing to release, and a
+    # raw exit must not blow up the caller's disable path.
+    :exit, _ -> :ok
   end
 
   @doc "Stops the browser, closing all pages and killing Chrome."
@@ -391,31 +399,52 @@ defmodule CDPEx.Browser do
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
     # An interception owner died without disabling. Drop its reservation and disable
-    # Fetch on that page's connection (off the hot path, via handle_continue) so the
-    # page isn't left bricked with no resolver. Unknown ref → a stale monitor; ignore.
+    # Fetch on that page's connection so the page isn't left bricked with no resolver.
+    # The disable runs OFF the Browser process (a hung page conn must not stall every
+    # other page — the same responsiveness #36 protects for auth). Unknown ref → a
+    # stale monitor; ignore.
     case pop_intercept_by_ref(state.intercepts, ref) do
       {nil, _} ->
         {:noreply, state}
 
       {tid, intercepts} ->
-        state = %{state | intercepts: intercepts}
-
         case Map.get(state.pages, tid) do
-          nil -> {:noreply, state}
-          conn -> {:noreply, state, {:continue, {:disable_fetch, conn}}}
+          # Page already closed: its Fetch domain went with it, nothing to disable.
+          nil -> :ok
+          conn -> disable_fetch_async(conn)
         end
+
+        {:noreply, %{state | intercepts: intercepts}}
     end
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
 
-  @impl true
-  def handle_continue({:disable_fetch, conn}, state) do
-    # Best-effort Fetch.disable for a dead interception owner. Connection.call
-    # tolerates a dead conn (returns {:error, _} instead of exiting), so this can't
-    # crash the Browser.
-    _ = Connection.call(conn, "Fetch.disable", %{}, @create_timeout)
-    {:noreply, state}
+  # Best-effort Fetch.disable for a dead interception owner, on a throwaway process so
+  # an unresponsive page connection can't block the Browser GenServer. Connection.call
+  # tolerates a dead conn (returns {:error, _} rather than exiting); a genuine failure
+  # on a live conn is logged since it can leave the page intercepted.
+  defp disable_fetch_async(conn) do
+    _ =
+      Task.start(fn ->
+        case Connection.call(conn, "Fetch.disable", %{}, @create_timeout) do
+          {:ok, _} ->
+            :ok
+
+          {:error, :noproc} ->
+            :ok
+
+          {:error, {:ws_closed, _}} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning(
+              "[CDPEx.Browser] Fetch.disable after interception owner death returned #{inspect(reason)}; the page may remain intercepted"
+            )
+        end
+      end)
+
+    :ok
   end
 
   @impl true

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -37,7 +37,9 @@ defmodule CDPEx.Browser do
     :parent,
     pages: %{},
     sessions: %{},
-    auths: %{}
+    auths: %{},
+    intercepts: %{},
+    pending_auth: %{}
   ]
 
   @type t :: %__MODULE__{}
@@ -88,6 +90,23 @@ defmodule CDPEx.Browser do
   @spec authenticate(GenServer.server(), Page.t(), keyword()) :: :ok | {:error, term()}
   def authenticate(browser, %Page{} = page, opts) do
     GenServer.call(browser, {:authenticate, page, opts}, 15_000)
+  end
+
+  # Internal hops for `CDPEx.Page.enable/disable_request_interception/2`, which own the
+  # public contract. Browser is the reservation + monitor authority: it records the
+  # interception owner (so auth and interception are mutually exclusive per page) and
+  # monitors it, auto-disabling Fetch if the owner dies. The actual subscribe +
+  # `Fetch.enable` stay on the caller's process (subscriptions key on the subscriber).
+  @doc false
+  @spec reserve_interception(GenServer.server(), Page.t()) :: :ok | {:error, term()}
+  def reserve_interception(browser, %Page{} = page) do
+    GenServer.call(browser, {:reserve_interception, page})
+  end
+
+  @doc false
+  @spec release_interception(GenServer.server(), Page.t()) :: :ok
+  def release_interception(browser, %Page{} = page) do
+    GenServer.call(browser, {:release_interception, page})
   end
 
   @doc "Stops the browser, closing all pages and killing Chrome."
@@ -210,7 +229,7 @@ defmodule CDPEx.Browser do
 
   def handle_call(
         {:authenticate, %Page{conn: conn, target_id: tid, session_id: sid}, opts},
-        _from,
+        from,
         state
       ) do
     # Dedicated page only (the :session clause above already returned).
@@ -221,6 +240,11 @@ defmodule CDPEx.Browser do
         # foreign connection and linking it to us.
         {:reply, {:error, :unknown_page}, state}
 
+      Map.has_key?(state.intercepts, tid) ->
+        # Request interception is active on this page; both drive the Fetch domain, so
+        # arming auth would clobber the interceptor. Enforce mutual exclusion.
+        {:reply, {:error, {:conflict, :intercepting}}, state}
+
       Map.has_key?(state.auths, tid) ->
         # Already authenticated: a second handler would double every
         # continueRequest/continueWithAuth, and its teardown would disable Fetch for
@@ -229,15 +253,64 @@ defmodule CDPEx.Browser do
 
       true ->
         # Start a per-page Fetch handler linked to us (crash-isolated, dies with the
-        # browser). It self-stops when the page's connection goes down; we drop the
-        # auths entry when it exits (see the {:EXIT, …} clause).
+        # browser). It arms asynchronously and signals {:armed, pid} when ready; we
+        # park the caller's `from` in pending_auth and reply only then, so
+        # authenticate/4 still returns once interception is armed — without blocking
+        # this GenServer for the whole enable. It self-stops when the page's connection
+        # goes down; we drop the auths entry when it exits (see the {:EXIT, …} clause).
         fetch_opts =
-          [conn: conn, session_id: sid] ++ Keyword.take(opts, [:username, :password, :source])
+          [conn: conn, session_id: sid, browser: self()] ++
+            Keyword.take(opts, [:username, :password, :source])
 
         case Fetch.start_link(fetch_opts) do
-          {:ok, pid} -> {:reply, :ok, %{state | auths: Map.put(state.auths, tid, pid)}}
-          {:error, reason} -> {:reply, {:error, reason}, state}
+          {:ok, pid} ->
+            {:noreply,
+             %{
+               state
+               | auths: Map.put(state.auths, tid, pid),
+                 pending_auth: Map.put(state.pending_auth, pid, from)
+             }}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
         end
+    end
+  end
+
+  def handle_call({:reserve_interception, %Page{session_id: sid}}, _from, state)
+      when not is_nil(sid) do
+    # Same shared-connection problem authenticate/4 rejects: an interception owner on a
+    # :session page would outlive close_page (which never stops the shared connection).
+    {:reply, {:error, {:unsupported_transport, :session}}, state}
+  end
+
+  def handle_call({:reserve_interception, %Page{conn: conn, target_id: tid}}, {caller, _tag}, state) do
+    cond do
+      Map.get(state.pages, tid) != conn ->
+        {:reply, {:error, :unknown_page}, state}
+
+      Map.has_key?(state.auths, tid) ->
+        {:reply, {:error, {:conflict, :authenticated}}, state}
+
+      Map.has_key?(state.intercepts, tid) ->
+        {:reply, {:error, :already_intercepting}, state}
+
+      true ->
+        # Monitor (not link) the foreign caller; on its death we auto-disable Fetch so
+        # a crashed/forgetful owner can't leave the page bricked with no resolver.
+        ref = Process.monitor(caller)
+        {:reply, :ok, %{state | intercepts: Map.put(state.intercepts, tid, {caller, ref})}}
+    end
+  end
+
+  def handle_call({:release_interception, %Page{target_id: tid}}, _from, state) do
+    case Map.pop(state.intercepts, tid) do
+      {nil, _} ->
+        {:reply, :ok, state}
+
+      {{_caller, ref}, intercepts} ->
+        Process.demonitor(ref, [:flush])
+        {:reply, :ok, %{state | intercepts: intercepts}}
     end
   end
 
@@ -258,10 +331,23 @@ defmodule CDPEx.Browser do
     {:stop, reason, state}
   end
 
-  def handle_info({:EXIT, pid, _reason}, state) do
-    # A page connection or a Fetch auth handler exited (closed or crashed). Drop it
-    # from both maps: a stale page handle's next op returns {:error, :noproc}, and
-    # clearing the auths entry lets the page be authenticated again.
+  def handle_info({:EXIT, pid, reason}, state) do
+    # A page connection or a Fetch auth handler exited (closed or crashed). If a Fetch
+    # handler was still arming, its authenticate/4 caller is parked on a delayed reply
+    # in pending_auth — fail it with the exit reason rather than let it hang to the
+    # call timeout. Then drop the pid from both maps: a stale page handle's next op
+    # returns {:error, :noproc}, and clearing the auths entry lets the page be
+    # authenticated again.
+    state =
+      case Map.pop(state.pending_auth, pid) do
+        {nil, _} ->
+          state
+
+        {from, pending_auth} ->
+          GenServer.reply(from, {:error, reason})
+          %{state | pending_auth: pending_auth}
+      end
+
     {:noreply, %{state | pages: drop_conn(state.pages, pid), auths: drop_value(state.auths, pid)}}
   end
 
@@ -275,7 +361,62 @@ defmodule CDPEx.Browser do
     {:noreply, %{state | sessions: Map.delete(state.sessions, params["targetId"])}}
   end
 
+  def handle_info({:armed, pid}, state) do
+    # A Fetch handler finished arming; reply :ok to the authenticate/4 caller parked in
+    # pending_auth. Unknown pid → a late or duplicate signal; ignore.
+    case Map.pop(state.pending_auth, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {from, pending_auth} ->
+        GenServer.reply(from, :ok)
+        {:noreply, %{state | pending_auth: pending_auth}}
+    end
+  end
+
+  def handle_info({:arm_failed, pid, reason}, state) do
+    # A Fetch handler couldn't arm; fail the parked authenticate/4 caller and drop the
+    # (already-recorded) auths entry so the page can be authenticated again. The
+    # handler stops :normal, so this is the quiet failure path (no crash report); the
+    # {:EXIT} clause below is the fallback if a handler dies without signalling.
+    case Map.pop(state.pending_auth, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {from, pending_auth} ->
+        GenServer.reply(from, {:error, reason})
+        {:noreply, %{state | pending_auth: pending_auth, auths: drop_value(state.auths, pid)}}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+    # An interception owner died without disabling. Drop its reservation and disable
+    # Fetch on that page's connection (off the hot path, via handle_continue) so the
+    # page isn't left bricked with no resolver. Unknown ref → a stale monitor; ignore.
+    case pop_intercept_by_ref(state.intercepts, ref) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {tid, intercepts} ->
+        state = %{state | intercepts: intercepts}
+
+        case Map.get(state.pages, tid) do
+          nil -> {:noreply, state}
+          conn -> {:noreply, state, {:continue, {:disable_fetch, conn}}}
+        end
+    end
+  end
+
   def handle_info(_msg, state), do: {:noreply, state}
+
+  @impl true
+  def handle_continue({:disable_fetch, conn}, state) do
+    # Best-effort Fetch.disable for a dead interception owner. Connection.call
+    # tolerates a dead conn (returns {:error, _} instead of exiting), so this can't
+    # crash the Browser.
+    _ = Connection.call(conn, "Fetch.disable", %{}, @create_timeout)
+    {:noreply, state}
+  end
 
   @impl true
   def terminate(_reason, state) do
@@ -445,6 +586,15 @@ defmodule CDPEx.Browser do
 
   defp drop_value(map, pid) do
     map |> Enum.reject(fn {_k, v} -> v == pid end) |> Map.new()
+  end
+
+  # Pop the interception entry whose monitor ref matches, returning {tid, rest} — or
+  # {nil, intercepts} if none matches (a stale monitor we no longer track).
+  defp pop_intercept_by_ref(intercepts, ref) do
+    case Enum.find(intercepts, fn {_tid, {_caller, r}} -> r == ref end) do
+      nil -> {nil, intercepts}
+      {tid, _entry} -> {tid, Map.delete(intercepts, tid)}
+    end
   end
 
   # Close a CDP target on the browser connection, ignoring failures (the browser

--- a/lib/cdp_ex/fetch.ex
+++ b/lib/cdp_ex/fetch.ex
@@ -20,6 +20,8 @@ defmodule CDPEx.Fetch do
 
   alias CDPEx.Connection
 
+  require Logger
+
   @call_timeout 10_000
   @max_tracked_challenges 1024
 
@@ -71,15 +73,16 @@ defmodule CDPEx.Fetch do
         {:noreply, state}
 
       {:error, reason} ->
-        # Arming failed (e.g. a CDP error). Tell the Browser so it fails the waiting
-        # authenticate/4 caller, then stop quietly (:normal — a benign arm failure
-        # shouldn't emit a GenServer crash report).
+        # A real CDP error on a live conn — worth a log line, since the caller only
+        # gets {:error, _}. Tell the Browser to fail the waiting authenticate/4 caller,
+        # then stop quietly (:normal — no GenServer crash report for a benign failure).
+        Logger.warning("[CDPEx.Fetch] arming failed: #{inspect(reason)}")
         send(state.browser, {:arm_failed, self(), reason})
         {:stop, :normal, state}
     end
   catch
     :exit, _ ->
-      # The page connection died mid-arm (a close/authenticate race) — same quiet path.
+      # The page connection died mid-arm (a close/authenticate race) — benign, no log.
       send(state.browser, {:arm_failed, self(), :noproc})
       {:stop, :normal, state}
   end

--- a/lib/cdp_ex/fetch.ex
+++ b/lib/cdp_ex/fetch.ex
@@ -23,7 +23,7 @@ defmodule CDPEx.Fetch do
   @call_timeout 10_000
   @max_tracked_challenges 1024
 
-  defstruct [:conn, :session_id, :username, :password, :source, attempts: %{}]
+  defstruct [:conn, :session_id, :username, :password, :source, :browser, attempts: %{}]
 
   @type t :: %__MODULE__{}
 
@@ -34,35 +34,54 @@ defmodule CDPEx.Fetch do
   @impl true
   def init(opts) do
     conn = Keyword.fetch!(opts, :conn)
-    session_id = Keyword.get(opts, :session_id)
+    # Monitor the page connection so we stop when it goes down. The blocking arm
+    # work (subscribe ×2 + Fetch.enable, up to @call_timeout) is deferred to
+    # handle_continue/2 so that init/1 — and therefore the Browser GenServer that
+    # called start_link — returns immediately instead of blocking the whole enable.
     Process.monitor(conn)
 
+    {:ok,
+     %__MODULE__{
+       conn: conn,
+       session_id: Keyword.get(opts, :session_id),
+       username: Keyword.fetch!(opts, :username),
+       password: Keyword.fetch!(opts, :password),
+       source: Keyword.get(opts, :source, :any),
+       browser: Keyword.fetch!(opts, :browser)
+     }, {:continue, :arm}}
+  end
+
+  @impl true
+  def handle_continue(:arm, state) do
     # Subscribe BEFORE enabling so no paused request can slip through between the
     # enable and the first event delivery. These are GenServer.calls; if `conn`
-    # already died (a rare race where the Browser processes authenticate/4 just
-    # ahead of the page-conn EXIT) they exit — catch it so start_link returns a
-    # clean {:error, :noproc} rather than a raw exit reason.
-    Connection.subscribe(conn, "Fetch.requestPaused")
-    Connection.subscribe(conn, "Fetch.authRequired")
+    # already died (a rare race where the Browser processed authenticate/4 just
+    # ahead of the page-conn EXIT) they exit — catch it and stop with :noproc.
+    Connection.subscribe(state.conn, "Fetch.requestPaused")
+    Connection.subscribe(state.conn, "Fetch.authRequired")
 
-    case Connection.call(conn, "Fetch.enable", %{"handleAuthRequests" => true}, @call_timeout,
-           session_id: session_id
+    case Connection.call(state.conn, "Fetch.enable", %{"handleAuthRequests" => true}, @call_timeout,
+           session_id: state.session_id
          ) do
       {:ok, _} ->
-        {:ok,
-         %__MODULE__{
-           conn: conn,
-           session_id: session_id,
-           username: Keyword.fetch!(opts, :username),
-           password: Keyword.fetch!(opts, :password),
-           source: Keyword.get(opts, :source, :any)
-         }}
+        # Signal the Browser we're armed so it can reply :ok to the still-waiting
+        # authenticate/4 caller — preserving the "armed before return" guarantee
+        # while leaving the Browser free to process other messages during the enable.
+        send(state.browser, {:armed, self()})
+        {:noreply, state}
 
       {:error, reason} ->
-        {:stop, reason}
+        # Arming failed (e.g. a CDP error). Tell the Browser so it fails the waiting
+        # authenticate/4 caller, then stop quietly (:normal — a benign arm failure
+        # shouldn't emit a GenServer crash report).
+        send(state.browser, {:arm_failed, self(), reason})
+        {:stop, :normal, state}
     end
   catch
-    :exit, _ -> {:stop, :noproc}
+    :exit, _ ->
+      # The page connection died mid-arm (a close/authenticate race) — same quiet path.
+      send(state.browser, {:arm_failed, self(), :noproc})
+      {:stop, :normal, state}
   end
 
   @impl true

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -252,8 +252,10 @@ defmodule CDPEx.Page do
 
   Only `:dedicated` pages (the `new_page/2` default) are supported; a `:session`
   page returns `{:error, {:unsupported_transport, :session}}`. A page that isn't one
-  of this browser's open pages returns `{:error, :unknown_page}`, and a page that is
-  already authenticated returns `{:error, :already_authenticated}`.
+  of this browser's open pages returns `{:error, :unknown_page}`, a page that is
+  already authenticated returns `{:error, :already_authenticated}`, and a page that
+  already has request interception enabled returns `{:error, {:conflict, :intercepting}}`
+  (auth and interception both drive the `Fetch` domain — use one per page).
 
   The bad-credentials loop guard keys on the request id, so a single request that
   must answer **both** a proxy and an origin challenge isn't supported — the second

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -653,9 +653,10 @@ defmodule CDPEx.Page do
   > forgetful caller can't leave it bricked (every request paused with no resolver).
   > While interception is enabled you must still resolve every pause.
 
-  On a `:session`-transport page the caller receives **every** session's
-  `Fetch.requestPaused` events on the shared connection (subscriptions are keyed by
-  method, not session); match on the `session_id` element to filter to this page.
+  Only `:dedicated` pages are supported; a `:session`-transport page is rejected with
+  `{:error, {:unsupported_transport, :session}}` (mirroring `authenticate/4`) — its
+  subscription and owner-monitor would outlive `close_page`, which never stops the
+  shared browser connection.
 
   Mutually exclusive with `authenticate/4` on the same page — both drive the `Fetch`
   domain. The conflict is **enforced**: enabling interception on an authenticated page
@@ -684,6 +685,10 @@ defmodule CDPEx.Page do
         else
           {:error, _} = error ->
             unsubscribe_each(page.conn, [@fetch_paused])
+            # A client-side timeout can mean Chrome actually enabled Fetch; disable it
+            # best-effort before releasing, so a timed-out enable can't leave the page
+            # bricked (Fetch on, no resolver) with the reservation/monitor already gone.
+            _ = ok_call(page, "Fetch.disable", %{}, timeout)
             Browser.release_interception(page.browser, page)
             error
         end

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -642,25 +642,24 @@ defmodule CDPEx.Page do
   handle it in a `handle_info`. The caller is subscribed **before** the domain is
   enabled, so no paused request is missed.
 
-  > #### The caller owns the lifecycle {: .warning}
+  > #### Drive interception from one long-lived process {: .info}
   >
-  > Nothing ties the enabled `Fetch` domain to the calling process. If the caller
-  > exits — or simply never calls `disable_request_interception/2` — `Fetch` stays
-  > enabled with no resolver and **every** subsequent request pauses forever: the
-  > page stalls permanently and can't even navigate away. Unlike a leaked
-  > `Network.enable`, a leaked `Fetch.enable` bricks the page. Drive interception
-  > from a long-lived process you control, and use that same process for `enable`,
-  > the pause handling, and `disable` (the subscription is keyed to its pid).
+  > Use the **same process** for `enable_request_interception/2`, the pause handling,
+  > and `disable_request_interception/2` — the subscription is keyed to its pid. That
+  > process is registered with the browser as the interception owner: if it exits
+  > without disabling, the browser auto-`Fetch.disable`s the page, so a crashed or
+  > forgetful caller can't leave it bricked (every request paused with no resolver).
+  > While interception is enabled you must still resolve every pause.
 
   On a `:session`-transport page the caller receives **every** session's
   `Fetch.requestPaused` events on the shared connection (subscriptions are keyed by
   method, not session); match on the `session_id` element to filter to this page.
 
   Mutually exclusive with `authenticate/4` on the same page — both drive the `Fetch`
-  domain. The conflict is **not enforced and fails silently**: enabling interception
-  on an authenticated page re-runs `Fetch.enable` without `handleAuthRequests`
-  (breaking auth) while the auth handler keeps racing the caller for each pause. Use
-  one or the other per page.
+  domain. The conflict is **enforced**: enabling interception on an authenticated page
+  returns `{:error, {:conflict, :authenticated}}`, and `authenticate/4` on an
+  intercepting page returns `{:error, {:conflict, :intercepting}}`. Re-enabling
+  interception on a page that already has it returns `{:error, :already_intercepting}`.
 
   Options:
     * `:patterns` — CDP `RequestPattern`s (default `[%{"urlPattern" => "*"}]`, all requests)
@@ -671,13 +670,23 @@ defmodule CDPEx.Page do
     timeout = Keyword.get(opts, :timeout, @command_timeout)
     patterns = Keyword.get(opts, :patterns, [%{"urlPattern" => "*"}])
 
-    # Subscribe before enabling (mirrors observe_network/2); undo on enable failure.
-    with :ok <- subscribe_each(page.conn, [@fetch_paused]),
-         {:ok, _} <- do_call(page, "Fetch.enable", %{"patterns" => patterns}, timeout) do
-      :ok
-    else
+    # Reserve the page's Fetch domain with the browser first: it enforces mutual
+    # exclusion with authenticate/4 and monitors this process so the domain is
+    # auto-disabled if we die. Only on a successful reservation do we subscribe +
+    # enable (on this process, mirroring observe_network/2); roll both back on failure.
+    case Browser.reserve_interception(page.browser, page) do
+      :ok ->
+        with :ok <- subscribe_each(page.conn, [@fetch_paused]),
+             {:ok, _} <- do_call(page, "Fetch.enable", %{"patterns" => patterns}, timeout) do
+          :ok
+        else
+          {:error, _} = error ->
+            unsubscribe_each(page.conn, [@fetch_paused])
+            Browser.release_interception(page.browser, page)
+            error
+        end
+
       {:error, _} = error ->
-        unsubscribe_each(page.conn, [@fetch_paused])
         error
     end
   end
@@ -694,7 +703,11 @@ defmodule CDPEx.Page do
   def disable_request_interception(%__MODULE__{} = page, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, @command_timeout)
     unsubscribe_each(page.conn, [@fetch_paused])
-    ok_call(page, "Fetch.disable", %{}, timeout)
+    result = ok_call(page, "Fetch.disable", %{}, timeout)
+    # Release the browser-side reservation (demonitors this process) regardless of the
+    # disable result, so the eventual owner :DOWN can't re-issue a spurious disable.
+    Browser.release_interception(page.browser, page)
+    result
   end
 
   @doc """

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -141,13 +141,31 @@ defmodule CDPEx.BrowserTest do
                Browser.handle_call({:release_interception, page}, {self(), make_ref()}, state)
     end
 
-    test "an owner :DOWN drops the entry and disables Fetch on its connection" do
-      conn = self()
+    test "an owner :DOWN drops the reservation (the Fetch.disable runs off-process)" do
+      # A dead conn makes the fire-and-forget disable Task resolve to :noproc silently;
+      # the actual disable is verified end-to-end by the integration suite.
+      conn = spawn(fn -> :ok end)
       ref = make_ref()
       state = %Browser{pages: %{"T1" => conn}, intercepts: %{"T1" => {self(), ref}}}
 
-      assert {:noreply, %Browser{intercepts: %{}}, {:continue, {:disable_fetch, ^conn}}} =
+      assert {:noreply, %Browser{intercepts: %{}}} =
                Browser.handle_info({:DOWN, ref, :process, self(), :killed}, state)
+    end
+
+    test "an owner :DOWN for an already-closed page drops the reservation without crashing" do
+      ref = make_ref()
+      state = %Browser{pages: %{}, intercepts: %{"T1" => {self(), ref}}}
+
+      assert {:noreply, %Browser{intercepts: %{}}} =
+               Browser.handle_info({:DOWN, ref, :process, self(), :killed}, state)
+    end
+
+    test "release of a page with no reservation is an idempotent :ok" do
+      page = %Page{browser: self(), conn: self(), target_id: "T_GONE"}
+      state = %Browser{intercepts: %{}}
+
+      assert {:reply, :ok, ^state} =
+               Browser.handle_call({:release_interception, page}, {self(), make_ref()}, state)
     end
 
     test "an owner :DOWN for an unknown ref is ignored" do
@@ -211,6 +229,18 @@ defmodule CDPEx.BrowserTest do
       assert new_state.pending_auth == %{}
       {_pid, tag} = from
       assert_receive {^tag, {:error, :boom}}
+    end
+
+    test "{:armed} for an unknown pid is a no-op (late or duplicate signal)" do
+      state = %Browser{pending_auth: %{}}
+      assert {:noreply, ^state} = Browser.handle_info({:armed, spawn(fn -> :ok end)}, state)
+    end
+
+    test "{:arm_failed} for an unknown pid is a no-op" do
+      state = %Browser{pending_auth: %{}}
+
+      assert {:noreply, ^state} =
+               Browser.handle_info({:arm_failed, spawn(fn -> :ok end), :boom}, state)
     end
   end
 end

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -81,4 +81,136 @@ defmodule CDPEx.BrowserTest do
       assert %{shutdown: 10_000} = Browser.child_spec([])
     end
   end
+
+  describe "interception reservation (#30)" do
+    test "rejects a :session page (shared-connection ownership problem)" do
+      page = %Page{browser: self(), conn: self(), target_id: "T1", session_id: "S1"}
+      state = %Browser{}
+
+      assert {:reply, {:error, {:unsupported_transport, :session}}, ^state} =
+               Browser.handle_call({:reserve_interception, page}, {self(), make_ref()}, state)
+    end
+
+    test "rejects a page this browser doesn't own" do
+      page = %Page{browser: self(), conn: self(), target_id: "T1"}
+      state = %Browser{pages: %{}}
+
+      assert {:reply, {:error, :unknown_page}, ^state} =
+               Browser.handle_call({:reserve_interception, page}, {self(), make_ref()}, state)
+    end
+
+    test "rejects when the page is already authenticated (mutual exclusion)" do
+      conn = self()
+      page = %Page{browser: self(), conn: conn, target_id: "T1"}
+      state = %Browser{pages: %{"T1" => conn}, auths: %{"T1" => self()}}
+
+      assert {:reply, {:error, {:conflict, :authenticated}}, ^state} =
+               Browser.handle_call({:reserve_interception, page}, {self(), make_ref()}, state)
+    end
+
+    test "rejects a double reservation" do
+      conn = self()
+      page = %Page{browser: self(), conn: conn, target_id: "T1"}
+      state = %Browser{pages: %{"T1" => conn}, intercepts: %{"T1" => {self(), make_ref()}}}
+
+      assert {:reply, {:error, :already_intercepting}, ^state} =
+               Browser.handle_call({:reserve_interception, page}, {self(), make_ref()}, state)
+    end
+
+    test "records and monitors the caller on success" do
+      conn = self()
+      page = %Page{browser: self(), conn: conn, target_id: "T1"}
+      state = %Browser{pages: %{"T1" => conn}}
+      caller = spawn(fn -> Process.sleep(:infinity) end)
+
+      assert {:reply, :ok, new_state} =
+               Browser.handle_call({:reserve_interception, page}, {caller, make_ref()}, state)
+
+      assert {^caller, ref} = new_state.intercepts["T1"]
+      assert is_reference(ref)
+
+      Process.exit(caller, :kill)
+    end
+
+    test "release demonitors and drops the entry" do
+      page = %Page{browser: self(), conn: self(), target_id: "T1"}
+      ref = Process.monitor(self())
+      state = %Browser{intercepts: %{"T1" => {self(), ref}}}
+
+      assert {:reply, :ok, %Browser{intercepts: %{}}} =
+               Browser.handle_call({:release_interception, page}, {self(), make_ref()}, state)
+    end
+
+    test "an owner :DOWN drops the entry and disables Fetch on its connection" do
+      conn = self()
+      ref = make_ref()
+      state = %Browser{pages: %{"T1" => conn}, intercepts: %{"T1" => {self(), ref}}}
+
+      assert {:noreply, %Browser{intercepts: %{}}, {:continue, {:disable_fetch, ^conn}}} =
+               Browser.handle_info({:DOWN, ref, :process, self(), :killed}, state)
+    end
+
+    test "an owner :DOWN for an unknown ref is ignored" do
+      state = %Browser{intercepts: %{}}
+
+      assert {:noreply, ^state} =
+               Browser.handle_info({:DOWN, make_ref(), :process, self(), :killed}, state)
+    end
+
+    test "authenticate is rejected when interception is active (reverse exclusion)" do
+      conn = self()
+      page = %Page{browser: self(), conn: conn, target_id: "T1"}
+      state = %Browser{pages: %{"T1" => conn}, intercepts: %{"T1" => {self(), make_ref()}}}
+
+      assert {:reply, {:error, {:conflict, :intercepting}}, ^state} =
+               Browser.handle_call(
+                 {:authenticate, page, [username: "u", password: "p"]},
+                 {self(), make_ref()},
+                 state
+               )
+    end
+  end
+
+  describe "non-blocking authenticate (#36)" do
+    test "{:armed} replies :ok to the parked caller and clears pending_auth" do
+      from = {self(), make_ref()}
+      fetch = spawn(fn -> :ok end)
+      state = %Browser{pending_auth: %{fetch => from}}
+
+      assert {:noreply, %Browser{pending_auth: %{}}} = Browser.handle_info({:armed, fetch}, state)
+
+      {_pid, tag} = from
+      assert_receive {^tag, :ok}
+    end
+
+    test "{:arm_failed} fails the parked caller and clears its auths + pending_auth" do
+      from = {self(), make_ref()}
+      fetch = spawn(fn -> :ok end)
+      state = %Browser{auths: %{"T1" => fetch}, pending_auth: %{fetch => from}}
+
+      assert {:noreply, new_state} =
+               Browser.handle_info(
+                 {:arm_failed, fetch, {:cdp_error, "Fetch.enable", %{}}},
+                 state
+               )
+
+      assert new_state.pending_auth == %{}
+      assert new_state.auths == %{}
+
+      {_pid, tag} = from
+      assert_receive {^tag, {:error, {:cdp_error, "Fetch.enable", %{}}}}
+    end
+
+    test "a Fetch handler {:EXIT} during arming fails a still-parked caller (fallback)" do
+      from = {self(), make_ref()}
+      fetch = spawn(fn -> :ok end)
+      state = %Browser{auths: %{"T1" => fetch}, pending_auth: %{fetch => from}}
+
+      assert {:noreply, new_state} = Browser.handle_info({:EXIT, fetch, :boom}, state)
+
+      assert new_state.pending_auth == %{}
+      {_pid, tag} = from
+      assert_receive {^tag, {:error, :boom}}
+    end
+  end
 end

--- a/test/cdp_ex/fetch_test.exs
+++ b/test/cdp_ex/fetch_test.exs
@@ -1,6 +1,8 @@
 defmodule CDPEx.FetchTest do
   use ExUnit.Case, async: true
 
+  alias CDPEx.Connection
+  alias CDPEx.FakeCDP
   alias CDPEx.Fetch
 
   @creds [username: "u", password: "p"]
@@ -54,18 +56,56 @@ defmodule CDPEx.FetchTest do
   end
 
   describe "start_link/1" do
-    test "stops with {:error, :noproc} when the connection is already dead" do
-      # Trap exits: the handler is linked, and an init {:stop, :noproc} exits the
-      # child with that (abnormal) reason.
+    test "arms asynchronously, then signals {:arm_failed, _, :noproc} on a dead connection" do
+      # The handler is linked. init/1 now returns fast and defers arming to
+      # handle_continue/2, so start_link succeeds; the dead-conn subscribe/enable then
+      # fails there and is reported to the browser (here, the test process) as
+      # {:arm_failed, pid, :noproc} before the handler stops quietly (:normal).
       Process.flag(:trap_exit, true)
 
       conn = spawn(fn -> :ok end)
       ref = Process.monitor(conn)
       assert_receive {:DOWN, ^ref, :process, ^conn, _}, 1_000
 
-      # A subscribe/enable against the dead conn would exit; init catches it so the
-      # caller gets a clean error instead of a raw exit reason.
-      assert {:error, :noproc} = Fetch.start_link(conn: conn, username: "u", password: "p")
+      assert {:ok, pid} =
+               Fetch.start_link(conn: conn, browser: self(), username: "u", password: "p")
+
+      assert_receive {:arm_failed, ^pid, :noproc}, 1_000
+    end
+  end
+
+  describe "handle_continue(:arm) (FakeCDP)" do
+    setup do
+      {:ok, server} = FakeCDP.start()
+      {:ok, conn} = Connection.start_link(server.url)
+      assert_receive {:fake_cdp_connected, fake}, 2_000
+
+      on_exit(fn ->
+        try do
+          # Closing the conn makes the (conn-monitoring) Fetch handler self-stop.
+          if Process.alive?(conn), do: Connection.close(conn)
+        catch
+          :exit, _ -> :ok
+        end
+      end)
+
+      %{conn: conn, fake: fake}
+    end
+
+    test "subscribes, enables Fetch with handleAuthRequests, then signals {:armed}", %{
+      conn: conn,
+      fake: fake
+    } do
+      {:ok, pid} = Fetch.start_link(conn: conn, browser: self(), username: "u", password: "p")
+
+      assert_receive {:fake_cdp_recv, ^fake,
+                      %{"id" => id, "method" => "Fetch.enable", "params" => params}},
+                     2_000
+
+      assert params["handleAuthRequests"] == true
+      FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
+
+      assert_receive {:armed, ^pid}, 2_000
     end
   end
 end

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -556,14 +556,15 @@ defmodule CDPEx.IntegrationTest do
       Process.exit(owner, :kill)
       assert_receive {:DOWN, ^ref, :process, ^owner, _}, 5_000
 
-      # Once the browser has processed the owner's :DOWN (clearing the reservation),
-      # its handle_continue has already issued Fetch.disable — so the page is no longer
-      # bricked and a fresh navigation actually loads (requests aren't paused with no
-      # resolver). Pre-fix, this navigation would pause on the document and never load.
-      assert eventually(fn -> :sys.get_state(browser).intercepts == %{} end)
-
-      {:ok, _} = Page.navigate(page, fixture, wait_until: :load)
-      assert {:ok, "Hello"} = Page.text(page, "#greeting")
+      # The browser monitors the owner and Fetch.disables the page (off-process) when
+      # it dies. Poll a fresh navigation until it actually renders: while Fetch is
+      # still enabled the document stays paused and a short-timeout navigate returns
+      # best-effort without loading, so the selector text stays absent; once the
+      # async disable lands the page loads. Pre-fix it would never recover.
+      assert eventually(fn ->
+               Page.navigate(page, fixture, wait_until: :load, timeout: 1_000)
+               match?({:ok, "Hello"}, Page.text(page, "#greeting"))
+             end)
     end
 
     test "interception and authenticate are mutually exclusive per page" do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -533,6 +533,54 @@ defmodule CDPEx.IntegrationTest do
 
       assert :ok = Page.disable_request_interception(page)
     end
+
+    test "auto-disables Fetch when the interception owner process dies (anti-brick)", %{
+      fixture: fixture
+    } do
+      {:ok, browser} = CDPEx.launch()
+      {:ok, page} = CDPEx.new_page(browser)
+      on_exit(fn -> stop_quietly(browser) end)
+
+      test = self()
+
+      # Enable interception from a separate process, then kill it WITHOUT disabling.
+      owner =
+        spawn(fn ->
+          send(test, {:enabled, Page.enable_request_interception(page)})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:enabled, :ok}, 5_000
+
+      ref = Process.monitor(owner)
+      Process.exit(owner, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^owner, _}, 5_000
+
+      # Once the browser has processed the owner's :DOWN (clearing the reservation),
+      # its handle_continue has already issued Fetch.disable — so the page is no longer
+      # bricked and a fresh navigation actually loads (requests aren't paused with no
+      # resolver). Pre-fix, this navigation would pause on the document and never load.
+      assert eventually(fn -> :sys.get_state(browser).intercepts == %{} end)
+
+      {:ok, _} = Page.navigate(page, fixture, wait_until: :load)
+      assert {:ok, "Hello"} = Page.text(page, "#greeting")
+    end
+
+    test "interception and authenticate are mutually exclusive per page" do
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      # Authenticate first → interception is refused.
+      {:ok, p1} = CDPEx.new_page(browser)
+      assert :ok = Page.authenticate(p1, "cdpex", "secret")
+      assert {:error, {:conflict, :authenticated}} = Page.enable_request_interception(p1)
+
+      # Intercept first → authenticate is refused (the reverse direction).
+      {:ok, p2} = CDPEx.new_page(browser)
+      assert :ok = Page.enable_request_interception(p2)
+      assert {:error, {:conflict, :intercepting}} = Page.authenticate(p2, "cdpex", "secret")
+      assert :ok = Page.disable_request_interception(p2)
+    end
   end
 
   describe "tracer bullet" do

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -1,9 +1,28 @@
+defmodule CDPEx.PageTest.StubBrowser do
+  @moduledoc false
+  # Minimal stand-in for CDPEx.Browser so the page-level interception tests exercise
+  # the caller-side subscribe/enable path. Answers the reservation hops with a
+  # configurable reply; the reservation *logic* (exclusion, monitor, auto-disable on
+  # owner death) is covered directly in CDPEx.BrowserTest.
+  use GenServer
+
+  def start_link(reserve_reply \\ :ok), do: GenServer.start_link(__MODULE__, reserve_reply)
+
+  @impl true
+  def init(reserve_reply), do: {:ok, reserve_reply}
+
+  @impl true
+  def handle_call({:reserve_interception, _page}, _from, reply), do: {:reply, reply, reply}
+  def handle_call({:release_interception, _page}, _from, reply), do: {:reply, :ok, reply}
+end
+
 defmodule CDPEx.PageTest do
   use ExUnit.Case, async: true
 
   alias CDPEx.Connection
   alias CDPEx.FakeCDP
   alias CDPEx.Page
+  alias CDPEx.PageTest.StubBrowser
 
   @network_methods ["Network.requestWillBeSent", "Network.responseReceived"]
 
@@ -16,6 +35,8 @@ defmodule CDPEx.PageTest do
     {:ok, conn} = Connection.start_link(server.url)
     assert_receive {:fake_cdp_connected, fake}, 2_000
 
+    {:ok, browser} = StubBrowser.start_link()
+
     on_exit(fn ->
       try do
         if Process.alive?(conn), do: Connection.close(conn)
@@ -25,7 +46,7 @@ defmodule CDPEx.PageTest do
     end)
 
     %{
-      page: %Page{browser: self(), conn: conn, target_id: "T", session_id: nil},
+      page: %Page{browser: browser, conn: conn, target_id: "T", session_id: nil},
       conn: conn,
       fake: fake
     }

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -405,6 +405,11 @@ defmodule CDPEx.PageTest do
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => id, "method" => "Fetch.enable"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{id},"error":{"code":-32000,"message":"boom"}}))
 
+      # The rollback issues a best-effort Fetch.disable (covers the timed-out-but-
+      # enabled brick edge); answer it so the rollback completes promptly.
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => did, "method" => "Fetch.disable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{did},"result":{}}))
+
       assert_receive {:enable_result, {:error, {:cdp_error, "Fetch.enable", _}}}, 2_000
       refute subscribed?(conn, observer, "Fetch.requestPaused")
 

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -6,14 +6,22 @@ defmodule CDPEx.PageTest.StubBrowser do
   # owner death) is covered directly in CDPEx.BrowserTest.
   use GenServer
 
-  def start_link(reserve_reply \\ :ok), do: GenServer.start_link(__MODULE__, reserve_reply)
+  def start_link(reserve_reply \\ :ok, notify \\ nil),
+    do: GenServer.start_link(__MODULE__, {reserve_reply, notify})
 
   @impl true
-  def init(reserve_reply), do: {:ok, reserve_reply}
+  def init(state), do: {:ok, state}
 
   @impl true
-  def handle_call({:reserve_interception, _page}, _from, reply), do: {:reply, reply, reply}
-  def handle_call({:release_interception, _page}, _from, reply), do: {:reply, :ok, reply}
+  def handle_call({:reserve_interception, page}, _from, {reply, notify} = state) do
+    if notify, do: send(notify, {:stub_reserve, page})
+    {:reply, reply, state}
+  end
+
+  def handle_call({:release_interception, page}, _from, {_reply, notify} = state) do
+    if notify, do: send(notify, {:stub_release, page})
+    {:reply, :ok, state}
+  end
 end
 
 defmodule CDPEx.PageTest do
@@ -35,7 +43,7 @@ defmodule CDPEx.PageTest do
     {:ok, conn} = Connection.start_link(server.url)
     assert_receive {:fake_cdp_connected, fake}, 2_000
 
-    {:ok, browser} = StubBrowser.start_link()
+    {:ok, browser} = StubBrowser.start_link(:ok, self())
 
     on_exit(fn ->
       try do
@@ -399,6 +407,10 @@ defmodule CDPEx.PageTest do
 
       assert_receive {:enable_result, {:error, {:cdp_error, "Fetch.enable", _}}}, 2_000
       refute subscribed?(conn, observer, "Fetch.requestPaused")
+
+      # The reservation must be released on the rollback path, else the page stays
+      # locked in the browser's intercepts map after a failed enable.
+      assert_receive {:stub_release, _}, 2_000
 
       send(observer, :stop)
     end


### PR DESCRIPTION
First v0.4.0 PR — two robustness fixes to shipped 0.3.0 Fetch-domain features.

## #30 — request interception lifecycle + auth exclusion
0.3.0's interception had a footgun: nothing tied the enabled `Fetch` domain to the caller, so a crashed/forgetful caller left `Fetch` enabled with no resolver and **bricked the page** (every request paused, can't even navigate away). It also conflicted with `authenticate/4` *silently* (both drive `Fetch`).

- **Reservation protocol.** `enable_request_interception/2` first reserves the page's Fetch slot with the `Browser`, which **monitors the calling process**. If that process exits without disabling, the Browser auto-`Fetch.disable`s the page (via `handle_continue`, off the hot path) — no more brick. The `subscribe` + `Fetch.enable` still run on the caller, so the shipped event-delivery contract (`{:cdp_event, conn, "Fetch.requestPaused", …}` to the caller) is unchanged.
- **Enforced mutual exclusion.** Auth ↔ interception now return `{:error, {:conflict, :authenticated}}` / `{:error, {:conflict, :intercepting}}` / `{:error, :already_intercepting}` instead of silently clobbering each other. Interception also now rejects `:session` pages, matching `authenticate/4`.

## #36 — non-blocking `authenticate/4` init
`authenticate/4` blocked the `Browser` GenServer for the whole `Fetch.enable` (up to ~10s), stalling every other page. Now the Fetch handler arms in `handle_continue` and signals `{:armed}` / `{:arm_failed}`; the Browser parks the caller's reply in `pending_auth` and answers then. The browser stays responsive during the enable, and `authenticate/4` still returns only once interception is armed (the before-`navigate/3` guarantee holds). Arm failure stops the handler quietly (`:normal`) — no spurious crash report.

## Tests
- **Unit (`mix ci` green, +13 tests):** `BrowserTest` drives the reservation/exclusion/`{:DOWN}` and `{:armed}`/`{:arm_failed}` logic directly; `FetchTest` covers async arming (FakeCDP) + dead-conn arm failure; `PageTest` uses a stub browser for the reservation hop.
- **Integration (44 tests pass, real Chrome):** new **anti-brick** test (kill the interception owner → the page recovers and navigates) and **bidirectional conflict**; the existing auth-then-navigate test (the #36 guarantee's witness) still passes.

Closes #30. Closes #36.
