### PR TITLE
Add wait_for_response/3 and wait_for_network_idle/2 (SPA readiness) (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - `CDPEx.Page.navigate/3` accepts `response: true` to return `{:ok, page, %{status, url}}` — the main document's HTTP status and final (post-redirect) URL, correlated to the navigation by its `loaderId`. Lets callers detect a 403 wall / 404 / login-redirect instead of treating every navigation as success. Lazily enables the `Network` domain; returns `{:error, {:no_document_response, url}}` when no document response arrives (#31).
+- `CDPEx.Page.wait_for_response/3` blocks until a network response whose URL matches a function / `Regex` / substring arrives, returning the `Network.responseReceived` params (HTTP status + `requestId` for a follow-up `response_body/3`) — for an XHR/`fetch` kicked off by a `click/3` (#32).
+- `CDPEx.Page.wait_for_network_idle/2` blocks until the network is idle (≤ `:max_inflight` in-flight requests for `:idle_time` ms continuously) — the Puppeteer "networkidle" primitive for waiting out SPA hydration (#32).
 
 ### Breaking
+- `CDPEx.Connection.await_event/4` now returns `{:ok, params}` (the matched event's params) on a match, instead of a bare `:ok` (#32).
 - Request interception ↔ `authenticate/4` mutual exclusion is now **enforced** (it previously failed silently — returning a misleading `:ok` while breaking the page, since both drive the `Fetch` domain). On the same page: `enable_request_interception/2` returns `{:error, {:conflict, :authenticated}}` when the page is authenticated, `authenticate/4` returns `{:error, {:conflict, :intercepting}}` when it's intercepting, and re-enabling interception returns `{:error, :already_intercepting}` (was `:ok`). Interception also now rejects a `:session`-transport page with `{:error, {:unsupported_transport, :session}}`, matching `authenticate/4`. Update any caller that only matched `:ok` on these paths (#30).
 
 ### Fixed

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -115,15 +115,16 @@ defmodule CDPEx.Connection do
   @doc """
   Blocks until an event for which `matcher.(params)` returns true, or `timeout`.
 
-  `matcher` receives the event params map. Returns `:ok` on a match, or
-  `{:error, reason}` where reason is `{:timeout, :await_event}` (no matching event
-  in time) or `:noproc` / `{:ws_closed, _}` (the connection itself went away) —
-  callers must be able to tell those apart.
+  `matcher` receives the event params map. Returns `{:ok, params}` (the matched
+  event's params) on a match, or `{:error, reason}` where reason is
+  `{:timeout, :await_event}` (no matching event in time) or `:noproc` /
+  `{:ws_closed, _}` (the connection itself went away) — callers must be able to
+  tell those apart.
 
   Pass `opts` with `session_id: sid` to only match events from that session.
   """
   @spec await_event(GenServer.server(), (map() -> boolean()), timeout(), keyword()) ::
-          :ok | {:error, {:timeout, :await_event} | :noproc | {:ws_closed, term()}}
+          {:ok, map()} | {:error, {:timeout, :await_event} | :noproc | {:ws_closed, term()}}
   def await_event(conn, matcher, timeout \\ @default_call_timeout, opts \\ [])
       when is_function(matcher, 1) do
     session_id = Keyword.get(opts, :session_id)
@@ -382,7 +383,7 @@ defmodule CDPEx.Connection do
 
     Enum.each(matched, fn {_matcher, _sid, from, timer} ->
       cancel_timer(timer)
-      GenServer.reply(from, :ok)
+      GenServer.reply(from, {:ok, params})
     end)
 
     %{state | waiters: kept}

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -909,7 +909,7 @@ defmodule CDPEx.Page do
 
       try do
         # Idle from the call onward: arm immediately (0 in-flight <= max_inflight).
-        case await_network_idle(ctx, 0, arm_idle(idle_time)) do
+        case await_network_idle(ctx, %{}, arm_idle(idle_time)) do
           :idle -> :ok
           :timeout -> {:error, :timeout}
           {:down, reason} -> {:error, down_reason(reason)}
@@ -927,34 +927,38 @@ defmodule CDPEx.Page do
     end
   end
 
-  # Count in-flight requests (requestWillBeSent +1; loadingFinished/Failed −1, clamped at
-  # 0 — responseReceived is NOT counted). The idle timer is armed while the count is
-  # at/below the threshold and cancelled when it rises above; when the live timer fires,
-  # the network has stayed idle for the whole window. Scoped to this page's session
-  # (`^sid`); the connection dying or the overall deadline ends the wait.
+  # Track in-flight requests in a map keyed by request id, used as a set (`inflight`), not
+  # a counter: requestWillBeSent adds, loadingFinished/Failed removes; responseReceived is
+  # ignored. A set (vs a +1/−1 delta) is robust to the two ways CDP breaks a naive counter:
+  #   * a redirect re-emits requestWillBeSent for the SAME id (a no-op re-add) yet fires
+  #     only one terminal event, and
+  #   * a request that started BEFORE this call (its requestWillBeSent never seen) fires a
+  #     terminal event whose id isn't tracked (a no-op remove) — so it can't clear a live
+  #     request's slot and trigger a false idle.
+  # The idle timer is armed while the size is at/below the threshold and cancelled above;
+  # when the live timer fires, the network stayed idle the whole window. Scoped to this
+  # page's session (`^sid`); the connection dying or the overall deadline ends it. (A plain
+  # map, not MapSet, keeps Dialyzer happy with this unspecced recursive helper.)
   defp await_network_idle(
          %{conn: conn, sid: sid, max_inflight: max_inflight, mon: mon, deadline: deadline} = ctx,
          inflight,
          {timer, tag} = idle
        ) do
     receive do
-      {:cdp_event, ^conn, @request_will_be_sent, params, ^sid} ->
-        # A redirect hop re-emits requestWillBeSent for the SAME request (carrying a
-        # `redirectResponse`), but the chain still fires only ONE terminal
-        # loadingFinished/Failed — so count the original request once, never per hop, or
-        # the counter never returns to 0 and a redirecting request never reaches idle.
-        if Map.has_key?(params, "redirectResponse") do
-          await_network_idle(ctx, inflight, idle)
-        else
-          inflight = inflight + 1
-          idle = if inflight > max_inflight, do: disarm_idle(idle), else: idle
-          await_network_idle(ctx, inflight, idle)
-        end
+      {:cdp_event, ^conn, @request_will_be_sent, %{"requestId" => id}, ^sid} ->
+        inflight = Map.put(inflight, id, true)
+        idle = if map_size(inflight) > max_inflight, do: disarm_idle(idle), else: idle
+        await_network_idle(ctx, inflight, idle)
 
-      {:cdp_event, ^conn, method, _params, ^sid}
+      {:cdp_event, ^conn, method, %{"requestId" => id}, ^sid}
       when method in [@loading_finished, @loading_failed] ->
-        inflight = max(inflight - 1, 0)
-        idle = if inflight <= max_inflight and timer == nil, do: arm_idle(ctx.idle_time), else: idle
+        inflight = Map.delete(inflight, id)
+
+        idle =
+          if map_size(inflight) <= max_inflight and timer == nil,
+            do: arm_idle(ctx.idle_time),
+            else: idle
+
         await_network_idle(ctx, inflight, idle)
 
       {:cdp_event, ^conn, _method, _params, _other_sid} ->

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -38,8 +38,14 @@ defmodule CDPEx.Page do
   @command_timeout 10_000
 
   @lifecycle_method "Page.lifecycleEvent"
+  @request_will_be_sent "Network.requestWillBeSent"
   @response_received "Network.responseReceived"
-  @network_events ["Network.requestWillBeSent", @response_received]
+  @loading_finished "Network.loadingFinished"
+  @loading_failed "Network.loadingFailed"
+  @network_events [@request_will_be_sent, @response_received]
+  # In-flight accounting for wait_for_network_idle/2: requestWillBeSent (+1),
+  # loadingFinished / loadingFailed (−1). responseReceived is deliberately excluded.
+  @idle_events [@request_will_be_sent, @loading_finished, @loading_failed]
   @fetch_paused "Fetch.requestPaused"
 
   @enforce_keys [:browser, :conn, :target_id]
@@ -786,6 +792,204 @@ defmodule CDPEx.Page do
 
       {:error, _} = error ->
         error
+    end
+  end
+
+  @doc """
+  Blocks until a network response whose URL matches `matcher` arrives, or `timeout`.
+
+  Useful after a `click/3` (or other in-page action) that triggers an XHR/`fetch`:
+  wait for the specific response, then read it with `response_body/3` (the returned
+  params carry the `"requestId"`).
+
+  `matcher` selects on the response URL and may be:
+
+    * a **function** `(url :: String.t() -> boolean())`,
+    * a **`Regex`** (matched against the URL), or
+    * a **binary** substring (matched with `String.contains?/2`).
+
+  Returns `{:ok, params}` — the full `Network.responseReceived` params (HTTP status
+  under `params["response"]["status"]`, request id under `params["requestId"]`) — or
+  `{:error, :timeout}` if nothing matched in time, or `{:error, reason}` if the
+  connection drops. Lazily enables the `Network` domain. Only responses observed
+  **after** this call are considered, so call it before triggering the request.
+
+  Options: `:timeout` — ms (default 30_000).
+  """
+  @spec wait_for_response(t(), (String.t() -> boolean()) | Regex.t() | String.t(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def wait_for_response(%__MODULE__{} = page, matcher, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, @navigate_timeout)
+    predicate = response_url_predicate(matcher)
+
+    with :ok <- ensure_network(page, timeout) do
+      case Connection.await_event(page.conn, predicate, timeout, session_id: page.session_id) do
+        {:ok, params} -> {:ok, params}
+        {:error, {:timeout, :await_event}} -> {:error, :timeout}
+        {:error, _} = error -> error
+      end
+    end
+  end
+
+  # Build a params-predicate from the public URL matcher (function / Regex / substring),
+  # always guarding that the event actually carries a response URL — so it fires only on
+  # a Network.responseReceived, never a request or lifecycle event.
+  defp response_url_predicate(fun) when is_function(fun, 1) do
+    fn params -> match_response_url(params, fun) end
+  end
+
+  defp response_url_predicate(%Regex{} = regex) do
+    fn params -> match_response_url(params, &Regex.match?(regex, &1)) end
+  end
+
+  defp response_url_predicate(substring) when is_binary(substring) do
+    fn params -> match_response_url(params, &String.contains?(&1, substring)) end
+  end
+
+  defp match_response_url(%{"response" => %{"url" => url}}, fun) when is_binary(url), do: fun.(url)
+  defp match_response_url(_params, _fun), do: false
+
+  @doc """
+  Blocks until the network has been idle — at most `:max_inflight` in-flight requests —
+  for `:idle_time` ms continuously, or `timeout`.
+
+  The Puppeteer "networkidle" primitive: use it after a `click/3` (or other action)
+  that kicks off XHR/`fetch` hydration to wait for the page to settle. Idleness is
+  measured **from the call onward** — requests already in flight when you call are not
+  counted — so call it right after triggering the work.
+
+  Returns `:ok` once idle, `{:error, :timeout}` if it never settles within `timeout`
+  (e.g. a streaming / SSE / long-poll connection that never closes), or
+  `{:error, reason}` if the connection drops. Lazily enables the `Network` domain.
+
+  Options:
+    * `:idle_time` — ms of continuous idleness required (default 500)
+    * `:max_inflight` — in-flight requests still considered idle (default 0; 2 is
+      Puppeteer's `networkidle2`)
+    * `:timeout` — overall ceiling in ms (default 30_000)
+  """
+  @spec wait_for_network_idle(t(), keyword()) :: :ok | {:error, term()}
+  def wait_for_network_idle(%__MODULE__{} = page, opts \\ []) do
+    idle_time = Keyword.get(opts, :idle_time, 500)
+    max_inflight = Keyword.get(opts, :max_inflight, 0)
+    timeout = Keyword.get(opts, :timeout, @navigate_timeout)
+
+    # Subscribe BEFORE enabling so a request that starts the instant the domain turns
+    # on is counted (mirrors observe_network/2); roll the subscriptions back if enable fails.
+    with :ok <- subscribe_each(page.conn, @idle_events),
+         :ok <- ensure_network(page, timeout) do
+      Enum.each(@idle_events, &drain_events(page.conn, &1))
+      ref = Process.monitor(page.conn)
+
+      ctx = %{
+        conn: page.conn,
+        sid: page.session_id,
+        max_inflight: max_inflight,
+        idle_time: idle_time,
+        mon: ref,
+        deadline: System.monotonic_time(:millisecond) + timeout
+      }
+
+      try do
+        # Idle from the call onward: arm immediately (0 in-flight <= max_inflight).
+        case await_network_idle(ctx, 0, arm_idle(idle_time)) do
+          :idle -> :ok
+          :timeout -> {:error, :timeout}
+          {:down, reason} -> {:error, down_reason(reason)}
+        end
+      after
+        Process.demonitor(ref, [:flush])
+        unsubscribe_each(page.conn, @idle_events)
+        Enum.each(@idle_events, &drain_events(page.conn, &1))
+        drain_idle_ticks()
+      end
+    else
+      {:error, _} = error ->
+        unsubscribe_each(page.conn, @idle_events)
+        error
+    end
+  end
+
+  # Count in-flight requests (requestWillBeSent +1; loadingFinished/Failed −1, clamped at
+  # 0 — responseReceived is NOT counted). The idle timer is armed while the count is
+  # at/below the threshold and cancelled when it rises above; when the live timer fires,
+  # the network has stayed idle for the whole window. Scoped to this page's session
+  # (`^sid`); the connection dying or the overall deadline ends the wait.
+  defp await_network_idle(
+         %{conn: conn, sid: sid, max_inflight: max_inflight, mon: mon, deadline: deadline} = ctx,
+         inflight,
+         {timer, tag} = idle
+       ) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:cdp_event, ^conn, @request_will_be_sent, _params, ^sid} ->
+        inflight = inflight + 1
+
+        idle =
+          if inflight > max_inflight and timer != nil do
+            _ = Process.cancel_timer(timer)
+            {nil, nil}
+          else
+            idle
+          end
+
+        await_network_idle(ctx, inflight, idle)
+
+      {:cdp_event, ^conn, method, _params, ^sid}
+      when method in [@loading_finished, @loading_failed] ->
+        inflight = max(inflight - 1, 0)
+        idle = if inflight <= max_inflight and timer == nil, do: arm_idle(ctx.idle_time), else: idle
+        await_network_idle(ctx, inflight, idle)
+
+      {:cdp_event, ^conn, _method, _params, _other_sid} ->
+        # Another session's event on a shared :session connection — ignore.
+        await_network_idle(ctx, inflight, idle)
+
+      {:idle_tick, ^tag} ->
+        :idle
+
+      {:idle_tick, _stale} ->
+        # A cancelled timer that had already fired — ignore.
+        await_network_idle(ctx, inflight, idle)
+
+      {:DOWN, ^mon, :process, ^conn, reason} ->
+        cancel_idle(idle)
+        {:down, reason}
+    after
+      remaining ->
+        # Exact deadline-vs-DOWN tie: prefer a just-landed {:DOWN} over a stale timeout.
+        receive do
+          {:DOWN, ^mon, :process, ^conn, reason} ->
+            cancel_idle(idle)
+            {:down, reason}
+        after
+          0 ->
+            cancel_idle(idle)
+            :timeout
+        end
+    end
+  end
+
+  # A ref-tagged one-shot timer; the tag identifies *this* arming, so a stale fire from a
+  # cancelled-but-already-delivered timer is ignored by the receive.
+  defp arm_idle(idle_time) do
+    tag = make_ref()
+    {Process.send_after(self(), {:idle_tick, tag}, idle_time), tag}
+  end
+
+  defp cancel_idle({nil, _tag}), do: :ok
+
+  defp cancel_idle({timer, _tag}) do
+    _ = Process.cancel_timer(timer)
+    :ok
+  end
+
+  defp drain_idle_ticks do
+    receive do
+      {:idle_tick, _tag} -> drain_idle_ticks()
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -315,10 +315,10 @@ defmodule CDPEx.Page do
     remaining = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
-      {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => ^name}, ^sid} ->
+      {:cdp_event, ^conn, @lifecycle_method, %{"name" => ^name}, ^sid} ->
         :reached
 
-      {:cdp_event, ^conn, "Page.lifecycleEvent", _params, _session_id} ->
+      {:cdp_event, ^conn, @lifecycle_method, _params, _session_id} ->
         await_lifecycle(page, name, ref, deadline)
 
       {:DOWN, ^ref, :process, ^conn, reason} ->
@@ -342,13 +342,13 @@ defmodule CDPEx.Page do
   # dies mid-navigation) would otherwise make them exit and crash navigate/3 —
   # which must instead return {:error, _}. Treat (un)subscription as best-effort.
   defp safe_subscribe(conn) do
-    Connection.subscribe(conn, "Page.lifecycleEvent")
+    Connection.subscribe(conn, @lifecycle_method)
   catch
     :exit, _ -> {:error, :noproc}
   end
 
   defp safe_unsubscribe(conn) do
-    Connection.unsubscribe(conn, "Page.lifecycleEvent")
+    Connection.unsubscribe(conn, @lifecycle_method)
   catch
     :exit, _ -> :ok
   end
@@ -814,16 +814,25 @@ defmodule CDPEx.Page do
   connection drops. Lazily enables the `Network` domain. Only responses observed
   **after** this call are considered, so call it before triggering the request.
 
+  > #### Returns `{:ok, params}`, not a bare `:ok` {: .info}
+  >
+  > Unlike `wait_for_navigation/2` / `wait_for_selector/3` / `wait_for_network_idle/2`
+  > (which return `:ok`), this returns the matched event — match on `{:ok, params}`.
+
   Options: `:timeout` — ms (default 30_000).
   """
   @spec wait_for_response(t(), (String.t() -> boolean()) | Regex.t() | String.t(), keyword()) ::
           {:ok, map()} | {:error, term()}
   def wait_for_response(%__MODULE__{} = page, matcher, opts \\ []) do
-    timeout = Keyword.get(opts, :timeout, @navigate_timeout)
+    deadline = System.monotonic_time(:millisecond) + Keyword.get(opts, :timeout, @navigate_timeout)
     predicate = response_url_predicate(matcher)
 
-    with :ok <- ensure_network(page, timeout) do
-      case Connection.await_event(page.conn, predicate, timeout, session_id: page.session_id) do
+    # One deadline for the whole call so :timeout is a true overall ceiling: the lazy
+    # Network.enable and the await draw from the same budget.
+    with :ok <- ensure_network(page, remaining(deadline)) do
+      case Connection.await_event(page.conn, predicate, remaining(deadline),
+             session_id: page.session_id
+           ) do
         {:ok, params} -> {:ok, params}
         {:error, {:timeout, :await_event}} -> {:error, :timeout}
         {:error, _} = error -> error
@@ -862,6 +871,13 @@ defmodule CDPEx.Page do
   (e.g. a streaming / SSE / long-poll connection that never closes), or
   `{:error, reason}` if the connection drops. Lazily enables the `Network` domain.
 
+  > #### Don't combine with `observe_network/2` on the same page {: .warning}
+  >
+  > This subscribes the calling process to the `Network` request-lifecycle events for
+  > the duration of the call, then unsubscribes on the way out. If the *same process*
+  > is also running `observe_network/2` on this page, that subscription is torn down.
+  > Drive the idle wait from a process that isn't also observing the network.
+
   Options:
     * `:idle_time` — ms of continuous idleness required (default 500)
     * `:max_inflight` — in-flight requests still considered idle (default 0; 2 is
@@ -872,12 +888,13 @@ defmodule CDPEx.Page do
   def wait_for_network_idle(%__MODULE__{} = page, opts \\ []) do
     idle_time = Keyword.get(opts, :idle_time, 500)
     max_inflight = Keyword.get(opts, :max_inflight, 0)
-    timeout = Keyword.get(opts, :timeout, @navigate_timeout)
+    deadline = System.monotonic_time(:millisecond) + Keyword.get(opts, :timeout, @navigate_timeout)
 
-    # Subscribe BEFORE enabling so a request that starts the instant the domain turns
-    # on is counted (mirrors observe_network/2); roll the subscriptions back if enable fails.
+    # Subscribe BEFORE enabling so a request that starts the instant the domain turns on
+    # is counted (mirrors observe_network/2); roll the subscriptions back if enable fails.
+    # One deadline spans enable + the idle wait, so :timeout is a true overall ceiling.
     with :ok <- subscribe_each(page.conn, @idle_events),
-         :ok <- ensure_network(page, timeout) do
+         :ok <- ensure_network(page, remaining(deadline)) do
       Enum.each(@idle_events, &drain_events(page.conn, &1))
       ref = Process.monitor(page.conn)
 
@@ -887,7 +904,7 @@ defmodule CDPEx.Page do
         max_inflight: max_inflight,
         idle_time: idle_time,
         mon: ref,
-        deadline: System.monotonic_time(:millisecond) + timeout
+        deadline: deadline
       }
 
       try do
@@ -920,21 +937,19 @@ defmodule CDPEx.Page do
          inflight,
          {timer, tag} = idle
        ) do
-    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
-
     receive do
-      {:cdp_event, ^conn, @request_will_be_sent, _params, ^sid} ->
-        inflight = inflight + 1
-
-        idle =
-          if inflight > max_inflight and timer != nil do
-            _ = Process.cancel_timer(timer)
-            {nil, nil}
-          else
-            idle
-          end
-
-        await_network_idle(ctx, inflight, idle)
+      {:cdp_event, ^conn, @request_will_be_sent, params, ^sid} ->
+        # A redirect hop re-emits requestWillBeSent for the SAME request (carrying a
+        # `redirectResponse`), but the chain still fires only ONE terminal
+        # loadingFinished/Failed — so count the original request once, never per hop, or
+        # the counter never returns to 0 and a redirecting request never reaches idle.
+        if Map.has_key?(params, "redirectResponse") do
+          await_network_idle(ctx, inflight, idle)
+        else
+          inflight = inflight + 1
+          idle = if inflight > max_inflight, do: disarm_idle(idle), else: idle
+          await_network_idle(ctx, inflight, idle)
+        end
 
       {:cdp_event, ^conn, method, _params, ^sid}
       when method in [@loading_finished, @loading_failed] ->
@@ -954,35 +969,38 @@ defmodule CDPEx.Page do
         await_network_idle(ctx, inflight, idle)
 
       {:DOWN, ^mon, :process, ^conn, reason} ->
-        cancel_idle(idle)
+        _ = disarm_idle(idle)
         {:down, reason}
     after
-      remaining ->
+      remaining(deadline) ->
         # Exact deadline-vs-DOWN tie: prefer a just-landed {:DOWN} over a stale timeout.
         receive do
           {:DOWN, ^mon, :process, ^conn, reason} ->
-            cancel_idle(idle)
+            _ = disarm_idle(idle)
             {:down, reason}
         after
           0 ->
-            cancel_idle(idle)
+            _ = disarm_idle(idle)
             :timeout
         end
     end
   end
 
   # A ref-tagged one-shot timer; the tag identifies *this* arming, so a stale fire from a
-  # cancelled-but-already-delivered timer is ignored by the receive.
+  # cancelled-but-already-delivered timer is ignored by the receive. A non-positive
+  # idle_time is clamped to 0 (Process.send_after would raise on a negative).
   defp arm_idle(idle_time) do
     tag = make_ref()
-    {Process.send_after(self(), {:idle_tick, tag}, idle_time), tag}
+    {Process.send_after(self(), {:idle_tick, tag}, max(idle_time, 0)), tag}
   end
 
-  defp cancel_idle({nil, _tag}), do: :ok
+  # Cancel the idle timer and return the disarmed state ({nil, nil}); idempotent, so it is
+  # safe on a teardown path or when already disarmed.
+  defp disarm_idle({nil, _tag}), do: {nil, nil}
 
-  defp cancel_idle({timer, _tag}) do
+  defp disarm_idle({timer, _tag}) do
     _ = Process.cancel_timer(timer)
-    :ok
+    {nil, nil}
   end
 
   defp drain_idle_ticks do
@@ -992,6 +1010,8 @@ defmodule CDPEx.Page do
       0 -> :ok
     end
   end
+
+  defp remaining(deadline), do: max(deadline - System.monotonic_time(:millisecond), 0)
 
   @doc """
   Enables request interception: pauses matching requests and delivers a

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -191,7 +191,7 @@ defmodule CDPEx.ConnectionTest do
       ~s({"method":"Page.lifecycleEvent","sessionId":"A","params":{"name":"x"}})
     )
 
-    assert :ok = Task.await(task2)
+    assert {:ok, %{"name" => "x"}} = Task.await(task2)
   end
 
   test "await_event resolves when a matching event arrives", %{conn: conn, fake: fake} do
@@ -208,7 +208,7 @@ defmodule CDPEx.ConnectionTest do
       ~s({"method":"Page.lifecycleEvent","params":{"name":"networkAlmostIdle"}})
     )
 
-    assert :ok = Task.await(task)
+    assert {:ok, %{"name" => "networkAlmostIdle"}} = Task.await(task)
   end
 
   test "await_event times out when no event matches", %{conn: conn} do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -314,6 +314,42 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, {:selector_not_found, "#nope"}} = Page.click(page, "#nope")
     end
 
+    test "wait_for_network_idle settles after a click triggers a fetch", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#fetch-btn")
+
+      # Idleness is measured from the call onward, so arm it (in a task) and let it
+      # subscribe BEFORE the click kicks off the fetch.
+      waiter =
+        Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 300, timeout: 5_000) end)
+
+      Process.sleep(200)
+      assert :ok = Page.click(page, "#fetch-btn")
+
+      assert :ok = Task.await(waiter, 10_000)
+      # The fetch resolved during the idle wait — its handler writes the body into #greeting.
+      assert {:ok, "fetched-data"} = Page.text(page, "#greeting")
+    end
+
+    test "wait_for_response returns the matching fetch response", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#fetch-btn")
+
+      # Arm the waiter (it enables Network + registers) before triggering the fetch.
+      waiter = Task.async(fn -> Page.wait_for_response(page, "/data", timeout: 5_000) end)
+      Process.sleep(200)
+      assert :ok = Page.click(page, "#fetch-btn")
+
+      assert {:ok, %{"requestId" => req, "response" => %{"status" => 200, "url" => url}}} =
+               Task.await(waiter, 10_000)
+
+      assert url =~ "/data"
+      assert {:ok, "fetched-data"} = Page.response_body(page, req)
+    end
+
     test "screenshot returns PNG bytes and can write a file", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       :ok = Page.wait_for_selector(page, "#greeting")

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -350,6 +350,25 @@ defmodule CDPEx.IntegrationTest do
       assert {:ok, "fetched-data"} = Page.response_body(page, req)
     end
 
