### PR TITLE
Isolate wait_for_network_idle/2 in a helper process (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - `CDPEx.Page.navigate/3` with `response: true` no longer disturbs a same-process `observe_network/2` subscription. The document-response capture now runs in a short-lived, isolated helper process with its own `Network.responseReceived` subscription and mailbox, so a caller that is also observing the network on the same page keeps its subscription and its buffered events intact (previously the navigation unsubscribed the caller and drained those events). Cross-process observation was already unaffected (#42).
+- `CDPEx.Page.wait_for_network_idle/2` no longer disturbs a same-process `observe_network/2` subscription — the same fix as #42 applied to the idle wait. The in-flight tracking now runs in an isolated helper process, so a caller observing the network on the same page keeps its subscription and buffered events intact (previously the idle wait tore down the overlapping request-lifecycle subscriptions and drained those events). An abnormal crash of the internal helper surfaces as `{:error, {:idle_wait_failed, reason}}` (#48).
 
 ## [0.4.0] - 2026-06-04
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -167,7 +167,7 @@ defmodule CDPEx.Page do
   # Like navigate_with_wait/4 but also captures the main-document Network.responseReceived
   # (HTTP status + final URL) for THIS navigation. Kept separate so the default path
   # stays untouched. Requires the Network domain; enables it lazily. The capture itself
-  # runs in an isolated helper process (capture_via_helper/4) so it never disturbs a
+  # runs in an isolated helper process (run_in_helper/2) so it never disturbs a
   # same-process observe_network/2 subscription (#42).
   defp navigate_capturing_response(page, url, wait_until, timeout) do
     # Validate :wait_until up front (lifecycle_name/1 raises on a bad value) so an

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -176,27 +176,25 @@ defmodule CDPEx.Page do
     milestone = if wait_until == :none, do: nil, else: lifecycle_name(wait_until)
 
     with :ok <- ensure_network(page, timeout) do
-      capture_via_helper(page, url, milestone, timeout)
+      run_in_helper(fn -> run_capture(page, url, milestone, timeout) end, :capture_failed)
     end
   end
 
-  # Run the response capture in its own short-lived, monitored process. The helper
-  # subscribes to Network.responseReceived (+ lifecycle) on *its* pid and drains *its*
-  # mailbox, so a caller that is also running observe_network/2 on this page keeps its
-  # subscription and its buffered events intact (#42). Connection monitors every
-  # subscriber and drops it on :DOWN, so the helper's subscription is released when it
-  # exits — no explicit unsubscribe. Every blocking op the helper makes is individually
-  # bounded (subscribe_each catches a dead conn; the Page.navigate call carries `timeout`;
-  # await_capture monitors the conn and honours `deadline`), so the helper always
-  # terminates and the caller awaits exactly one of its result or its :DOWN.
-  defp capture_via_helper(page, url, milestone, timeout) do
+  # Run a capture/wait body (`fun`) in its own short-lived, monitored process and return
+  # its result. The body subscribes to its CDP events on *the helper's* pid and drains
+  # *the helper's* mailbox, so a caller that is also running observe_network/2 on this page
+  # keeps its subscription and its buffered events intact (#42, #48). Connection monitors
+  # every subscriber and drops it on :DOWN, so the helper's subscriptions are released when
+  # it exits — no explicit unsubscribe. `fun` must bound every blocking op it makes
+  # (subscribe_each catches a dead conn; CDP calls carry a timeout; the await loops monitor
+  # the conn and honour a deadline), so the helper always terminates and the caller awaits
+  # exactly one of its result or its :DOWN. A helper that crashes before replying (a
+  # should-never-happen bug) surfaces as {:error, {on_crash, reason}}.
+  defp run_in_helper(fun, on_crash) when is_function(fun, 0) do
     parent = self()
     tag = make_ref()
 
-    {helper, mon} =
-      spawn_monitor(fn ->
-        send(parent, {tag, run_capture(page, url, milestone, timeout)})
-      end)
+    {helper, mon} = spawn_monitor(fn -> send(parent, {tag, fun.()}) end)
 
     receive do
       {^tag, result} ->
@@ -204,7 +202,7 @@ defmodule CDPEx.Page do
         result
 
       {:DOWN, ^mon, :process, ^helper, reason} ->
-        {:error, {:capture_failed, reason}}
+        {:error, {on_crash, reason}}
     end
   end
 
@@ -926,12 +924,11 @@ defmodule CDPEx.Page do
   (e.g. a streaming / SSE / long-poll connection that never closes), or
   `{:error, reason}` if the connection drops. Lazily enables the `Network` domain.
 
-  > #### Don't combine with `observe_network/2` on the same page {: .warning}
-  >
-  > This subscribes the calling process to the `Network` request-lifecycle events for
-  > the duration of the call, then unsubscribes on the way out. If the *same process*
-  > is also running `observe_network/2` on this page, that subscription is torn down.
-  > Drive the idle wait from a process that isn't also observing the network.
+  The idle wait runs in a short-lived helper process with its own subscription, so it
+  composes safely with `observe_network/2` on the same page — the caller's subscription
+  and any buffered events are left untouched. A normal connection drop surfaces as
+  `{:error, :noproc}` / `{:error, {:ws_closed, _}}`; only an abnormal crash of that
+  internal helper returns `{:error, {:idle_wait_failed, reason}}`.
 
   Options:
     * `:idle_time` — ms of continuous idleness required (default 500)
@@ -945,9 +942,20 @@ defmodule CDPEx.Page do
     max_inflight = Keyword.get(opts, :max_inflight, 0)
     deadline = System.monotonic_time(:millisecond) + Keyword.get(opts, :timeout, @navigate_timeout)
 
-    # Subscribe BEFORE enabling so a request that starts the instant the domain turns on
-    # is counted (mirrors observe_network/2); roll the subscriptions back if enable fails.
-    # One deadline spans enable + the idle wait, so :timeout is a true overall ceiling.
+    run_in_helper(
+      fn -> run_network_idle(page, idle_time, max_inflight, deadline) end,
+      :idle_wait_failed
+    )
+  end
+
+  # The idle-wait helper body (runs in the spawned process). Subscribes BEFORE enabling so a
+  # request that starts the instant the domain turns on is counted (mirrors observe_network/2),
+  # then tracks in-flight requests until the network stays idle. `deadline` is an absolute
+  # monotonic time computed by the caller, so one deadline spans enable + the idle wait and
+  # :timeout is a true overall ceiling. Returns :ok | {:error, reason}. No try/after teardown:
+  # the helper's subscriptions are pruned by Connection on its :DOWN and its idle-tick timers
+  # die with it (an enable failure likewise just exits the helper and is auto-pruned).
+  defp run_network_idle(page, idle_time, max_inflight, deadline) do
     with :ok <- subscribe_each(page.conn, @idle_events),
          :ok <- ensure_network(page, remaining(deadline)) do
       Enum.each(@idle_events, &drain_events(page.conn, &1))
@@ -962,23 +970,12 @@ defmodule CDPEx.Page do
         deadline: deadline
       }
 
-      try do
-        # Idle from the call onward: arm immediately (0 in-flight <= max_inflight).
-        case await_network_idle(ctx, %{}, arm_idle(idle_time)) do
-          :idle -> :ok
-          :timeout -> {:error, :timeout}
-          {:down, reason} -> {:error, down_reason(reason)}
-        end
-      after
-        Process.demonitor(ref, [:flush])
-        unsubscribe_each(page.conn, @idle_events)
-        Enum.each(@idle_events, &drain_events(page.conn, &1))
-        drain_idle_ticks()
+      # Idle from the call onward: arm immediately (0 in-flight <= max_inflight).
+      case await_network_idle(ctx, %{}, arm_idle(idle_time)) do
+        :idle -> :ok
+        :timeout -> {:error, :timeout}
+        {:down, reason} -> {:error, down_reason(reason)}
       end
-    else
-      {:error, _} = error ->
-        unsubscribe_each(page.conn, @idle_events)
-        error
     end
   end
 
@@ -1060,14 +1057,6 @@ defmodule CDPEx.Page do
   defp disarm_idle({timer, _tag}) do
     _ = Process.cancel_timer(timer)
     {nil, nil}
-  end
-
-  defp drain_idle_ticks do
-    receive do
-      {:idle_tick, _tag} -> drain_idle_ticks()
-    after
-      0 -> :ok
-    end
   end
 
   defp remaining(deadline), do: max(deadline - System.monotonic_time(:millisecond), 0)

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -259,7 +259,7 @@ defmodule CDPEx.PageTest do
           send(
             test,
             {:caller_done, result, subscribed?(conn, self(), "Network.responseReceived"),
-             drain_cdp_events(conn, [])}
+             drain_cdp_events(conn, "Network.responseReceived", [])}
           )
         end)
 
