### PR TITLE
Add navigate(response: true): capture the document HTTP status + final URL (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `CDPEx.Page.navigate/3` accepts `response: true` to return `{:ok, page, %{status, url}}` — the main document's HTTP status and final (post-redirect) URL, correlated to the navigation by its `loaderId`. Lets callers detect a 403 wall / 404 / login-redirect instead of treating every navigation as success. Lazily enables the `Network` domain; returns `{:error, {:no_document_response, url}}` when no document response arrives (#31).
+
 ### Breaking
 - Request interception ↔ `authenticate/4` mutual exclusion is now **enforced** (it previously failed silently — returning a misleading `:ok` while breaking the page, since both drive the `Fetch` domain). On the same page: `enable_request_interception/2` returns `{:error, {:conflict, :authenticated}}` when the page is authenticated, `authenticate/4` returns `{:error, {:conflict, :intercepting}}` when it's intercepting, and re-enabling interception returns `{:error, :already_intercepting}` (was `:ok`). Interception also now rejects a `:session`-transport page with `{:error, {:unsupported_transport, :session}}`, matching `authenticate/4`. Update any caller that only matched `:ok` on these paths (#30).
 

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -77,6 +77,7 @@ defmodule CDPEx do
           | {:timeout, :await_event}
           | {:conflict, :authenticated | :intercepting}
           | {:navigate, String.t()}
+          | {:no_document_response, String.t()}
           | {:selector_not_found, String.t()}
           | {:evaluate_exception, term()}
           | {:unexpected_evaluate, term()}

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -39,6 +39,8 @@ defmodule CDPEx.Page do
 
   @network_events ["Network.requestWillBeSent", "Network.responseReceived"]
   @fetch_paused "Fetch.requestPaused"
+  @lifecycle_method "Page.lifecycleEvent"
+  @response_method "Network.responseReceived"
 
   @enforce_keys [:browser, :conn, :target_id]
   defstruct [:browser, :conn, :target_id, :session_id]
@@ -57,15 +59,37 @@ defmodule CDPEx.Page do
   best-effort: if it times out, navigation still returns `{:ok, page}` (the page
   may simply be slow); a hard navigation error returns `{:error, _}`.
 
+  ## Capturing the document response
+
+  Pass `response: true` to also get the main document's HTTP outcome — a clean signal
+  for "did I land on the real page", versus a 403 wall / 404 / redirect-to-login that
+  all otherwise look like success:
+
+      {:ok, page, %{status: 200, url: final_url}} = Page.navigate(page, url, response: true)
+
+  `status` is the HTTP status and `url` is the **final** URL after redirects,
+  correlated to *this* navigation's main document by its `loaderId` (not "the first
+  `Document` response seen"). This lazily enables the `Network` domain. If no main
+  document response arrives before the wait ends, it returns
+  `{:error, {:no_document_response, url}}` (e.g. a connection that never produced an
+  HTTP response — though those usually surface earlier as `{:navigate, _}`).
+
   Options:
     * `:wait_until` — `:network_almost_idle` (default), `:load`, or `:none`
+    * `:response` — `true` to also return `%{status, url}` (default `false`)
     * `:timeout` — ms (default 30_000)
   """
-  @spec navigate(t(), String.t(), keyword()) :: {:ok, t()} | {:error, term()}
+  @spec navigate(t(), String.t(), keyword()) ::
+          {:ok, t()} | {:ok, t(), map()} | {:error, term()}
   def navigate(%__MODULE__{} = page, url, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, @navigate_timeout)
     wait_until = Keyword.get(opts, :wait_until, :network_almost_idle)
-    navigate_with_wait(page, url, wait_until, timeout)
+
+    if Keyword.get(opts, :response, false) do
+      navigate_capturing_response(page, url, wait_until, timeout)
+    else
+      navigate_with_wait(page, url, wait_until, timeout)
+    end
   end
 
   defp navigate_with_wait(page, url, :none, timeout) do
@@ -103,6 +127,122 @@ defmodule CDPEx.Page do
 
       {:error, _} = error ->
         error
+    end
+  end
+
+  # Like navigate_with_wait/4 but also captures the main-document Network.responseReceived
+  # (HTTP status + final URL) for THIS navigation. Kept separate so the default path
+  # stays untouched. Requires the Network domain; enables it lazily.
+  defp navigate_capturing_response(page, url, wait_until, timeout) do
+    methods = [@lifecycle_method, @response_method]
+
+    with :ok <- ensure_network(page, timeout),
+         :ok <- subscribe_each(page.conn, methods) do
+      Enum.each(methods, &drain_events(page.conn, &1))
+      ref = Process.monitor(page.conn)
+      deadline = System.monotonic_time(:millisecond) + timeout
+
+      try do
+        capture_after_navigate(page, url, wait_until, timeout, ref, deadline)
+      after
+        Process.demonitor(ref, [:flush])
+        unsubscribe_each(page.conn, methods)
+        Enum.each(methods, &drain_events(page.conn, &1))
+      end
+    end
+  end
+
+  defp capture_after_navigate(page, url, wait_until, timeout, ref, deadline) do
+    case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
+      {:ok, %{"errorText" => error}} ->
+        {:error, {:navigate, error}}
+
+      {:ok, result} ->
+        milestone = if wait_until == :none, do: nil, else: lifecycle_name(wait_until)
+
+        case await_capture(
+               page,
+               milestone,
+               ref,
+               deadline,
+               result["loaderId"],
+               result["frameId"],
+               nil
+             ) do
+          {:ok, nil} -> {:error, {:no_document_response, url}}
+          {:ok, resp} -> {:ok, page, resp}
+          {:down, reason} -> {:error, down_reason(reason)}
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # Await the readiness milestone (or, with :none, the document response itself) while
+  # accumulating the main-document response — scoped to this page's session (`^sid`),
+  # correlated by loaderId (+ frameId when present) and type "Document".
+  defp await_capture(
+         %__MODULE__{conn: conn, session_id: sid} = page,
+         milestone,
+         ref,
+         deadline,
+         lid,
+         fid,
+         captured
+       ) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:cdp_event, ^conn, @response_method, params, ^sid} ->
+        captured =
+          if document_response?(params, lid, fid), do: response_summary(params), else: captured
+
+        if is_nil(milestone) and not is_nil(captured) do
+          {:ok, captured}
+        else
+          await_capture(page, milestone, ref, deadline, lid, fid, captured)
+        end
+
+      {:cdp_event, ^conn, @lifecycle_method, %{"name" => ^milestone}, ^sid}
+      when not is_nil(milestone) ->
+        {:ok, captured}
+
+      {:cdp_event, ^conn, _method, _params, _other_sid} ->
+        # Another session's event, or this session's non-milestone lifecycle — ignore.
+        await_capture(page, milestone, ref, deadline, lid, fid, captured)
+
+      {:DOWN, ^ref, :process, ^conn, reason} ->
+        {:down, reason}
+    after
+      remaining ->
+        # Best-effort: return whatever document response we captured (nil → the caller
+        # maps it to {:error, {:no_document_response, _}}). Prefer a just-landed :DOWN.
+        receive do
+          {:DOWN, ^ref, :process, ^conn, reason} -> {:down, reason}
+        after
+          0 -> {:ok, captured}
+        end
+    end
+  end
+
+  defp document_response?(%{"type" => "Document", "loaderId" => loader} = params, lid, fid) do
+    loader == lid and Map.get(params, "frameId", fid) == fid
+  end
+
+  defp document_response?(_params, _lid, _fid), do: false
+
+  defp response_summary(params) do
+    response = params["response"] || %{}
+    %{status: response["status"], url: response["url"]}
+  end
+
+  # Generic mailbox drain for one cdp method (parallel to drain_lifecycle/1).
+  defp drain_events(conn, method) do
+    receive do
+      {:cdp_event, ^conn, ^method, _params, _sid} -> drain_events(conn, method)
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -37,10 +37,10 @@ defmodule CDPEx.Page do
   @screenshot_timeout 30_000
   @command_timeout 10_000
 
-  @network_events ["Network.requestWillBeSent", "Network.responseReceived"]
-  @fetch_paused "Fetch.requestPaused"
   @lifecycle_method "Page.lifecycleEvent"
-  @response_method "Network.responseReceived"
+  @response_received "Network.responseReceived"
+  @network_events ["Network.requestWillBeSent", @response_received]
+  @fetch_paused "Fetch.requestPaused"
 
   @enforce_keys [:browser, :conn, :target_id]
   defstruct [:browser, :conn, :target_id, :session_id]
@@ -69,10 +69,18 @@ defmodule CDPEx.Page do
 
   `status` is the HTTP status and `url` is the **final** URL after redirects,
   correlated to *this* navigation's main document by its `loaderId` (not "the first
-  `Document` response seen"). This lazily enables the `Network` domain. If no main
-  document response arrives before the wait ends, it returns
-  `{:error, {:no_document_response, url}}` (e.g. a connection that never produced an
-  HTTP response — though those usually surface earlier as `{:navigate, _}`).
+  `Document` response seen"). This lazily enables the `Network` domain (and leaves it
+  enabled). If no main document response arrives before the wait ends, it returns
+  `{:error, {:no_document_response, url}}` (e.g. a same-document/hash navigation that
+  loads no new document, or a connection that never produced an HTTP response — though
+  the latter usually surfaces earlier as `{:navigate, _}`).
+
+  > #### Don't combine with `observe_network/2` on the same page {: .warning}
+  >
+  > `response: true` subscribes the calling process to `Network.responseReceived` for
+  > the duration of the call, then unsubscribes on the way out. If the *same process*
+  > is also running `observe_network/2` on this page, the navigation tears that
+  > subscription down. Observe from a separate process, or capture via `response: true`.
 
   Options:
     * `:wait_until` — `:network_almost_idle` (default), `:load`, or `:none`
@@ -80,7 +88,9 @@ defmodule CDPEx.Page do
     * `:timeout` — ms (default 30_000)
   """
   @spec navigate(t(), String.t(), keyword()) ::
-          {:ok, t()} | {:ok, t(), map()} | {:error, term()}
+          {:ok, t()}
+          | {:ok, t(), %{status: non_neg_integer(), url: String.t()}}
+          | {:error, term()}
   def navigate(%__MODULE__{} = page, url, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, @navigate_timeout)
     wait_until = Keyword.get(opts, :wait_until, :network_almost_idle)
@@ -134,7 +144,11 @@ defmodule CDPEx.Page do
   # (HTTP status + final URL) for THIS navigation. Kept separate so the default path
   # stays untouched. Requires the Network domain; enables it lazily.
   defp navigate_capturing_response(page, url, wait_until, timeout) do
-    methods = [@lifecycle_method, @response_method]
+    # Validate :wait_until up front (lifecycle_name/1 raises on a bad value) so an
+    # invalid option never enables Network / fires the navigation first — matching the
+    # default path, which validates before any side effect.
+    milestone = if wait_until == :none, do: nil, else: lifecycle_name(wait_until)
+    methods = [@lifecycle_method, @response_received]
 
     with :ok <- ensure_network(page, timeout),
          :ok <- subscribe_each(page.conn, methods) do
@@ -143,7 +157,7 @@ defmodule CDPEx.Page do
       deadline = System.monotonic_time(:millisecond) + timeout
 
       try do
-        capture_after_navigate(page, url, wait_until, timeout, ref, deadline)
+        capture_after_navigate(page, url, milestone, timeout, ref, deadline)
       after
         Process.demonitor(ref, [:flush])
         unsubscribe_each(page.conn, methods)
@@ -152,14 +166,12 @@ defmodule CDPEx.Page do
     end
   end
 
-  defp capture_after_navigate(page, url, wait_until, timeout, ref, deadline) do
+  defp capture_after_navigate(page, url, milestone, timeout, ref, deadline) do
     case do_call(page, "Page.navigate", %{"url" => url}, timeout) do
       {:ok, %{"errorText" => error}} ->
         {:error, {:navigate, error}}
 
       {:ok, result} ->
-        milestone = if wait_until == :none, do: nil, else: lifecycle_name(wait_until)
-
         case await_capture(
                page,
                milestone,
@@ -194,7 +206,7 @@ defmodule CDPEx.Page do
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
-      {:cdp_event, ^conn, @response_method, params, ^sid} ->
+      {:cdp_event, ^conn, @response_received, params, ^sid} ->
         captured =
           if document_response?(params, lid, fid), do: response_summary(params), else: captured
 
@@ -226,18 +238,32 @@ defmodule CDPEx.Page do
     end
   end
 
-  defp document_response?(%{"type" => "Document", "loaderId" => loader} = params, lid, fid) do
+  # The main document response for THIS navigation: type "Document", matching loaderId
+  # (+ frameId when the navigate result carried one), and a well-formed response (an
+  # integer status and a URL). Requiring both keeps the {:ok, page, %{status, url}}
+  # contract honest — a degenerate response missing them is not reported as the landing,
+  # so the call falls through to {:error, {:no_document_response, _}} rather than
+  # returning nils. (Real Chrome always populates both on a Document response.)
+  defp document_response?(
+         %{
+           "type" => "Document",
+           "loaderId" => loader,
+           "response" => %{"status" => status, "url" => url}
+         } = params,
+         lid,
+         fid
+       )
+       when is_integer(status) and is_binary(url) do
     loader == lid and Map.get(params, "frameId", fid) == fid
   end
 
   defp document_response?(_params, _lid, _fid), do: false
 
-  defp response_summary(params) do
-    response = params["response"] || %{}
+  defp response_summary(%{"response" => response}) do
     %{status: response["status"], url: response["url"]}
   end
 
-  # Generic mailbox drain for one cdp method (parallel to drain_lifecycle/1).
+  # Generic mailbox drain for one cdp method.
   defp drain_events(conn, method) do
     receive do
       {:cdp_event, ^conn, ^method, _params, _sid} -> drain_events(conn, method)
@@ -258,7 +284,7 @@ defmodule CDPEx.Page do
         {:error, reason}
 
       :ok ->
-        drain_lifecycle(page.conn)
+        drain_events(page.conn, @lifecycle_method)
         ref = Process.monitor(page.conn)
         deadline = System.monotonic_time(:millisecond) + timeout
 
@@ -270,7 +296,7 @@ defmodule CDPEx.Page do
         after
           Process.demonitor(ref, [:flush])
           safe_unsubscribe(page.conn)
-          drain_lifecycle(page.conn)
+          drain_events(page.conn, @lifecycle_method)
         end
     end
   end
@@ -319,16 +345,6 @@ defmodule CDPEx.Page do
     Connection.unsubscribe(conn, "Page.lifecycleEvent")
   catch
     :exit, _ -> :ok
-  end
-
-  # Flush lifecycle events left in our mailbox (other sessions/names, or stragglers
-  # from a prior navigation) so they don't leak to the caller.
-  defp drain_lifecycle(conn) do
-    receive do
-      {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _sid} -> drain_lifecycle(conn)
-    after
-      0 -> :ok
-    end
   end
 
   defp lifecycle_name(:load), do: "load"

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -187,6 +187,31 @@ defmodule CDPEx.IntegrationTest do
       assert {:ok, "Hello"} = Page.text(page, "#greeting")
     end
 
+    test "navigate/3 response: true reports the post-redirect 200 and final URL", %{
+      page: page,
+      fixture: fixture
+    } do
+      # /redirect 302s to "/", so the reported response must be the FINAL landing
+      # (200 at the root URL), not the redirect hop — correlation is by loaderId.
+      assert {:ok, ^page, %{status: 200, url: url}} =
+               Page.navigate(page, fixture <> "redirect", response: true)
+
+      assert url == fixture
+      assert {:ok, "Hello"} = Page.text(page, "#greeting")
+    end
+
+    test "navigate/3 response: true surfaces a 404 (a clean signal vs a bare {:ok, page})", %{
+      page: page,
+      fixture: fixture
+    } do
+      # A 404 still loads (it has a body), so the default navigate/3 can't tell it
+      # apart from a 200. response: true exposes the status.
+      missing = fixture <> "missing"
+
+      assert {:ok, ^page, %{status: 404, url: ^missing}} =
+               Page.navigate(page, missing, response: true)
+    end
+
     test "evaluate returns a JS value", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       assert {:ok, "CDPEx Fixture"} = Page.evaluate(page, "document.title")

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -98,6 +98,96 @@ defmodule CDPEx.PageTest do
     end
   end
 
+  describe "navigate/3 with response: true" do
+    test "reports the main document's status + final URL, correlated by loaderId", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.navigate(page, "http://example.test/", response: true) end)
+
+      # response: true enables the Network domain first (responseReceived needs it).
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      # Both the lifecycle and responseReceived subscriptions are in place before navigate.
+      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+      wait_until_subscribed(conn, task.pid, "Page.lifecycleEvent")
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      # Two Document responses share this navigation's loaderId — a redirect hop, then
+      # the landing. The last one wins, so the post-redirect 200 is reported, not the 302.
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"type":"Document","loaderId":"L","frameId":"F","response":{"status":302,"url":"http://example.test/"}}})
+      )
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"type":"Document","loaderId":"L","frameId":"F","response":{"status":200,"url":"http://example.test/landed"}}})
+      )
+
+      # The readiness milestone closes the capture window.
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Page.lifecycleEvent","params":{"name":"networkAlmostIdle"}})
+      )
+
+      assert {:ok, %Page{}, %{status: 200, url: "http://example.test/landed"}} = Task.await(task)
+    end
+
+    test "ignores a Document response from another navigation (loaderId mismatch)", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task =
+        Task.async(fn ->
+          Page.navigate(page, "http://example.test/", response: true, timeout: 300)
+        end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      # A Document response carrying a *different* loaderId must not be mistaken for
+      # ours; with no matching response by the deadline, navigate reports the miss.
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"type":"Document","loaderId":"OTHER","frameId":"F","response":{"status":200,"url":"http://example.test/other"}}})
+      )
+
+      assert {:error, {:no_document_response, "http://example.test/"}} = Task.await(task)
+    end
+
+    test "the default navigate/3 still returns a bare {:ok, page} (no response capture)", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.navigate(page, "http://example.test/") end)
+
+      # No Network.enable on the default path — it only subscribes to lifecycle.
+      wait_until_subscribed(conn, task.pid, "Page.lifecycleEvent")
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Page.lifecycleEvent","params":{"name":"networkAlmostIdle"}})
+      )
+
+      assert {:ok, %Page{}} = Task.await(task)
+    end
+  end
+
   describe "authenticate/4 source validation" do
     # A bad :source short-circuits before Browser.authenticate, so these never touch
     # the (test-process) browser — they exercise the boundary guard in isolation.

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -145,7 +145,7 @@ defmodule CDPEx.PageTest do
     } do
       task =
         Task.async(fn ->
-          Page.navigate(page, "http://example.test/", response: true, timeout: 300)
+          Page.navigate(page, "http://example.test/", response: true, timeout: 1_000)
         end)
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
@@ -185,6 +185,59 @@ defmodule CDPEx.PageTest do
       )
 
       assert {:ok, %Page{}} = Task.await(task)