+    test "wait_for_network_idle settles even when the fetch redirects", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = Page.wait_for_selector(page, "#redirect-fetch-btn")
+
+      waiter =
+        Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 300, timeout: 5_000) end)
+
+      Process.sleep(200)
+      assert :ok = Page.click(page, "#redirect-fetch-btn")
+
+      # The fetch hits /redirect (302 → /). The redirect hop must not leave a phantom
+      # in-flight request, or this hangs to the timeout — regression guard for the
+      # requestWillBeSent-per-hop overcount.
+      assert :ok = Task.await(waiter, 10_000)
+    end
+
     test "screenshot returns PNG bytes and can write a file", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       :ok = Page.wait_for_selector(page, "#greeting")

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -814,6 +814,27 @@ defmodule CDPEx.PageTest do
       assert :ok = Task.await(task, 3_000)
     end
 
+    test "a completion for a request started before the call doesn't cause a false idle", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 150, timeout: 5_000) end)
+      enable_network_idle(fake, conn, task.pid)
+
+      # A NEW request (seen after the call) is in flight.
+      send_network_event(fake, "Network.requestWillBeSent", "NEW")
+
+      # A request that started BEFORE the call completes during the wait. Its id was never
+      # tracked, so its terminal event must NOT clear NEW's slot — the wait stays busy.
+      send_network_event(fake, "Network.loadingFinished", "PRECALL")
+      refute Task.yield(task, 300), "false idle: a pre-call completion cleared a live request"
+
+      # NEW completes → genuinely idle.
+      send_network_event(fake, "Network.loadingFinished", "NEW")
+      assert :ok = Task.await(task, 3_000)
+    end
+
     test "max_inflight: 2 stays idle at the threshold, busies above it", %{
       page: page,
       conn: conn,

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -33,6 +33,7 @@ defmodule CDPEx.PageTest do
   alias CDPEx.PageTest.StubBrowser
 
   @network_methods ["Network.requestWillBeSent", "Network.responseReceived"]
+  @idle_methods ["Network.requestWillBeSent", "Network.loadingFinished", "Network.loadingFailed"]
 
   setup do
     # The test process owns the linked connection (via start_link), so trap exits
@@ -696,6 +697,34 @@ defmodule CDPEx.PageTest do
 
       assert {:error, :timeout} = Task.await(task)
     end
+
+    test "accepts a Regex matcher over the response URL", %{page: page, conn: conn, fake: fake} do
+      task = Task.async(fn -> Page.wait_for_response(page, ~r{/api/v\d+/data}, timeout: 2_000) end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+      wait_until_waiting(conn)
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"requestId":"R1","response":{"url":"http://x/api/v2/data","status":200}}})
+      )
+
+      assert {:ok, %{"requestId" => "R1"}} = Task.await(task)
+    end
+
+    test "errors if the connection drops while awaiting", %{page: page, conn: conn, fake: fake} do
+      task = Task.async(fn -> Page.wait_for_response(page, "/never", timeout: 3_000) end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+      wait_until_waiting(conn)
+
+      Connection.close(conn)
+
+      assert {:error, reason} = Task.await(task, 2_000)
+      assert reason == :noproc or match?({:ws_closed, _}, reason)
+    end
   end
 
   describe "wait_for_network_idle/2" do
@@ -760,6 +789,111 @@ defmodule CDPEx.PageTest do
       assert {:error, reason} = Task.await(task, 2_000)
       assert reason == :noproc or match?({:ws_closed, _}, reason)
     end
+
+    test "does not count redirect hops (requestWillBeSent carrying redirectResponse)", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 150, timeout: 3_000) end)
+      enable_network_idle(fake, conn, task.pid)
+
+      # A redirecting request: the initial requestWillBeSent (+1), then a redirect hop
+      # (requestWillBeSent carrying redirectResponse — must NOT add another +1), then the
+      # single terminal loadingFinished (−1). Net 0 → idle. Pre-fix this stuck at +1 →
+      # {:error, :timeout}.
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.requestWillBeSent","params":{"requestId":"R1","redirectResponse":{"status":302}}})
+      )
+
+      send_network_event(fake, "Network.loadingFinished", "R1")
+
+      assert :ok = Task.await(task, 3_000)
+    end
+
+    test "max_inflight: 2 stays idle at the threshold, busies above it", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task =
+        Task.async(fn ->
+          Page.wait_for_network_idle(page, max_inflight: 2, idle_time: 150, timeout: 5_000)
+        end)
+
+      enable_network_idle(fake, conn, task.pid)
+
+      # 3 in flight (> max_inflight 2) → busy: must not resolve even past idle_time.
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+      send_network_event(fake, "Network.requestWillBeSent", "R2")
+      send_network_event(fake, "Network.requestWillBeSent", "R3")
+      refute Task.yield(task, 300), "resolved while 3 requests were in flight (max_inflight: 2)"
+
+      # Drop back to 2 (≤ threshold) → the idle timer rearms and resolves.
+      send_network_event(fake, "Network.loadingFinished", "R3")
+      assert :ok = Task.await(task, 3_000)
+    end
+
+    test "a new request resets the idle timer (armed → cancelled → rearmed)", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 200, timeout: 5_000) end)
+      enable_network_idle(fake, conn, task.pid)
+
+      # Request then complete → the idle timer arms (in-flight 0).
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+      send_network_event(fake, "Network.loadingFinished", "R1")
+      Process.sleep(60)
+
+      # A new request before idle_time elapses must cancel the armed timer (busy again).
+      send_network_event(fake, "Network.requestWillBeSent", "R2")
+      refute Task.yield(task, 300), "resolved despite a new request before idle_time"
+
+      # Complete it → rearm → resolve.
+      send_network_event(fake, "Network.loadingFinished", "R2")
+      assert :ok = Task.await(task, 3_000)
+    end
+
+    test "rolls back idle subscriptions when Network.enable fails", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      test = self()
+
+      # Run from a long-lived helper (not a Task that exits) so post-rollback state
+      # reflects the explicit unsubscribe, not the connection's dead-subscriber prune.
+      runner =
+        spawn_link(fn ->
+          send(
+            test,
+            {:idle_result, Page.wait_for_network_idle(page, idle_time: 100, timeout: 1_000)}
+          )
+
+          receive do
+            :stop -> :ok
+          after
+            5_000 -> :ok
+          end
+        end)
+
+      for m <- @idle_methods, do: wait_until_subscribed(conn, runner, m)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"error":{"code":-32000,"message":"boom"}}))
+
+      assert_receive {:idle_result, {:error, {:cdp_error, "Network.enable", _}}}, 2_000
+
+      # The enable failed → the subscribe-before-enable subscriptions were rolled back.
+      for m <- @idle_methods, do: refute(subscribed?(conn, runner, m))
+
+      send(runner, :stop)
+    end
   end
 
   # Poll until `pid` is registered as a `method` subscriber on `conn`, so events sent