@@ -802,7 +802,7 @@ defmodule CDPEx.PageTest do
       fake: fake
     } do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 150, timeout: 3_000) end)
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # Two requests start (in-flight 2 > 0 → busy, idle timer cancelled), then both end.
       send_network_event(fake, "Network.requestWillBeSent", "R1")
@@ -816,7 +816,7 @@ defmodule CDPEx.PageTest do
 
     test "clamps in-flight at zero on extra completions", %{page: page, conn: conn, fake: fake} do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 100, timeout: 2_000) end)
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # One request, three completions: the counter must clamp at 0 (never negative)
       # and still resolve.
@@ -830,7 +830,7 @@ defmodule CDPEx.PageTest do
 
     test "times out while a request stays in flight", %{page: page, conn: conn, fake: fake} do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 200, timeout: 500) end)
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # A request that never completes keeps in-flight at 1 (> 0), so it never idles.
       send_network_event(fake, "Network.requestWillBeSent", "R1")
@@ -842,7 +842,7 @@ defmodule CDPEx.PageTest do
       task =
         Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 1_000, timeout: 3_000) end)
 
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # Keep it busy so the idle timer can't fire, then drop the connection.
       send_network_event(fake, "Network.requestWillBeSent", "R1")
@@ -858,7 +858,7 @@ defmodule CDPEx.PageTest do
       fake: fake
     } do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 150, timeout: 3_000) end)
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # A redirecting request: the initial requestWillBeSent (+1), then a redirect hop
       # (requestWillBeSent carrying redirectResponse — must NOT add another +1), then the