+    end
+
+    test "wait_until: :none returns on the document response itself (no milestone wait)", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task =
+        Task.async(fn ->
+          Page.navigate(page, "http://example.test/", response: true, wait_until: :none)
+        end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      # With :none there is NO lifecycle milestone — the matching Document response is
+      # itself the completion signal, so the call returns without a networkAlmostIdle.
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"type":"Document","loaderId":"L","frameId":"F","response":{"status":200,"url":"http://example.test/landed"}}})
+      )
+
+      assert {:ok, %Page{}, %{status: 200, url: "http://example.test/landed"}} = Task.await(task)
+    end
+
+    test "a connection death mid-capture surfaces as an error (never hangs)", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.navigate(page, "http://example.test/", response: true) end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      # The task is now in await_capture (which monitors the conn). Drop the connection
+      # before any document response: the wait must end with an error, not hang. Either
+      # the await_capture {:DOWN} (-> {:ws_closed, _}) or the in-flight call (-> :noproc)
+      # wins the race; both are clean errors.
+      Connection.close(conn)
+
+      assert {:error, reason} = Task.await(task)
+      assert reason == :noproc or match?({:ws_closed, _}, reason)
     end
   end
 

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -40,15 +40,31 @@ defmodule CDPEx.FixtureServer do
 
   @basic_auth "Basic " <> Base.encode64("cdpex:secret")
 