@@ -791,8 +925,6 @@ defmodule CDPEx.PageTest do
       true -> Process.sleep(10) && wait_until_waiting(conn, retries - 1)
     end
   end
-
-  @idle_methods ["Network.requestWillBeSent", "Network.loadingFinished", "Network.loadingFailed"]
 
   # Answer the Network.enable that wait_for_network_idle/2 issues. When `conn`/`pid` are
   # given, first wait until the three idle subscriptions are registered (subscribe runs

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -640,6 +640,128 @@ defmodule CDPEx.PageTest do
     end
   end
 
+  describe "wait_for_response/3" do
+    test "resolves on the first response whose URL matches, returning its params", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.wait_for_response(page, "/api/data", timeout: 2_000) end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      # await_event registers a connection-side waiter (no subscription) — wait for it,
+      # then feed a non-matching response before the match.
+      wait_until_waiting(conn)
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"requestId":"R0","response":{"url":"http://x/other","status":200}}})
+      )
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"requestId":"R1","response":{"url":"http://x/api/data","status":201}}})
+      )
+
+      assert {:ok,
+              %{"requestId" => "R1", "response" => %{"status" => 201, "url" => "http://x/api/data"}}} =
+               Task.await(task)
+    end
+
+    test "accepts a function matcher over the response URL", %{page: page, conn: conn, fake: fake} do
+      task =
+        Task.async(fn ->
+          Page.wait_for_response(page, &String.ends_with?(&1, ".json"), timeout: 2_000)
+        end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+      wait_until_waiting(conn)
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"requestId":"R1","response":{"url":"http://x/feed.json","status":200}}})
+      )
+
+      assert {:ok, %{"requestId" => "R1"}} = Task.await(task)
+    end
+
+    test "maps the await timeout to a bare {:error, :timeout}", %{page: page, fake: fake} do
+      task = Task.async(fn -> Page.wait_for_response(page, ~r/never-matches/, timeout: 150) end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      assert {:error, :timeout} = Task.await(task)
+    end
+  end
+
+  describe "wait_for_network_idle/2" do
+    test "resolves when nothing is in flight from the call onward", %{page: page, fake: fake} do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 100, timeout: 2_000) end)
+      enable_network_idle(fake)
+      assert :ok = Task.await(task, 2_000)
+    end
+
+    test "resolves once in-flight requests complete and the network goes quiet", %{
+      page: page,
+      conn: conn,
+      fake: fake
+    } do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 150, timeout: 3_000) end)
+      enable_network_idle(fake, conn, task.pid)
+
+      # Two requests start (in-flight 2 > 0 → busy, idle timer cancelled), then both end.
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+      send_network_event(fake, "Network.requestWillBeSent", "R2")
+      send_network_event(fake, "Network.loadingFinished", "R1")
+      send_network_event(fake, "Network.loadingFailed", "R2")
+
+      # Back to 0 in flight → the idle timer rearms and fires after idle_time.
+      assert :ok = Task.await(task, 3_000)
+    end
+
+    test "clamps in-flight at zero on extra completions", %{page: page, conn: conn, fake: fake} do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 100, timeout: 2_000) end)
+      enable_network_idle(fake, conn, task.pid)
+
+      # One request, three completions: the counter must clamp at 0 (never negative)
+      # and still resolve.
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+      send_network_event(fake, "Network.loadingFinished", "R1")
+      send_network_event(fake, "Network.loadingFinished", "R1")
+      send_network_event(fake, "Network.loadingFailed", "R1")
+
+      assert :ok = Task.await(task, 2_000)
+    end
+
+    test "times out while a request stays in flight", %{page: page, conn: conn, fake: fake} do
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 200, timeout: 500) end)
+      enable_network_idle(fake, conn, task.pid)
+
+      # A request that never completes keeps in-flight at 1 (> 0), so it never idles.
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+
+      assert {:error, :timeout} = Task.await(task, 2_000)
+    end
+
+    test "errors if the connection drops while waiting", %{page: page, conn: conn, fake: fake} do
+      task =
+        Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 1_000, timeout: 3_000) end)
+
+      enable_network_idle(fake, conn, task.pid)
+
+      # Keep it busy so the idle timer can't fire, then drop the connection.
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+      Connection.close(conn)
+
+      assert {:error, reason} = Task.await(task, 2_000)
+      assert reason == :noproc or match?({:ws_closed, _}, reason)
+    end
+  end
+
   # Poll until `pid` is registered as a `method` subscriber on `conn`, so events sent
   # afterward are guaranteed to be delivered to it (no send/subscribe race).
   defp wait_until_subscribed(conn, pid, method \\ "Page.lifecycleEvent", retries \\ 100) do