@@ -882,7 +882,7 @@ defmodule CDPEx.PageTest do
       fake: fake
     } do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 150, timeout: 5_000) end)
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # A NEW request (seen after the call) is in flight.
       send_network_event(fake, "Network.requestWillBeSent", "NEW")
@@ -907,7 +907,7 @@ defmodule CDPEx.PageTest do
           Page.wait_for_network_idle(page, max_inflight: 2, idle_time: 150, timeout: 5_000)
         end)
 
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # 3 in flight (> max_inflight 2) → busy: must not resolve even past idle_time.
       send_network_event(fake, "Network.requestWillBeSent", "R1")
@@ -926,7 +926,7 @@ defmodule CDPEx.PageTest do
       fake: fake
     } do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 200, timeout: 5_000) end)
-      enable_network_idle(fake, conn, task.pid)
+      enable_network_idle(fake, conn)
 
       # Request then complete → the idle timer arms (in-flight 0).
       send_network_event(fake, "Network.requestWillBeSent", "R1")
@@ -942,40 +942,71 @@ defmodule CDPEx.PageTest do
       assert :ok = Task.await(task, 3_000)
     end
 
-    test "rolls back idle subscriptions when Network.enable fails", %{
+    test "an enable failure leaves no lingering idle subscriptions", %{
       page: page,
       conn: conn,
       fake: fake
     } do
-      test = self()
+      task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 100, timeout: 1_000) end)
 
