### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-04
+
 ### Changed
 - `CDPEx.Pool` now launches browsers **asynchronously**. A cold Chrome start used to run synchronously inside the pool process, blocking every other checkout, checkin, and timeout for its duration (a few seconds), so a short `:checkout_timeout` was unreliable while the pool grew to `:size`. Each launch now runs in its own task: the pool stays responsive during warmup, launches for simultaneous waiters run concurrently, and `:checkout_timeout` is honored even mid-launch. Behavior is otherwise unchanged — `count + in-flight launches` never exceeds `:size`, a launch failure surfaces to the caller, and a launched browser is adopted (re-linked) by the pool so its crash handling and `terminate` reaping are preserved (#22).
 
@@ -113,7 +115,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page`: `navigate/3`, `wait_for_selector/3`, `evaluate/3`, `click/3`,
   `html/2`, `screenshot/2`.
 
-[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/patrols/cdp_ex/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/patrols/cdp_ex/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/patrols/cdp_ex/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/patrols/cdp_ex/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/patrols/cdp_ex/compare/v0.2.0...v0.2.1

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CDPEx.MixProject do
   use Mix.Project
 
-  @version "0.4.0"
+  @version "0.5.0"
   @source_url "https://github.com/patrols/cdp_ex"
 
   def project do


### PR DESCRIPTION
The v0.5.0 "robustness" milestone — five fixes hardening the v0.4.0 surface. Promotes the CHANGELOG `[Unreleased]` → `[0.5.0]`, bumps `@version 0.4.0 → 0.5.0`, and repairs the footer compare-links (adds the missing `[0.4.0]` and fixes the stale `[Unreleased]` base).

## What's in v0.5.0

| # | Fix |
|---|-----|
| #42 | `navigate(response: true)` captures in an isolated helper — composes safely with `observe_network/2` |
| #48 | `wait_for_network_idle/2` gets the same isolation (shared `run_in_helper` primitive) |
| #40 | `authenticate/4` recovers from a caller timeout instead of sticking on `:already_authenticated` |
| #49 | `navigate/3` + `wait_for_navigation/2` honour `:timeout` as a true overall ceiling; `Connection.subscribe/3` gains an optional timeout |
| #22 | `CDPEx.Pool` launches browsers asynchronously (concurrent warmup, responsive cold starts) with owner-adoption + a bounded shutdown drain |

Every fix went through build → multi-agent review → fix → green CI; #22 additionally through a GitHub-bot review and a focused correctness+adversarial pass (which caught a P1 ownership regression and a P2 shutdown-drain scaling cliff, both fixed).

## Verification
- `mix ci` green (178 tests + 16 doctests, dialyzer 0) across Elixir 1.15 / 1.19 / 1.20.
- All 55 real-Chrome integration tests pass.
- `mix hex.build` produces a clean `cdp_ex-0.5.0` package.

After merge: tag `v0.5.0` + push, then `mix hex.publish` (run by the maintainer — interactive 2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)