### PR TITLE
Add :telemetry instrumentation (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.navigate/3` accepts `response: true` to return `{:ok, page, %{status, url}}` — the main document's HTTP status and final (post-redirect) URL, correlated to the navigation by its `loaderId`. Lets callers detect a 403 wall / 404 / login-redirect instead of treating every navigation as success. Lazily enables the `Network` domain; returns `{:error, {:no_document_response, url}}` when no document response arrives (#31).
 - `CDPEx.Page.wait_for_response/3` blocks until a network response whose URL matches a function / `Regex` / substring arrives, returning the `Network.responseReceived` params (HTTP status + `requestId` for a follow-up `response_body/3`) — for an XHR/`fetch` kicked off by a `click/3` (#32).
 - `CDPEx.Page.wait_for_network_idle/2` blocks until the network is idle (≤ `:max_inflight` in-flight requests for `:idle_time` ms continuously) — the Puppeteer "networkidle" primitive for waiting out SPA hydration (#32).
+- `:telemetry` instrumentation — CDPEx emits launch + navigate spans, page open/close events, and error events (Chrome exit, browser-connection down, WebSocket close). Silent by default (no handlers attached); see `CDPEx.Telemetry` for the event taxonomy. Adds a `{:telemetry, "~> 1.2"}` dependency (#33).
 
 ### Breaking
 - `CDPEx.Connection.await_event/4` now returns `{:ok, params}` (the matched event's params) on a match, instead of a bare `:ok` (#32).

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ automatically, and a crashed browser is relaunched on demand.
 |---|---|
 | `navigate/3` | Go to a URL, waiting for `networkAlmostIdle` (configurable) |
 | `wait_for_selector/3` | Poll until a CSS selector matches |
+| `wait_for_response/3` | Block until a network response URL matches (fn / `Regex` / substring) |
+| `wait_for_network_idle/2` | Block until the network settles (Puppeteer "networkidle") |
 | `evaluate/3` | Run JS and return the value (`returnByValue`) |
 | `click/3` | Synthetic `.click()` on the first match |
 | `html/2` | Full serialized DOM (`document.documentElement.outerHTML`) |
@@ -191,6 +193,30 @@ automatically, and a crashed browser is relaunched on demand.
 | `authenticate/4` | Answer a proxy / HTTP Basic auth challenge (call before `navigate/3`) |
 
 Full API: [hexdocs.pm/cdp_ex](https://hexdocs.pm/cdp_ex).
+
+## Telemetry
+
+CDPEx emits [`:telemetry`](https://hexdocs.pm/telemetry) events and attaches no
+handlers — attach your own to record them (emitting with nothing attached is a no-op).
+Events: `[:cdp_ex, :launch, …]` and `[:cdp_ex, :navigate, …]` spans,
+`[:cdp_ex, :page, :start | :stop]`, and `[:cdp_ex, :error]`. See
+[`CDPEx.Telemetry`](https://hexdocs.pm/cdp_ex/CDPEx.Telemetry.html) for the full
+taxonomy (measurements + metadata).
+
+```elixir
+:telemetry.attach(
+  "cdp-nav",
+  [:cdp_ex, :navigate, :stop],
+  fn _event, %{duration: d}, %{url: url, status: status}, _config ->
+    ms = System.convert_time_unit(d, :native, :millisecond)
+    IO.puts("#{url} -> #{inspect(status)} in #{ms}ms")
+  end,
+  nil
+)
+```
+
+`status` (and the post-redirect `final_url`) are `nil` unless the navigation used
+`response: true` — see `CDPEx.Page.navigate/3`.
 
 ## Development
 

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -106,8 +106,17 @@ defmodule CDPEx do
   """
   @spec launch(keyword()) :: GenServer.on_start()
   def launch(opts \\ []) do
-    Telemetry.span(:launch, %{}, fn -> {Browser.start_link(opts), %{}} end)
+    Telemetry.span(:launch, %{}, fn ->
+      result = Browser.start_link(opts)
+      {result, launch_metadata(result)}
+    end)
   end
+
+  # Launch span :stop metadata: empty on success, {error: reason} on failure — so a
+  # consumer can tell a failed launch from a successful one (mirrors navigate's span).
+  defp launch_metadata({:ok, _pid}), do: %{}
+  defp launch_metadata({:error, reason}), do: %{error: reason}
+  defp launch_metadata(:ignore), do: %{error: :ignore}
 
   @doc "Stops a browser started with `launch/1`, closing all pages and killing Chrome."
   @spec stop(pid()) :: :ok

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -25,6 +25,9 @@ defmodule CDPEx do
         CDPEx.Page.html(page)
       end)
 
+  Observability is via `:telemetry` — see `CDPEx.Telemetry` for the event taxonomy
+  (launch / navigate spans, page open/close, and error events). Silent by default.
+
   > #### Status {: .info}
   >
   > Pages default to one WebSocket each (strong crash isolation); opt into
@@ -35,6 +38,7 @@ defmodule CDPEx do
 
   alias CDPEx.Browser
   alias CDPEx.Page
+  alias CDPEx.Telemetry
 
   @typedoc """
   The `reason` shapes that appear in `{:error, reason}` across CDPEx.
@@ -101,7 +105,9 @@ defmodule CDPEx do
   putting `CDPEx.Browser` under your own supervisor with a `:shutdown` timeout.
   """
   @spec launch(keyword()) :: GenServer.on_start()
-  def launch(opts \\ []), do: Browser.start_link(opts)
+  def launch(opts \\ []) do
+    Telemetry.span(:launch, %{}, fn -> {Browser.start_link(opts), %{}} end)
+  end
 
   @doc "Stops a browser started with `launch/1`, closing all pages and killing Chrome."
   @spec stop(pid()) :: :ok

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -22,6 +22,7 @@ defmodule CDPEx.Browser do
   alias CDPEx.Fetch
   alias CDPEx.Page
   alias CDPEx.Protocol
+  alias CDPEx.Telemetry
 
   require Logger
 
@@ -201,6 +202,7 @@ defmodule CDPEx.Browser do
         # close the tab, but NEVER close that connection (other sessions use it).
         detach_session(state.browser_conn, sid)
         close_target(state.browser_conn, tid)
+        Telemetry.page(:stop, %{target_id: tid, transport: :session})
         {:reply, :ok, %{state | sessions: Map.delete(state.sessions, tid)}}
 
       _ ->
@@ -216,6 +218,7 @@ defmodule CDPEx.Browser do
         # since either may already be gone.
         close_target(state.browser_conn, tid)
         safe_close(conn)
+        Telemetry.page(:stop, %{target_id: tid, transport: :dedicated})
         {:reply, :ok, %{state | pages: Map.delete(state.pages, tid)}}
 
       _ ->
@@ -325,10 +328,12 @@ defmodule CDPEx.Browser do
   @impl true
   def handle_info({port, {:exit_status, status}}, %{chrome: %{port: port}} = state) do
     Logger.warning("[CDPEx.Browser] Chrome exited with status #{status}")
+    Telemetry.error(status, :chrome_exited)
     {:stop, {:chrome_exited, status}, state}
   end
 
   def handle_info({:EXIT, pid, reason}, %{browser_conn: pid} = state) do
+    Telemetry.error(reason, :browser_connection_down)
     {:stop, browser_down_reason(reason), state}
   end
 
@@ -473,6 +478,7 @@ defmodule CDPEx.Browser do
   defp reply_dedicated_page(state, opts) do
     case open_page(state, opts) do
       {:ok, page} ->
+        Telemetry.page(:start, %{target_id: page.target_id, transport: :dedicated})
         {:reply, {:ok, page}, %{state | pages: Map.put(state.pages, page.target_id, page.conn)}}
 
       {:error, reason} ->
@@ -483,6 +489,7 @@ defmodule CDPEx.Browser do
   defp reply_session_page(state, opts) do
     case open_session_page(state, opts) do
       {:ok, page} ->
+        Telemetry.page(:start, %{target_id: page.target_id, transport: :session})
         sessions = Map.put(state.sessions, page.target_id, page.session_id)
         {:reply, {:ok, page}, %{state | sessions: sessions}}
 

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -22,6 +22,7 @@ defmodule CDPEx.Connection do
   use GenServer, restart: :temporary
 
   alias CDPEx.Protocol
+  alias CDPEx.Telemetry
   alias Mint.HTTP
   alias Mint.WebSocket
 
@@ -312,6 +313,7 @@ defmodule CDPEx.Connection do
   # `{:ws_closed, reason}` shape — terminate/2 is the single place that fails the
   # pending callers. The owning Browser sees the reason via its monitor.
   defp stop_ws_closed(state, reason) do
+    Telemetry.error(reason, :ws_closed)
     {:stop, {:shutdown, {:ws_closed, reason}}, state}
   end
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -28,6 +28,7 @@ defmodule CDPEx.Page do
   alias CDPEx.Browser
   alias CDPEx.Connection
   alias CDPEx.Protocol
+  alias CDPEx.Telemetry
 
   require Logger
 
@@ -98,6 +99,13 @@ defmodule CDPEx.Page do
           | {:ok, t(), %{status: non_neg_integer(), url: String.t()}}
           | {:error, term()}
   def navigate(%__MODULE__{} = page, url, opts \\ []) do
+    Telemetry.span(:navigate, %{url: url}, fn ->
+      result = do_navigate(page, url, opts)
+      {result, navigate_metadata(url, result)}
+    end)
+  end
+
+  defp do_navigate(page, url, opts) do
     timeout = Keyword.get(opts, :timeout, @navigate_timeout)
     wait_until = Keyword.get(opts, :wait_until, :network_almost_idle)
 
@@ -107,6 +115,16 @@ defmodule CDPEx.Page do
       navigate_with_wait(page, url, wait_until, timeout)
     end
   end
+
+  # Span :stop metadata for navigate/3: status + final_url are populated only on the
+  # response:true 3-tuple; an error tuple flows through :stop with :error set.
+  defp navigate_metadata(url, {:ok, _page, resp}),
+    do: %{url: url, status: resp.status, final_url: resp.url}
+
+  defp navigate_metadata(url, {:ok, _page}), do: %{url: url, status: nil, final_url: nil}
+
+  defp navigate_metadata(url, {:error, reason}),
+    do: %{url: url, status: nil, final_url: nil, error: reason}
 
   defp navigate_with_wait(page, url, :none, timeout) do
     case do_call(page, "Page.navigate", %{"url" => url}, timeout) do

--- a/lib/cdp_ex/telemetry.ex
+++ b/lib/cdp_ex/telemetry.ex
@@ -1,0 +1,111 @@
+defmodule CDPEx.Telemetry do
+  @moduledoc """
+  The `:telemetry` events CDPEx emits.
+
+  CDPEx is **silent by default**: it emits these events but attaches no handlers.
+  Attach your own with `:telemetry.attach/4` (or a reporter like `Telemetry.Metrics`)
+  to record them. Emitting with no handler attached is a cheap no-op.
+
+  Handlers run **synchronously in the process that emits the event** — including the
+  `CDPEx.Browser` / `CDPEx.Connection` GenServers, where error events fire immediately
+  before that process stops. Keep handlers fast (offload slow work to a `Task` or a
+  queue); a slow handler delays the emitting process and, for error events, Chrome
+  teardown.
+
+  ## Events
+
+  ### `[:cdp_ex, :launch, :start | :stop | :exception]`
+
+  A [span](`:telemetry.span/3`) around `CDPEx.launch/1` — Chrome spawn, WebSocket
+  connect, and bootstrap. `:stop` carries the span `:duration` (in `:native` time
+  units). A launch that returns `{:error, reason}` still completes through `:stop`
+  (the browser never started); only a raised exception emits `:exception`.
+
+  ### `[:cdp_ex, :navigate, :start | :stop | :exception]`
+
+  A span around `CDPEx.Page.navigate/3`.
+
+    * `:start` metadata — `%{url: url}`
+    * `:stop` metadata — `%{url, status, final_url}` plus `:error` when the navigation
+      failed. `status` and `final_url` are `nil` unless the call used `response: true`
+      (see `CDPEx.Page.navigate/3`) — `nil` means "not requested", not "unknown". A
+      navigation **error tuple flows through `:stop`** (with `:error` in the metadata),
+      not `:exception`.
+
+  Both spans' metadata also carry `:telemetry_span_context` (injected by
+  `:telemetry.span/3` to correlate `:start`/`:stop`/`:exception`).
+
+  ### `[:cdp_ex, :page, :start]` and `[:cdp_ex, :page, :stop]`
+
+  Emitted when a page is opened (`CDPEx.new_page/2`) and closed (`CDPEx.close_page/2`).
+
+    * measurements — `%{system_time: System.system_time()}`
+    * metadata — `%{target_id, transport}` where `transport` is `:dedicated` or `:session`
+
+  `:stop` fires only on an explicit `close_page/2`. A page that dies any other way (a
+  Chrome crash, the browser connection going down) emits `[:cdp_ex, :error]` **instead**
+  of `:stop` — so a gauge built by pairing `:start`/`:stop` should also decrement on
+  those errors, or use a counter.
+
+  ### `[:cdp_ex, :error]`
+
+  A genuine fault — a page's WebSocket closed unexpectedly, the browser connection went
+  down, or Chrome exited.
+
+    * measurements — `%{system_time: System.system_time()}`
+    * metadata — `%{reason, context}`:
+      * `:chrome_exited` — `reason` is the integer OS exit status
+      * `:browser_connection_down` — `reason` is the connection's exit reason
+      * `:ws_closed` — `reason` is the WebSocket close reason (e.g. `:closed`, or a
+        `{code, binary}` peer close)
+
+  > #### One fault can emit several events {: .info}
+  >
+  > A single Chrome death surfaces as one `:ws_closed` **per live connection** (each
+  > dedicated page's, plus the browser's) and one `:browser_connection_down`, racing
+  > with `:chrome_exited` (whichever the browser observes first). Treat them as one
+  > incident per browser, not one fault each. A clean `CDPEx.stop/1` or `close_page/2`
+  > emits **no** error event.
+
+  ## Example
+
+      :telemetry.attach(
+        "log-cdp-navigate",
+        [:cdp_ex, :navigate, :stop],
+        fn _event, %{duration: dur}, %{url: url, status: status}, _config ->
+          ms = System.convert_time_unit(dur, :native, :millisecond)
+          IO.puts("navigated \#{url} -> \#{inspect(status)} in \#{ms}ms")
+        end,
+        nil
+      )
+  """
+  @moduledoc since: "0.4.0"
+
+  @typedoc "The CDPEx operations wrapped in a `:telemetry` span."
+  @type span_name :: :launch | :navigate
+
+  @doc false
+  @spec span(span_name(), :telemetry.event_metadata(), span_fun) :: result
+        when result: var,
+             span_fun: (-> {result, :telemetry.event_metadata()}
+                           | {result, :telemetry.event_measurements(), :telemetry.event_metadata()})
+  def span(name, start_metadata, fun) when name in [:launch, :navigate] do
+    :telemetry.span([:cdp_ex, name], start_metadata, fun)
+  end
+
+  @doc false
+  @spec page(:start | :stop, :telemetry.event_metadata()) :: :ok
+  def page(stage, metadata) when stage in [:start, :stop] do
+    :telemetry.execute([:cdp_ex, :page, stage], %{system_time: System.system_time()}, metadata)
+  end
+
+  @doc false
+  @spec error(term(), :chrome_exited | :browser_connection_down | :ws_closed) :: :ok
+  def error(reason, context) do
+    :telemetry.execute(
+      [:cdp_ex, :error],
+      %{system_time: System.system_time()},
+      %{reason: reason, context: context}
+    )
+  end
+end

--- a/lib/cdp_ex/telemetry.ex
+++ b/lib/cdp_ex/telemetry.ex
@@ -18,8 +18,9 @@ defmodule CDPEx.Telemetry do
 
   A [span](`:telemetry.span/3`) around `CDPEx.launch/1` — Chrome spawn, WebSocket
   connect, and bootstrap. `:stop` carries the span `:duration` (in `:native` time
-  units). A launch that returns `{:error, reason}` still completes through `:stop`
-  (the browser never started); only a raised exception emits `:exception`.
+  units); its metadata is `%{}` on success or `%{error: reason}` when the launch
+  failed. A failed launch still completes through `:stop` (the browser never started);
+  only a raised exception emits `:exception`.
 
   ### `[:cdp_ex, :navigate, :start | :stop | :exception]`
 
@@ -85,10 +86,8 @@ defmodule CDPEx.Telemetry do
   @type span_name :: :launch | :navigate
 
   @doc false
-  @spec span(span_name(), :telemetry.event_metadata(), span_fun) :: result
-        when result: var,
-             span_fun: (-> {result, :telemetry.event_metadata()}
-                           | {result, :telemetry.event_measurements(), :telemetry.event_metadata()})
+  @spec span(span_name(), :telemetry.event_metadata(), (-> {result, map()})) :: result
+        when result: var
   def span(name, start_metadata, fun) when name in [:launch, :navigate] do
     :telemetry.span([:cdp_ex, name], start_metadata, fun)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,8 @@ defmodule CDPEx.MixProject do
       {:mint_web_socket, "~> 1.0"},
       # JSON-RPC encoding/decoding for the CDP protocol.
       {:jason, "~> 1.4"},
+      # Observability: CDPEx emits :telemetry span/execute events (attaches no handlers).
+      {:telemetry, "~> 1.2"},
 
       # Dev/test tooling
       {:ex_doc, "~> 0.34", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -16,6 +16,7 @@
   "mix_audit": {:hex, :mix_audit, "2.1.5", "c0f77cee6b4ef9d97e37772359a187a166c7a1e0e08b50edf5bf6959dfe5a016", [:make, :mix], [{:jason, "~> 1.4", [hex: :jason, repo: "hexpm", optional: false]}, {:yaml_elixir, "~> 2.11", [hex: :yaml_elixir, repo: "hexpm", optional: false]}], "hexpm", "87f9298e21da32f697af535475860dc1d3617a010e0b418d2ec6142bc8b42d69"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "styler": {:hex, :styler, "1.11.0", "35010d970689a23c2bcc8e97bd8bf7d20e3561d60c49be84654df5c37d051a9c", [:mix], [], "hexpm", "70f36165d0cf238a32b7a456fdef6a9c72e77e657d7ac4a0ace33aeba3f2b8c0"},
+  "telemetry": {:hex, :telemetry, "1.4.2", "a0cb522801dffb1c49fe6e30561badffc7b6d0e180db1300df759faa22062855", [:rebar3], [], "hexpm", "928f6495066506077862c0d1646609eed891a4326bee3126ba54b60af61febb1"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.12.2", "9dd1330fb4cd9a36a7b0f502e5b12486eff632792ee4a5f0eba52a4d4ec32c9c", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "e7c1b10122f973e6558462d51c39026ba0e14afbc6745318e990ea82cfe9e159"},
 }

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -747,6 +747,98 @@ defmodule CDPEx.IntegrationTest do
     end
   end
 
+  describe "telemetry" do
+    test "CDPEx.launch/1 emits a [:cdp_ex, :launch] span with a positive duration" do
+      attach_telemetry([[:cdp_ex, :launch, :stop]])
+
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      assert_receive {:telemetry, [:cdp_ex, :launch, :stop], %{duration: duration}, _meta}, 15_000
+      assert duration > 0
+    end
+
+    test "opening and closing a page emits [:cdp_ex, :page, :start] then :stop, no error" do
+      attach_telemetry([[:cdp_ex, :page, :start], [:cdp_ex, :page, :stop], [:cdp_ex, :error]])
+
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, page} = CDPEx.new_page(browser)
+
+      assert_receive {:telemetry, [:cdp_ex, :page, :start], %{system_time: _},
+                      %{target_id: tid, transport: :dedicated}},
+                     5_000
+
+      assert tid == page.target_id
+
+      :ok = CDPEx.close_page(browser, page)
+      assert_receive {:telemetry, [:cdp_ex, :page, :stop], _, %{transport: :dedicated}}, 5_000
+
+      # A clean close is not a fault — no [:cdp_ex, :error].
+      refute_received {:telemetry, [:cdp_ex, :error], _, _}
+    end
+
+    test "a :session page open/close emits :start/:stop with transport: :session", %{
+      fixture: fixture
+    } do
+      attach_telemetry([[:cdp_ex, :page, :start], [:cdp_ex, :page, :stop]])
+
+      {:ok, browser} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, page} = CDPEx.new_page(browser, transport: :session)
+      assert_receive {:telemetry, [:cdp_ex, :page, :start], _, %{transport: :session}}, 5_000
+
+      {:ok, _} = Page.navigate(page, fixture)
+      :ok = CDPEx.close_page(browser, page)
+      assert_receive {:telemetry, [:cdp_ex, :page, :stop], _, %{transport: :session}}, 5_000
+    end
+
+    test "a page that dies with Chrome emits no [:cdp_ex, :page, :stop]" do
+      attach_telemetry([[:cdp_ex, :page, :stop]])
+
+      {:ok, browser} = CDPEx.launch()
+      {:ok, _page} = CDPEx.new_page(browser)
+
+      %{chrome: %{os_pid: os_pid}} = :sys.get_state(browser)
+      System.cmd("kill", ["-9", to_string(os_pid)])
+
+      # :stop fires only on an explicit close_page/2 — a page dying with Chrome does not
+      # emit it (consumers learn of the loss via [:cdp_ex, :error] instead).
+      refute_receive {:telemetry, [:cdp_ex, :page, :stop], _, _}, 2_000
+    end
+
+    test "killing Chrome emits a [:cdp_ex, :error] fault event" do
+      attach_telemetry([[:cdp_ex, :error]])
+
+      {:ok, browser} = CDPEx.launch()
+
+      %{chrome: %{os_pid: os_pid}} = :sys.get_state(browser)
+      System.cmd("kill", ["-9", to_string(os_pid)])
+
+      # Chrome's port exit and the browser-connection drop race; whichever the Browser
+      # processes first stops it, so assert a genuine fault event fires (any of the three
+      # contexts) rather than pinning the order.
+      assert_receive {:telemetry, [:cdp_ex, :error], %{system_time: _}, %{context: context}}, 10_000
+      assert context in [:chrome_exited, :browser_connection_down, :ws_closed]
+    end
+  end
+
+  # Attach a telemetry handler forwarding each event to the test process; detach on exit.
+  # A named (module) handler avoids :telemetry's local/anonymous-handler warning; the
+  # config (4th arg) carries the test pid.
+  defp attach_telemetry(events) do
+    id = "integration-telemetry-#{System.unique_integer([:positive])}"
+    :telemetry.attach_many(id, events, &__MODULE__.forward/4, self())
+    on_exit(fn -> :telemetry.detach(id) end)
+  end
+
+  @doc false
+  def forward(event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry, event, measurements, metadata})
+  end
+
   # Teardown helper. The browser is linked to (and watches) the test process, so
   # by the time on_exit runs it may already be stopping on its own — racing this
   # call. Tolerate an exit from the stop so a teardown race never fails a test

--- a/test/cdp_ex/telemetry_test.exs
+++ b/test/cdp_ex/telemetry_test.exs
@@ -1,5 +1,8 @@
 defmodule CDPEx.TelemetryTest do
-  use ExUnit.Case, async: true
+  # NOT async: :telemetry handlers are VM-global, so an async run would let this module's
+  # handler receive [:cdp_ex, :navigate, ...] events from other concurrent tests (e.g.
+  # PageTest navigating the same URL), making assert_receive/refute_received nondeterministic.
+  use ExUnit.Case, async: false
 
   alias CDPEx.Connection
   alias CDPEx.FakeCDP

--- a/test/cdp_ex/telemetry_test.exs
+++ b/test/cdp_ex/telemetry_test.exs
@@ -1,0 +1,172 @@
+defmodule CDPEx.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  alias CDPEx.Connection
+  alias CDPEx.FakeCDP
+  alias CDPEx.Page
+  alias CDPEx.Telemetry
+
+  setup do
+    # The test process owns the linked connection; trap exits and tolerate an
+    # already-dying conn in teardown (same as ConnectionTest / PageTest).
+    Process.flag(:trap_exit, true)
+
+    {:ok, server} = FakeCDP.start()
+    {:ok, conn} = Connection.start_link(server.url)
+    assert_receive {:fake_cdp_connected, fake}, 2_000
+
+    on_exit(fn ->
+      try do
+        if Process.alive?(conn), do: Connection.close(conn)
+      catch
+        :exit, _ -> :ok
+      end
+    end)
+
+    # navigate/3 only touches page.conn, so a dummy browser pid is fine here.
+    %{
+      page: %Page{browser: self(), conn: conn, target_id: "T", session_id: nil},
+      conn: conn,
+      fake: fake
+    }
+  end
+
+  describe "navigate/3 span" do
+    test "emits :start (url) then :stop (duration + url/status/final_url)", %{
+      page: page,
+      fake: fake
+    } do
+      attach([[:cdp_ex, :navigate, :start], [:cdp_ex, :navigate, :stop]])
+
+      task = Task.async(fn -> Page.navigate(page, "http://example.test/", wait_until: :none) end)
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => id, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
+      assert {:ok, %Page{}} = Task.await(task)
+
+      assert_receive {:telemetry, [:cdp_ex, :navigate, :start], _measurements,
+                      %{url: "http://example.test/"}}
+
+      assert_receive {:telemetry, [:cdp_ex, :navigate, :stop], %{duration: duration}, meta}
+      assert duration > 0
+      # :telemetry.span also injects :telemetry_span_context, so match the subset.
+      assert %{url: "http://example.test/", status: nil, final_url: nil} = meta
+    end
+
+    test "a navigation error flows through :stop (with :error), not :exception", %{
+      page: page,
+      fake: fake
+    } do
+      attach([[:cdp_ex, :navigate, :stop], [:cdp_ex, :navigate, :exception]])
+
+      task = Task.async(fn -> Page.navigate(page, "http://example.test/", wait_until: :none) end)
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => id, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{id},"result":{"errorText":"net::ERR_NAME_NOT_RESOLVED"}}))
+      assert {:error, {:navigate, _}} = Task.await(task)
+
+      assert_receive {:telemetry, [:cdp_ex, :navigate, :stop], _, %{error: {:navigate, _}}}
+      refute_received {:telemetry, [:cdp_ex, :navigate, :exception], _, _}
+    end
+
+    test "response: true populates :stop status + final_url", %{page: page, conn: conn, fake: fake} do
+      attach([[:cdp_ex, :navigate, :stop]])
+
+      task = Task.async(fn -> Page.navigate(page, "http://example.test/", response: true) end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
+
+      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+      wait_until_subscribed(conn, task.pid, "Page.lifecycleEvent")
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"type":"Document","loaderId":"L","frameId":"F","response":{"status":200,"url":"http://example.test/landed"}}})
+      )
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Page.lifecycleEvent","params":{"name":"networkAlmostIdle"}})
+      )
+
+      assert {:ok, %Page{}, %{status: 200}} = Task.await(task)
+
+      assert_receive {:telemetry, [:cdp_ex, :navigate, :stop], _,
+                      %{status: 200, final_url: "http://example.test/landed"}}
+    end
+
+    test "an invalid :wait_until raises and emits :exception, not :stop", %{page: page} do
+      attach([[:cdp_ex, :navigate, :exception], [:cdp_ex, :navigate, :stop]])
+
+      assert_raise ArgumentError, fn ->
+        Page.navigate(page, "http://example.test/", wait_until: :bogus)
+      end
+
+      assert_receive {:telemetry, [:cdp_ex, :navigate, :exception], _measurements,
+                      %{url: "http://example.test/", kind: :error}}
+
+      refute_received {:telemetry, [:cdp_ex, :navigate, :stop], _, _}
+    end
+  end
+
+  describe "execute helpers" do
+    test "page/2 emits [:cdp_ex, :page, stage] with system_time + metadata" do
+      attach([[:cdp_ex, :page, :start], [:cdp_ex, :page, :stop]])
+
+      Telemetry.page(:start, %{target_id: "T", transport: :dedicated})
+      assert_receive {:telemetry, [:cdp_ex, :page, :start], %{system_time: t}, meta}
+      assert is_integer(t)
+      assert meta == %{target_id: "T", transport: :dedicated}
+
+      Telemetry.page(:stop, %{target_id: "T", transport: :session})
+      assert_receive {:telemetry, [:cdp_ex, :page, :stop], _, %{transport: :session}}
+    end
+
+    test "error/2 emits [:cdp_ex, :error] with reason + context" do
+      attach([[:cdp_ex, :error]])
+
+      Telemetry.error(:boom, :ws_closed)
+
+      assert_receive {:telemetry, [:cdp_ex, :error], %{system_time: t},
+                      %{reason: :boom, context: :ws_closed}}
+
+      assert is_integer(t)
+    end
+
+    test "emitting with no handler attached is a no-op (doesn't raise)" do
+      assert :ok = Telemetry.page(:start, %{target_id: "T", transport: :dedicated})
+      assert :ok = Telemetry.error(:boom, :chrome_exited)
+    end
+  end
+
+  # Attach a handler forwarding each event to the test process; detach on exit. A named
+  # (module) handler avoids :telemetry's local/anonymous-handler warning; the config (4th
+  # arg) carries the test pid.
+  defp attach(events) do
+    id = "telemetry-test-#{System.unique_integer([:positive])}"
+    :telemetry.attach_many(id, events, &__MODULE__.forward/4, self())
+    on_exit(fn -> :telemetry.detach(id) end)
+  end
+
+  @doc false
+  def forward(event, measurements, metadata, test_pid) do
+    send(test_pid, {:telemetry, event, measurements, metadata})
+  end
+
+  # Poll until `pid` is registered as a `method` subscriber on `conn` (no send/subscribe
+  # race for the response-capture path).
+  defp wait_until_subscribed(conn, pid, method, retries \\ 100) do
+    cond do
+      MapSet.member?(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new()), pid) ->
+        :ok
+
+      retries == 0 ->
+        flunk("subscriber #{method} not registered in time")
+
+      true ->
+        Process.sleep(10) && wait_until_subscribed(conn, pid, method, retries - 1)
+    end
+  end
+end


### PR DESCRIPTION
## What

CDPEx now emits `:telemetry` events — **silent by default** (attaches no handlers; emitting with nothing attached is a no-op). New `CDPEx.Telemetry` module documents the taxonomy and holds the emit helpers. Adds `{:telemetry, "~> 1.2"}`.

### Events
- **`[:cdp_ex, :launch, :start|:stop|:exception]`** — span around `CDPEx.launch/1`.
- **`[:cdp_ex, :navigate, :start|:stop|:exception]`** — span around `Page.navigate/3`; `:stop` metadata `%{url, status, final_url}` (status/final_url `nil` unless `response: true`); a navigation **error tuple flows through `:stop`** (`:error` key), not `:exception`.
- **`[:cdp_ex, :page, :start]` / `[:cdp_ex, :page, :stop]`** — page open/close, metadata `%{target_id, transport}`. `:stop` fires only on `close_page/2`; a crash emits `[:cdp_ex, :error]` instead.
- **`[:cdp_ex, :error]`** — genuine faults only (Chrome exit, browser-connection down, WebSocket close), metadata `%{reason, context}`. Paired with the existing `Logger` calls, **not** every `{:error, _}`. One crash can fan out to several events; a clean stop/close emits none.

Spans wrap the public boundary so behavior + error contracts are unchanged. The moduledoc notes handlers run **synchronously in the emitting process** (keep them fast — they run right before a `Browser`/`Connection` stops).

## Review

Ran a 6-agent review before opening. **No P0/P1** — the adversarial reviewer confirmed across 25 real-Chrome cycles that the spans are behavior-preserving and a clean close/stop emits no spurious error. Findings (doc-completeness + test-coverage) are all addressed in this branch: documented the `:page` non-pairing on crash, the multi-event fan-out, sync-handler caveat, and per-context `reason` shapes; widened the `span/3` `@spec` + added a `span_name` type; added the tests below.

## Tests

- **Unit (FakeCDP):** navigate span — default, `response: true` status, error-through-`:stop`, `:exception` on bad `:wait_until`; the `page`/`error` helpers; a no-handler no-op.
- **Integration:** launch span; dedicated + session page open/close; a clean-close-emits-no-`:error` guard; a crash-emits-no-`:page`-`:stop` guard; a `[:cdp_ex, :error]` fault on killed Chrome.

`mix ci` green (161 unit). Full integration suite green (54 tests); zero orphan Chrome.

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)