### PR TITLE
Fix flaky wait_for_response integration test (getResponseBody race)

### DIFF
--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -875,8 +875,16 @@ defmodule CDPEx.Page do
   `observe_network/2`) **when the request was captured** — unlike the other Network
   ops this does not lazily enable it, since enabling now can't recover a past body.
   If it wasn't enabled, the call surfaces as
-  `{:error, {:cdp_error, "Network.getResponseBody", _}}`. Options: `:timeout`
-  (default 10_000).
+  `{:error, {:cdp_error, "Network.getResponseBody", _}}`.
+
+  The body is only retrievable once the request has finished loading. Calling this in
+  the window between `Network.responseReceived` (what `wait_for_response/3` resolves on)
+  and `Network.loadingFinished` can return
+  `{:error, {:cdp_error, "Network.getResponseBody", %{"code" => -32000}}}`
+  ("No data found …"). Wait for the network to settle (e.g. `wait_for_network_idle/2`)
+  before reading, or retry on that transient error.
+
+  Options: `:timeout` (default 10_000).
   """
   @spec response_body(t(), String.t(), keyword()) :: {:ok, binary()} | {:error, term()}
   def response_body(%__MODULE__{} = page, request_id, opts \\ []) when is_binary(request_id) do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -349,7 +349,7 @@ defmodule CDPEx.IntegrationTest do
                Task.await(waiter, 10_000)
 
       assert url =~ "/data"
-      assert {:ok, "fetched-data"} = Page.response_body(page, req)
+      assert {:ok, "fetched-data"} = read_body_eventually(page, req)
     end
 
     test "wait_for_network_idle settles even when the fetch redirects", %{
@@ -906,6 +906,26 @@ defmodule CDPEx.IntegrationTest do
       true ->
         Process.sleep(20)
         eventually(fun, retries - 1)
+    end
+  end
+
+  # wait_for_response/3 resolves on Network.responseReceived (headers/status arrived),
+  # but Chrome only guarantees the body via Network.getResponseBody after
+  # loadingFinished. In that window getResponseBody returns -32000 "No data found for
+  # resource with given identifier" — a transient race, widened under CI load. Retry only
+  # that specific error so the assertion still surfaces any genuine failure verbatim.
+  defp read_body_eventually(page, req, retries \\ 20)
+
+  defp read_body_eventually(page, req, 0), do: Page.response_body(page, req)
+
+  defp read_body_eventually(page, req, retries) do
+    case Page.response_body(page, req) do
+      {:error, {:cdp_error, "Network.getResponseBody", %{"code" => -32_000}}} ->
+        Process.sleep(50)
+        read_body_eventually(page, req, retries - 1)
+
+      other ->
+        other
     end
   end
 end


### PR DESCRIPTION
## The flake

`test/cdp_ex/integration_test.exs:339` ("wait_for_response returns the matching fetch response") intermittently failed on the v0.6.0 release-branch merge run:

```
assert {:ok, "fetched-data"} = Page.response_body(page, req)
right: {:error, {:cdp_error, "Network.getResponseBody",
        %{"code" => -32000, "message" => "No data found for resource with given identifier"}}}
```

## Root cause — a CDP timing race, not a library bug

- `wait_for_response/3` resolves on **`Network.responseReceived`** (fires when response headers/status arrive — its documented contract).
- The test then immediately calls `response_body/3` → **`Network.getResponseBody`**, but Chrome only guarantees the **body** is retrievable after **`Network.loadingFinished`** (body fully downloaded & stored), which comes *after* `responseReceived`.
- In that window `getResponseBody` returns `-32000 "No data found …"`. For the tiny body the window is normally sub-ms (passes ~always); under CI load it widens → the flake.

Both `wait_for_response/3` and `response_body/3` behave correctly — the *test* assumed the body was readable the instant the response arrived.

## Fix (test-scoped)

Retry `response_body/3` only on that specific transient `-32000` error (bounded: 20 × 50ms ≈ 1s) before asserting. Any other error — or exhaustion — returns verbatim, so a genuine failure still surfaces with full context.

Deliberately **not** a library change: `response_body/3` shouldn't silently sleep/retry (a `-32000` can also be terminal — an evicted/never-stored body), and retry policy belongs to the caller (who now has `CDPEx.classify_error/1`). Added a comment documenting the responseReceived↔loadingFinished timing.

`mix ci` green; the test passes against real Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)