### PR TITLE
ci: verify Elixir 1.20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
             otp: "26.2"
           - elixir: "1.19.5"
             otp: "28.0"
+          - elixir: "1.20.0"
+            otp: "28.0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -26,8 +26,6 @@ defmodule CDPEx.Connection do
   alias Mint.HTTP
   alias Mint.WebSocket
 
-  require Logger
-
   @upgrade_timeout 15_000
   @default_call_timeout 10_000
 

--- a/test/support/fake_cdp.ex
+++ b/test/support/fake_cdp.ex
@@ -234,7 +234,7 @@ defmodule CDPEx.FakeCDP do
 
   defp take_payload(opcode, true, len, data) do
     case data do
-      <<mask::binary-size(4), payload::binary-size(len), rest::binary>> ->
+      <<mask::binary-size(4), payload::binary-size(^len), rest::binary>> ->
         {:ok, {opcode, unmask(payload, mask)}, rest}
 
       _ ->
@@ -244,7 +244,7 @@ defmodule CDPEx.FakeCDP do
 
   defp take_payload(opcode, false, len, data) do
     case data do
-      <<payload::binary-size(len), rest::binary>> -> {:ok, {opcode, payload}, rest}
+      <<payload::binary-size(^len), rest::binary>> -> {:ok, {opcode, payload}, rest}
       _ -> :incomplete
     end
   end


### PR DESCRIPTION
Adds a **1.20.0 / OTP 28** lane to the `check` matrix to verify v0.4.0 is green on the just-released Elixir 1.20.

## Why
`mix.exs` already declares `elixir: "~> 1.15"` (= `>= 1.15.0 and < 2.0.0`), so 1.20 is **already permitted** — a user on 1.20 can use cdp_ex today. This PR *proves* it: format / `--warnings-as-errors` (compile + docs) / credo / dialyzer / unit tests all pass on 1.20.

Worth a dedicated lane because per-version formatter and warning behavior genuinely diverges — we just hit a `mix format` split between 1.15 and 1.19 on a `@spec`. CI is the only way to confirm 1.20 is clean.

## Scope
CI-only — **no library change**. If the lane surfaces a 1.20-specific format/warning, the fix lands here.

> Note: 1.20.0 released hours ago, so this also confirms `erlef/setup-beam` can install it. If the lane can't install 1.20.0 yet, that's the signal to wait.