@@ -658,5 +780,33 @@ defmodule CDPEx.PageTest do
 
   defp subscribed?(conn, pid, method) do
     MapSet.member?(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new()), pid)
+  end
+
+  # Poll until at least one await_event waiter is registered on `conn` (waiters are not
+  # subscriptions, so they can't be observed via `subscribed?/3`).
+  defp wait_until_waiting(conn, retries \\ 100) do
+    cond do
+      :sys.get_state(conn).waiters != [] -> :ok
+      retries == 0 -> flunk("await_event waiter not registered in time")
+      true -> Process.sleep(10) && wait_until_waiting(conn, retries - 1)
+    end
+  end
+
+  @idle_methods ["Network.requestWillBeSent", "Network.loadingFinished", "Network.loadingFailed"]
+
+  # Answer the Network.enable that wait_for_network_idle/2 issues. When `conn`/`pid` are
+  # given, first wait until the three idle subscriptions are registered (subscribe runs
+  # before enable), so events sent afterward are delivered rather than dropped by the drain.
+  defp enable_network_idle(fake, conn \\ nil, pid \\ nil) do
+    if conn && pid, do: for(m <- @idle_methods, do: wait_until_subscribed(conn, pid, m))
+    assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+    FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+    # Let the task drain stale events and enter the receive loop before the caller sends
+    # events, so they land in the loop rather than being swallowed by the pre-loop drain.
+    if conn && pid, do: Process.sleep(50)
+  end
+
+  defp send_network_event(fake, method, request_id) do
+    FakeCDP.send_text(fake, ~s({"method":"#{method}","params":{"requestId":"#{request_id}"}}))
   end
 end

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -48,7 +48,7 @@ defmodule CDPEx.FixtureServer do
   #     FINAL (post-redirect) 200, not the redirect hop.
   #   /missing    — a genuine 404 (with a body, so Chrome still paints it).
   #   /data       — a tiny XHR/fetch target (the #fetch-btn calls it), for the
