### PR TITLE
Isolate navigate(response: true) capture in a helper process (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- `CDPEx.Page.navigate/3` with `response: true` no longer disturbs a same-process `observe_network/2` subscription. The document-response capture now runs in a short-lived, isolated helper process with its own `Network.responseReceived` subscription and mailbox, so a caller that is also observing the network on the same page keeps its subscription and its buffered events intact (previously the navigation unsubscribed the caller and drained those events). Cross-process observation was already unaffected (#42).
+
 ## [0.4.0] - 2026-06-04
 
 ### Added

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -85,7 +85,9 @@ defmodule CDPEx.Page do
   `response: true` captures the document response in a short-lived helper process with
   its own `Network.responseReceived` subscription, so it composes safely with
   `observe_network/2` on the same page — the caller's subscription and any buffered
-  events are left untouched.
+  events are left untouched. A normal connection drop still surfaces as
+  `{:error, :noproc}` / `{:error, {:ws_closed, _}}`; only an abnormal crash of that
+  internal helper returns `{:error, {:capture_failed, reason}}`.
 
   Options:
     * `:wait_until` — `:network_almost_idle` (default), `:load`, or `:none`

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -82,12 +82,10 @@ defmodule CDPEx.Page do
   loads no new document, or a connection that never produced an HTTP response — though
   the latter usually surfaces earlier as `{:navigate, _}`).
 
-  > #### Don't combine with `observe_network/2` on the same page {: .warning}
-  >
-  > `response: true` subscribes the calling process to `Network.responseReceived` for
-  > the duration of the call, then unsubscribes on the way out. If the *same process*
-  > is also running `observe_network/2` on this page, the navigation tears that
-  > subscription down. Observe from a separate process, or capture via `response: true`.
+  `response: true` captures the document response in a short-lived helper process with
+  its own `Network.responseReceived` subscription, so it composes safely with
+  `observe_network/2` on the same page — the caller's subscription and any buffered
+  events are left untouched.
 
   Options:
     * `:wait_until` — `:network_almost_idle` (default), `:load`, or `:none`
@@ -166,27 +164,64 @@ defmodule CDPEx.Page do
 
   # Like navigate_with_wait/4 but also captures the main-document Network.responseReceived
   # (HTTP status + final URL) for THIS navigation. Kept separate so the default path
-  # stays untouched. Requires the Network domain; enables it lazily.
+  # stays untouched. Requires the Network domain; enables it lazily. The capture itself
+  # runs in an isolated helper process (capture_via_helper/4) so it never disturbs a
+  # same-process observe_network/2 subscription (#42).
   defp navigate_capturing_response(page, url, wait_until, timeout) do
     # Validate :wait_until up front (lifecycle_name/1 raises on a bad value) so an
-    # invalid option never enables Network / fires the navigation first — matching the
+    # invalid option never enables Network / spawns the helper first — matching the
     # default path, which validates before any side effect.
     milestone = if wait_until == :none, do: nil, else: lifecycle_name(wait_until)
+
+    with :ok <- ensure_network(page, timeout) do
+      capture_via_helper(page, url, milestone, timeout)
+    end
+  end
+
+  # Run the response capture in its own short-lived, monitored process. The helper
+  # subscribes to Network.responseReceived (+ lifecycle) on *its* pid and drains *its*
+  # mailbox, so a caller that is also running observe_network/2 on this page keeps its
+  # subscription and its buffered events intact (#42). Connection monitors every
+  # subscriber and drops it on :DOWN, so the helper's subscription is released when it
+  # exits — no explicit unsubscribe. Every blocking op the helper makes is individually
+  # bounded (subscribe_each catches a dead conn; the Page.navigate call carries `timeout`;
+  # await_capture monitors the conn and honours `deadline`), so the helper always
+  # terminates and the caller awaits exactly one of its result or its :DOWN.
+  defp capture_via_helper(page, url, milestone, timeout) do
+    parent = self()
+    tag = make_ref()
+
+    {helper, mon} =
+      spawn_monitor(fn ->
+        send(parent, {tag, run_capture(page, url, milestone, timeout)})
+      end)
+
+    receive do
+      {^tag, result} ->
+        Process.demonitor(mon, [:flush])
+        result
+
+      {:DOWN, ^mon, :process, ^helper, reason} ->
+        {:error, {:capture_failed, reason}}
+    end
+  end
+
+  # The capture helper body (runs in the spawned process). Subscribes on its own pid,
+  # then issues the navigation and accumulates the main-document response. Returns
+  # capture_after_navigate/6's fully mapped result: {:ok, page, %{status, url}} |
+  # {:error, reason}. No before/after drain is needed — the helper's mailbox starts empty
+  # and dies with it.
+  defp run_capture(page, url, milestone, timeout) do
     methods = [@lifecycle_method, @response_received]
 
-    with :ok <- ensure_network(page, timeout),
-         :ok <- subscribe_each(page.conn, methods) do
-      Enum.each(methods, &drain_events(page.conn, &1))
-      ref = Process.monitor(page.conn)
-      deadline = System.monotonic_time(:millisecond) + timeout
-
-      try do
+    case subscribe_each(page.conn, methods) do
+      :ok ->
+        ref = Process.monitor(page.conn)
+        deadline = System.monotonic_time(:millisecond) + timeout
         capture_after_navigate(page, url, milestone, timeout, ref, deadline)
-      after
-        Process.demonitor(ref, [:flush])
-        unsubscribe_each(page.conn, methods)
-        Enum.each(methods, &drain_events(page.conn, &1))
-      end
+
+      {:error, _} = error ->
+        error
     end
   end
 

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -1021,7 +1021,10 @@ defmodule CDPEx.PageTest do
   end
 
   # Collect every buffered Network.responseReceived event currently in this process's
-  # mailbox (the observer's copies), returning their params maps.
+  # mailbox (the observer's copies), returning their params maps. `after 0` is safe here:
+  # both copies are enqueued (local sends are synchronous) before the helper sends
+  # {:caller_done, ...} that unblocks the caller, so they are already in the mailbox by
+  # the time this runs — no flake window.
   defp drain_cdp_events(conn, acc) do
     receive do
       {:cdp_event, ^conn, "Network.responseReceived", params, _sid} ->

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -112,8 +112,9 @@ defmodule CDPEx.PageTest do
       FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
 
       # Both the lifecycle and responseReceived subscriptions are in place before navigate.
-      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
-      wait_until_subscribed(conn, task.pid, "Page.lifecycleEvent")
+      # response: true captures in an internal helper process, so match any subscriber pid.
+      wait_until_any_subscribed(conn, "Network.responseReceived")
+      wait_until_any_subscribed(conn, "Page.lifecycleEvent")
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
@@ -152,7 +153,7 @@ defmodule CDPEx.PageTest do
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
 
-      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+      wait_until_any_subscribed(conn, "Network.responseReceived")
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
@@ -201,7 +202,7 @@ defmodule CDPEx.PageTest do
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
 
-      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+      wait_until_any_subscribed(conn, "Network.responseReceived")
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
@@ -226,12 +227,12 @@ defmodule CDPEx.PageTest do
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
 
-      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
+      wait_until_any_subscribed(conn, "Network.responseReceived")
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
 
-      # The task is now in await_capture (which monitors the conn). Drop the connection
+      # The helper is now in await_capture (which monitors the conn). Drop the connection
       # before any document response: the wait must end with an error, not hang. Either
       # the await_capture {:DOWN} (-> {:ws_closed, _}) or the in-flight call (-> :noproc)
       # wins the race; both are clean errors.
@@ -239,6 +240,67 @@ defmodule CDPEx.PageTest do
 
       assert {:error, reason} = Task.await(task)
       assert reason == :noproc or match?({:ws_closed, _}, reason)
+    end
+
+    test "leaves a same-process observe_network/2 subscription and buffered events intact (#42)",
+         %{page: page, conn: conn, fake: fake} do
+      test = self()
+
+      # The caller observes the network AND navigates with response: true on the same
+      # page. Before #42 the navigation tore the observer's subscription down and drained
+      # its buffered events; with the isolated capture helper both survive.
+      caller =
+        spawn_link(fn ->
+          :ok = Page.observe_network(page)
+          send(test, :observing)
+
+          result = Page.navigate(page, "http://example.test/", response: true)
+
+          send(
+            test,
+            {:caller_done, result, subscribed?(conn, self(), "Network.responseReceived"),
+             drain_cdp_events(conn, [])}
+          )
+        end)
+
+      # observe_network/2: subscribe the caller, then answer its Network.enable.
+      wait_until_subscribed(conn, caller, "Network.responseReceived")
+      answer_network_enable(fake)
+      assert_receive :observing, 2_000
+
+      # navigate(response: true): re-enables Network (idempotent), then the helper
+      # subscribes (responseReceived count climbs to 2: caller + helper) and navigates.
+      answer_network_enable(fake)
+      wait_until_subscriber_count(conn, "Network.responseReceived", 2)
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
+      FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
+
+      # A sub-resource response (only the observer cares) and the main document response
+      # (the helper captures it; the observer also gets its own copy). Both subscribers
+      # receive their own copy — the helper's capture loop drains only the helper's mailbox.
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"requestId":"SUB","response":{"status":204,"url":"http://example.test/asset.js"}}})
+      )
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Network.responseReceived","params":{"type":"Document","loaderId":"L","frameId":"F","response":{"status":200,"url":"http://example.test/landed"}}})
+      )
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"method":"Page.lifecycleEvent","params":{"name":"networkAlmostIdle"}})
+      )
+
+      assert_receive {:caller_done, result, still_subscribed?, buffered}, 2_000
+
+      assert {:ok, %Page{}, %{status: 200, url: "http://example.test/landed"}} = result
+      assert still_subscribed?, "navigate(response: true) tore down the observer's subscription"
+
+      statuses = for %{"response" => %{"status" => s}} <- buffered, do: s
+      assert 204 in statuses, "observer lost its buffered sub-resource response"
+      assert 200 in statuses, "observer lost its own copy of the document response"
     end
   end
 