-      # Run from a long-lived helper (not a Task that exits) so post-rollback state
-      # reflects the explicit unsubscribe, not the connection's dead-subscriber prune.
-      runner =
-        spawn_link(fn ->
-          send(
-            test,
-            {:idle_result, Page.wait_for_network_idle(page, idle_time: 100, timeout: 1_000)}
-          )
-
-          receive do
-            :stop -> :ok
-          after
-            5_000 -> :ok
-          end
-        end)
-
-      for m <- @idle_methods, do: wait_until_subscribed(conn, runner, m)
+      # The helper subscribes to the idle methods before enabling Network.
+      for m <- @idle_methods, do: wait_until_any_subscribed(conn, m)
 
       assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
       FakeCDP.send_text(fake, ~s({"id":#{nid},"error":{"code":-32000,"message":"boom"}}))
 
-      assert_receive {:idle_result, {:error, {:cdp_error, "Network.enable", _}}}, 2_000
+      assert {:error, {:cdp_error, "Network.enable", _}} = Task.await(task)
 
-      # The enable failed → the subscribe-before-enable subscriptions were rolled back.
-      for m <- @idle_methods, do: refute(subscribed?(conn, runner, m))
+      # The helper exited on the error → Connection pruned its idle-method subscriptions
+      # on the resulting :DOWN, so nothing is left subscribed on the connection.
+      for m <- @idle_methods, do: wait_until_no_subscribers(conn, m)
+    end
 
-      send(runner, :stop)
+    test "leaves a same-process observe_network/2 subscription and buffered events intact (#48)",
+         %{page: page, conn: conn, fake: fake} do
+      test = self()
+
+      # The caller observes the network AND waits for idle on the same page. Before #48 the
+      # idle wait tore down the observer's overlapping requestWillBeSent subscription and
+      # drained its buffered events; with the isolated helper both survive.
+      caller =
+        spawn_link(fn ->
+          :ok = Page.observe_network(page)
+          send(test, :observing)
+
+          result = Page.wait_for_network_idle(page, idle_time: 100, timeout: 2_000)
+
+          send(
+            test,
+            {:caller_done, result, subscribed?(conn, self(), "Network.requestWillBeSent"),
+             drain_cdp_events(conn, "Network.requestWillBeSent", [])}
+          )
+        end)
+
+      # observe_network/2 subscribes the caller (requestWillBeSent + responseReceived), then
+      # answer its Network.enable.
+      wait_until_subscribed(conn, caller, "Network.requestWillBeSent")
+      answer_network_enable(fake)
+      assert_receive :observing, 2_000
+
+      # wait_for_network_idle re-enables Network (idempotent); the helper subscribes to the
+      # idle methods (gated on loadingFinished, which only the helper observes) and enters
+      # its loop. enable_network_idle waits for those subs + answers the second enable.
+      enable_network_idle(fake, conn)
+
+      # One request that starts and finishes: the helper counts it and, after idle_time with
+      # nothing in flight, resolves :ok. The observer gets its own copy of the
+      # requestWillBeSent (the helper's loop drains only the helper's mailbox).
+      send_network_event(fake, "Network.requestWillBeSent", "R1")
+      send_network_event(fake, "Network.loadingFinished", "R1")
+
+      assert_receive {:caller_done, result, still_subscribed?, buffered}, 3_000
+
+      assert result == :ok
+      assert still_subscribed?, "wait_for_network_idle tore down the observer's subscription"
+
+      ids = for %{"requestId" => id} <- buffered, do: id
+      assert "R1" in ids, "observer lost its buffered requestWillBeSent event"
     end
   end
 
@@ -1020,15 +1051,31 @@ defmodule CDPEx.PageTest do
     end
   end
 
-  # Collect every buffered Network.responseReceived event currently in this process's
-  # mailbox (the observer's copies), returning their params maps. `after 0` is safe here:
-  # both copies are enqueued (local sends are synchronous) before the helper sends
-  # {:caller_done, ...} that unblocks the caller, so they are already in the mailbox by
-  # the time this runs — no flake window.
-  defp drain_cdp_events(conn, acc) do
+  # Poll until `method` has zero subscribers — e.g. after an internal helper exits and
+  # Connection prunes it on the resulting :DOWN.
+  defp wait_until_no_subscribers(conn, method, retries \\ 100) do
+    cond do
+      MapSet.size(Map.get(:sys.get_state(conn).subscribers, method, MapSet.new())) == 0 ->
+        :ok
+
+      retries == 0 ->
+        flunk("subscribers for #{method} not pruned in time")
+
+      true ->
+        Process.sleep(10)
+        wait_until_no_subscribers(conn, method, retries - 1)
+    end
+  end
+
+  # Collect every buffered `method` cdp_event currently in this process's mailbox (the
+  # observer's copies), returning their params maps. `after 0` is safe here: the copies are
+  # enqueued (local sends are synchronous) before the helper sends the {:caller_done, ...}
+  # that unblocks the caller, so they are already in the mailbox by the time this runs — no
+  # flake window.
+  defp drain_cdp_events(conn, method, acc) do
     receive do
-      {:cdp_event, ^conn, "Network.responseReceived", params, _sid} ->
-        drain_cdp_events(conn, [params | acc])
+      {:cdp_event, ^conn, ^method, params, _sid} ->
+        drain_cdp_events(conn, method, [params | acc])
     after
       0 -> Enum.reverse(acc)
     end
@@ -1050,16 +1097,17 @@ defmodule CDPEx.PageTest do
     end
   end
 
-  # Answer the Network.enable that wait_for_network_idle/2 issues. When `conn`/`pid` are
-  # given, first wait until the three idle subscriptions are registered (subscribe runs
-  # before enable), so events sent afterward are delivered rather than dropped by the drain.
-  defp enable_network_idle(fake, conn \\ nil, pid \\ nil) do
-    if conn && pid, do: for(m <- @idle_methods, do: wait_until_subscribed(conn, pid, m))
+  # Answer the Network.enable that wait_for_network_idle/2 issues. When `conn` is given,
+  # first wait until the three idle subscriptions are registered (subscribe runs before
+  # enable, from the internal helper process whose pid the test can't name), so events sent
+  # afterward are delivered rather than dropped by the drain.
+  defp enable_network_idle(fake, conn \\ nil) do
+    if conn, do: for(m <- @idle_methods, do: wait_until_any_subscribed(conn, m))
     assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
     FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
-    # Let the task drain stale events and enter the receive loop before the caller sends
+    # Let the helper drain stale events and enter the receive loop before the caller sends
     # events, so they land in the loop rather than being swallowed by the pre-loop drain.
-    if conn && pid, do: Process.sleep(50)
+    if conn, do: Process.sleep(50)
   end
 
   defp send_network_event(fake, method, request_id) do


### PR DESCRIPTION
Fixes #48. Follows #42 (PR #47).

## Problem

`wait_for_network_idle/2` subscribed the **calling process** to the `Network` request-lifecycle events (`@idle_events` = `requestWillBeSent` + `loadingFinished` + `loadingFailed`) and tore them down (`unsubscribe_each` + drain) in a `try/after`. Subscriptions are keyed on `{method, pid}` as a `MapSet` (a set, not a refcount), so a process also running `observe_network/2` on the same page (which observes `requestWillBeSent` by default) lost that subscription and had its buffered events drained when the idle wait returned. This is the exact hazard #42 fixed for `navigate(response: true)`.

## Fix

Run the in-flight tracking in a short-lived, `spawn_monitor`'d helper with its own subscription + mailbox (Connection auto-unsubscribes it on `:DOWN`; its idle-tick timers die with it — so the `try/after` teardown and the now-dead `drain_idle_ticks/0` are gone).

Factored the helper-process boilerplate shared with #42 into one **`run_in_helper/2`** primitive. A per-caller crash tag keeps #42's documented `{:capture_failed, _}` shape unchanged; the idle wait surfaces `{:error, {:idle_wait_failed, reason}}` on an abnormal helper crash (documented in the `@doc`). No public API / return-shape change otherwise.

`deadline` is computed in the caller and passed (absolute monotonic time) into the helper, so the single-deadline ceiling is preserved.

## Tests

- New same-process compose regression test: `observe_network/2` + `wait_for_network_idle/2` on one process keeps the observer subscribed **and** its buffered events.
- Rewrote the enable-failure test around the helper-prune semantics (helper exits → Connection prunes → no lingering subscription).
- Generalized the test drain helper by method; updated idle test gates to "any subscriber" (the subscription now belongs to the internal helper pid).
- `mix ci` green (163 tests + 16 doctests, dialyzer 0); all 54 real-Chrome integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)