-  #     wait_for_response/2 and wait_for_network_idle/2 paths.
+  #     wait_for_response/3 and wait_for_network_idle/2 paths.
   #   anything else serves the page.
   defp respond(request) do
     path = request_path(request)

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -47,6 +47,8 @@ defmodule CDPEx.FixtureServer do
   #   /redirect   — 302 to "/", so navigate(response: true) can prove it reports the
   #     FINAL (post-redirect) 200, not the redirect hop.
   #   /missing    — a genuine 404 (with a body, so Chrome still paints it).
+  #   /data       — a tiny XHR/fetch target (the #fetch-btn calls it), for the
+  #     wait_for_response/2 and wait_for_network_idle/2 paths.
   #   anything else serves the page.
   defp respond(request) do
     path = request_path(request)
@@ -62,6 +64,9 @@ defmodule CDPEx.FixtureServer do
       String.starts_with?(path, "/missing") ->
         body = ~s(<!doctype html><html><body><p id="status">404</p></body></html>)
         http_response("404 Not Found", body, [])
+
+      String.starts_with?(path, "/data") ->
+        http_response("200 OK", "fetched-data", [])
 
       true ->
         http_response("200 OK", render(request), [])
@@ -99,6 +104,7 @@ defmodule CDPEx.FixtureServer do
       <body>
         <h1 id="greeting">Hello</h1>
         <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