@@ -935,6 +997,44 @@ defmodule CDPEx.PageTest do
 
   defp subscribed?(conn, pid, method) do
     MapSet.member?(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new()), pid)
+  end
+
+  # Like wait_until_subscribed/3 but matches *any* subscriber — used where the subscriber
+  # is an internal helper process whose pid the test can't name (e.g. the response-capture
+  # helper in navigate(response: true), #42).
+  defp wait_until_any_subscribed(conn, method, retries \\ 100),
+    do: wait_until_subscriber_count(conn, method, 1, retries)
+
+  # Poll until `method` has at least `count` distinct subscriber pids.
+  defp wait_until_subscriber_count(conn, method, count, retries \\ 100) do
+    cond do
+      MapSet.size(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new())) >= count ->
+        :ok
+
+      retries == 0 ->
+        flunk("fewer than #{count} subscribers for #{method} registered in time")
+
+      true ->
+        Process.sleep(10)
+        wait_until_subscriber_count(conn, method, count, retries - 1)
+    end
+  end
+
+  # Collect every buffered Network.responseReceived event currently in this process's
+  # mailbox (the observer's copies), returning their params maps.
+  defp drain_cdp_events(conn, acc) do
+    receive do
+      {:cdp_event, ^conn, "Network.responseReceived", params, _sid} ->
+        drain_cdp_events(conn, [params | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
+  # Answer one Network.enable command with an empty result.
+  defp answer_network_enable(fake) do
+    assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
+    FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
   end
 
   # Poll until at least one await_event waiter is registered on `conn` (waiters are not

--- a/test/cdp_ex/telemetry_test.exs
+++ b/test/cdp_ex/telemetry_test.exs
@@ -78,8 +78,9 @@ defmodule CDPEx.TelemetryTest do
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
 
-      wait_until_subscribed(conn, task.pid, "Network.responseReceived")
-      wait_until_subscribed(conn, task.pid, "Page.lifecycleEvent")
+      # response: true captures in an internal helper process, so match any subscriber pid.
+      wait_until_any_subscribed(conn, "Network.responseReceived")
+      wait_until_any_subscribed(conn, "Page.lifecycleEvent")
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => navid, "method" => "Page.navigate"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{navid},"result":{"frameId":"F","loaderId":"L"}}))
@@ -158,18 +159,19 @@ defmodule CDPEx.TelemetryTest do
     send(test_pid, {:telemetry, event, measurements, metadata})
   end
 