-  # /basic-auth gates on HTTP Basic credentials (cdpex:secret): without a valid
-  # Authorization header it answers 401 + WWW-Authenticate, so Chrome — and an armed
-  # CDPEx.Page.authenticate — receives an auth challenge. Any other path serves the page.
+  # Path routing:
+  #   /basic-auth — gates on HTTP Basic credentials (cdpex:secret): without a valid
+  #     Authorization header it answers 401 + WWW-Authenticate, so Chrome — and an armed
+  #     CDPEx.Page.authenticate — receives an auth challenge.
+  #   /redirect   — 302 to "/", so navigate(response: true) can prove it reports the
+  #     FINAL (post-redirect) 200, not the redirect hop.
+  #   /missing    — a genuine 404 (with a body, so Chrome still paints it).
+  #   anything else serves the page.
   defp respond(request) do
-    if String.starts_with?(request_path(request), "/basic-auth") and not authorized?(request) do
-      body = ~s(<!doctype html><html><body><p id="status">401</p></body></html>)
-      http_response("401 Unauthorized", body, ["WWW-Authenticate: Basic realm=\"cdpex\""])
-    else
-      http_response("200 OK", render(request), [])
+    path = request_path(request)
+
+    cond do
+      String.starts_with?(path, "/basic-auth") and not authorized?(request) ->
+        body = ~s(<!doctype html><html><body><p id="status">401</p></body></html>)
+        http_response("401 Unauthorized", body, ["WWW-Authenticate: Basic realm=\"cdpex\""])
+
+      String.starts_with?(path, "/redirect") ->
+        http_response("302 Found", "", ["Location: /"])
+
+      String.starts_with?(path, "/missing") ->
+        body = ~s(<!doctype html><html><body><p id="status">404</p></body></html>)
+        http_response("404 Not Found", body, [])
+
+      true ->
+        http_response("200 OK", render(request), [])
     end
   end
 