+        <button id="fetch-btn" onclick="fetch('/data').then(r => r.text()).then(t => { document.getElementById('greeting').textContent = t; })">Fetch</button>
         <div id="echo-header">#{echo}</div>
       </body>
     </html>

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -105,6 +105,7 @@ defmodule CDPEx.FixtureServer do
         <h1 id="greeting">Hello</h1>
         <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
         <button id="fetch-btn" onclick="fetch('/data').then(r => r.text()).then(t => { document.getElementById('greeting').textContent = t; })">Fetch</button>
+        <button id="redirect-fetch-btn" onclick="fetch('/redirect')">RedirectFetch</button>
         <div id="echo-header">#{echo}</div>
       </body>
     </html>


### PR DESCRIPTION
## What

Two readiness primitives for **single-page apps** — waiting out XHR/`fetch` hydration triggered by a `click/3` (or any in-page action). Until now the only readiness signal was `navigate/3`'s per-navigation lifecycle wait, which doesn't help once the page is loaded and hydrating.

### `wait_for_response/3`
Blocks until a network response whose URL matches arrives:
```elixir
{:ok, params} = Page.wait_for_response(page, "/api/data")          # substring
{:ok, params} = Page.wait_for_response(page, ~r{/api/\d+})         # Regex
{:ok, params} = Page.wait_for_response(page, &String.ends_with?(&1, ".json"))  # fn
```
Returns the full `Network.responseReceived` params — HTTP status under `params["response"]["status"]`, request id under `params["requestId"]` for a follow-up `response_body/3`. Built on the connection-side `await_event` waiter (no subscription); the predicate guards on `response.url`, so it only fires on a `responseReceived`, never a request/lifecycle event. Lazily enables `Network`; maps the await timeout to a bare `{:error, :timeout}`.