-  # Poll until `pid` is registered as a `method` subscriber on `conn` (no send/subscribe
-  # race for the response-capture path).
-  defp wait_until_subscribed(conn, pid, method, retries \\ 100) do
+  # Poll until *any* pid is registered as a `method` subscriber on `conn` (no
+  # send/subscribe race for the response-capture path, which subscribes from an internal
+  # helper process whose pid the test can't name).
+  defp wait_until_any_subscribed(conn, method, retries \\ 100) do
     cond do
-      MapSet.member?(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new()), pid) ->
+      MapSet.size(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new())) > 0 ->
         :ok
 
       retries == 0 ->
         flunk("subscriber #{method} not registered in time")
 
       true ->
-        Process.sleep(10) && wait_until_subscribed(conn, pid, method, retries - 1)
+        Process.sleep(10) && wait_until_any_subscribed(conn, method, retries - 1)
     end
   end
 end


### PR DESCRIPTION
Fixes #42.

## Problem

`navigate(page, url, response: true)` captured the main-document `Network.responseReceived` by subscribing the **calling process** and unsubscribing + draining its mailbox on the way out. Connection keys subscriptions on `{method, pid}` as a **set, not a refcount** (`connection.ex` `MapSet.put`/`MapSet.delete`), so if the same process was already running `observe_network/2` on that page, the navigation:

1. unsubscribed it from `Network.responseReceived` (killed the observer), and
2. drained buffered `responseReceived` events out of its mailbox.

Cross-process observation was already fine (each subscriber pid gets its own copy).

## Why not the other options

- **Conditional teardown** can keep the subscription alive, but the capture's `await_capture` receive loop still runs in the *caller's* mailbox and must consume every `responseReceived` for the session to find the document one — so it eats the observer's events regardless of subscription bookkeeping. It cannot satisfy "buffered events intact."
- **`await_event`-based capture** is one-shot/first-match, but capture needs *last-wins* across a redirect chain (302…→200). First-match would report the 302.

## Fix (Option 2 — dedicated helper)

Run the capture in a short-lived, `spawn_monitor`'d helper that subscribes on **its own** pid and drains **its own** mailbox. The caller's subscription and buffered events are never touched. Connection already auto-unsubscribes any subscriber on its `:DOWN`, so the helper needs no explicit teardown. Every blocking op the helper makes is individually bounded (`subscribe_each` catches a dead conn; the `Page.navigate` call carries `timeout`; `await_capture` monitors the conn and honours `deadline`), so it always terminates and the caller awaits exactly its result or its `:DOWN`.

No public API or return-shape change — `navigate(response: true)` still returns `{:ok, page, %{status, url}}` | `{:error, reason}`.

## Tests

- New deterministic regression test: `observe_network/2` then `navigate(response: true)` on **one** process keeps the subscription **and** its buffered events. (On the old code this can't even reach 2 distinct `responseReceived` subscribers, since the caller pid is reused — so it fails there.)
- Updated the existing `response: true` unit tests (page + telemetry) to gate on "any subscriber" since the capture subscription now belongs to the internal helper pid.
- `mix ci` green (format, deps.audit, compile/docs `--warnings-as-errors`, credo, dialyzer 0 errors, 162 tests + 16 doctests). All 54 real-Chrome integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)