### PR DESCRIPTION
## What

`navigate/3` returned `{:ok, page}` for a 403 wall, a 404, or a redirect-to-login exactly as for a real 200 — there was no clean signal for "did I land on the real page". This adds an opt-in third tuple element:

```elixir
{:ok, page, %{status: 200, url: final_url}} =
  Page.navigate(page, url, response: true)
```

- **`status`** — the main document's HTTP status.
- **`url`** — the final URL after redirects.

Correlation is by **`loaderId`** (authoritative; survives redirects): the one `Network.responseReceived` of `type: "Document"` whose `loaderId` matches the `Page.navigate` result. Redirect hops ride `requestWillBeSent.redirectResponse`, so the single landing response is the right one — and if more than one Document response shares the loaderId, the **last** wins (post-redirect landing).

## Design

- The **default path is untouched** — `navigate/3` still returns the bare `{:ok, page}`, so existing `with`-pipelines keep working. The capture logic lives in its own `navigate_capturing_response/4` parallel to `navigate_with_wait/4`; the hot path doesn't pay for it.
- `response: true` **lazily enables the `Network` domain** (`responseReceived` requires it).
- No main-document response by the time the readiness wait ends → `{:error, {:no_document_response, url}}` — a real failure for the status-detection use case (rather than a misleading `%{status: nil}`).
- `@spec` widened to `{:ok, t()} | {:ok, t(), map()} | {:error, term()}`; `{:no_document_response, String.t()}` added to `CDPEx.error_reason/0`.

## Tests

- **Unit (FakeCDP):** last-wins redirect correlation (302 then 200, same loaderId → reports the 200); a Document response with a *different* loaderId is ignored → `{:no_document_response, _}`; the default `navigate/3` still returns a bare `{:ok, page}` with no `Network.enable`.
- **Integration:** `CDPEx.FixtureServer` gains `/redirect` (302→`/`) and `/missing` (404). Asserts `%{status: 200, url: <root>}` post-redirect and `%{status: 404, url: <missing>}`.

`mix ci` green (format, deps.audit, compile + docs `--warnings-as-errors`, credo, dialyzer, unit). Full integration suite green (46 tests, 0 failures); zero orphan Chrome after the run.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)