### PR TITLE
Bound the pool's shutdown launch-drain by one shared deadline (#22 follow-up)

### DIFF
--- a/lib/cdp_ex/pool.ex
+++ b/lib/cdp_ex/pool.ex
@@ -29,7 +29,8 @@ defmodule CDPEx.Pool do
   ## Options
 
     * `:size` — maximum number of browsers (default `1`)
-    * `:launch_opts` — options passed to each `CDPEx.Browser` (see `CDPEx.Chrome`)
+    * `:launch_opts` — options passed to each `CDPEx.Browser` (see `CDPEx.Chrome`); any
+      `:owner` here is ignored — the pool owns its browsers and sets it itself
     * `:checkout_timeout` — ms to wait for a free browser (default `5_000`)
     * `:name` — registers the pool process
   """
@@ -37,6 +38,8 @@ defmodule CDPEx.Pool do
   use GenServer
 
   alias CDPEx.Browser
+
+  require Logger
 
   @default_size 1
   @default_checkout_timeout 5_000
@@ -255,17 +258,30 @@ defmodule CDPEx.Pool do
 
     # An in-flight launch may finish a browser we never adopted: once the task runs
     # Process.unlink/1, that browser is linked to nobody, so killing task_sup won't reap it.
-    # task_sup is still alive here, so each launch can still deliver — block briefly per ref
-    # to catch a just-completed one and stop it (or its terminal :DOWN/error), so a shutdown
-    # mid-launch doesn't orphan Chrome. Bounded by @launch_drain_timeout; child_spec's
-    # shutdown: 30_000 gives headroom for the pool's :size.
+    # task_sup is still alive here, so each launch can still deliver — wait briefly per ref to
+    # catch a just-completed one and stop it (or its terminal :DOWN/error), so a shutdown
+    # mid-launch doesn't orphan Chrome. One SHARED deadline caps the whole drain at
+    # @launch_drain_timeout regardless of :size, so it can't blow past child_spec's
+    # shutdown: 30_000 (which would let the supervisor :brutal_kill us mid-drain).
+    drain_deadline = System.monotonic_time(:millisecond) + @launch_drain_timeout
+
     Enum.each(Map.keys(state.launching), fn ref ->
+      remaining = max(drain_deadline - System.monotonic_time(:millisecond), 0)
+
       receive do
         {^ref, {:ok, browser}} -> safe_stop(browser)
         {^ref, _other} -> :ok
         {:DOWN, ^ref, :process, _pid, _reason} -> :ok
       after
-        @launch_drain_timeout -> :ok
+        remaining ->
+          # Budget spent before this launch delivered — its browser (if it completed) may
+          # leak. Surface it rather than leaking silently. (remaining == 0 once the shared
+          # deadline is used up, so later refs are skipped without a spurious wait.)
+          if remaining > 0 do
+            Logger.warning(
+              "[CDPEx.Pool] a browser launch didn't complete within the shutdown drain; its Chrome may be orphaned"
+            )
+          end
       end
     end)
 


### PR DESCRIPTION
Follow-up to #22, from a focused correctness + adversarial re-review of its review-fixes (run before tagging v0.5.0).

## Problem

`terminate/2`'s in-flight-launch drain waited up to `@launch_drain_timeout` (5s) **per** launching ref. So `size × 5s` could exceed `child_spec`'s `shutdown: 30_000` for a large pool (`:size ≳ 6`) with stalled launches — and the supervisor would `:brutal_kill` the pool mid-drain, orphaning the very browsers the drain exists to reap. (This was a scaling cliff in the bot-suggested per-ref drain; both Opus reviewers flagged it independently.)

## Fix

- **One shared deadline**: the whole drain is now bounded by a single `@launch_drain_timeout` regardless of `:size` (each ref waits only the *remaining* budget), leaving the 30s `shutdown` window for the available/busy Chrome reaps.
- **Observability**: log a warning if a launch doesn't deliver before the budget is spent — a possible orphan is now visible rather than silent.
- **Docs**: note that a caller's `:owner` in the pool's `launch_opts` is ignored (the pool owns its browsers).

## Re-review outcome

The rest of #22's review-fixes were confirmed correct by both reviewers (with traces): the `Browser` `:owner` self-reap (default path unchanged, stripped before `Chrome.launch`, targets the pool), the `launch_failed` shortfall refinement (no strand, no busy-loop), and the drain's message ordering (`{ref, result}` always precedes `{:DOWN}`; no phantom-message hang). This is the only finding.

`mix ci` green (178 tests + 16 doctests, dialyzer 0); all 55 real-Chrome integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)