### `wait_for_network_idle/2`
Blocks until at most `:max_inflight` requests are in flight for `:idle_time` ms continuously — Puppeteer's "networkidle" (default `networkidle0`):
```elixir
:ok = Page.click(page, "#load-more")
:ok = Page.wait_for_network_idle(page)                       # ≤0 in-flight for 500ms
:ok = Page.wait_for_network_idle(page, max_inflight: 2)      # networkidle2
```
A subscriber-driven receive loop counts `requestWillBeSent` (+1) / `loadingFinished`+`loadingFailed` (−1, clamped at 0 — `responseReceived` is **not** counted). The idle timer is armed while the count is at/below the threshold and cancelled when it rises above; a **ref-tagged** tick means a cancelled-but-already-fired timer can't false-resolve. Idleness is measured **from the call onward** (in-flight-before-the-call isn't counted — matches the post-`click` hydration use case). Monitors the connection and bounds the whole wait by `:timeout`.

## Supporting change (breaking, low-level)

`CDPEx.Connection.await_event/4` now returns **`{:ok, params}`** (the matched event) instead of a bare `:ok`, so callers get the payload (this is what makes `wait_for_response` useful). Spec/doc updated; the two `connection_test` success asserts updated. Zero other callers.

## Tests

- **Unit (FakeCDP):** `wait_for_response` — non-matching-then-match, function matcher, timeout→`:timeout`. `wait_for_network_idle` — idle-from-call, busy→idle resolution, in-flight clamp at 0, timeout-while-busy, connection-drop→error. `connection_test` pins the new `{:ok, params}` shape.
- **Integration:** `CDPEx.FixtureServer` gains a `/data` endpoint + a `#fetch-btn`; both primitives are driven end-to-end on real Chrome (click → fetch → settle / matched response → `response_body`).

`mix ci` green (format, deps.audit, compile + docs `--warnings-as-errors`, credo, dialyzer, 147 unit). Full integration suite green (48 tests, 0 failures); zero orphan Chrome.

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)