### PR TITLE
set_user_agent/3: UA Client Hints (userAgentMetadata) + accept_language (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `CDPEx.Page.set_user_agent/3` accepts `:user_agent_metadata` (a CDP `Emulation.UserAgentMetadata` map) and `:accept_language`, passed through to `Emulation.setUserAgentOverride`. Overriding only the UA string leaves the UA Client Hints surface (`navigator.userAgentData`, the `Sec-CH-UA*` headers) at Chrome's defaults — a visible `navigator.userAgent` ↔ Client-Hints mismatch; `:user_agent_metadata` keeps them consistent (#34).
+
 ## [0.6.0] - 2026-06-04
 
 ### Added

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -179,7 +179,10 @@ defmodule CDPEx do
   Retries are the caller's responsibility: bound the attempts and back off. A
   `:transient` result means **re-establish the resource** — open a fresh page/browser
   or call `CDPEx.Pool.checkout/2` again — not retry the same handle (a dead page keeps
-  returning `:noproc`). The input is typed `term()` so the catch-all stays reachable;
+  returning `:noproc`). Some `:transient` reasons are still a judgment call for your
+  environment — retrying a `:timeout` / `net::ERR_TIMED_OUT` multiplies wall-time and
+  browser memory, so a resource-constrained caller may reasonably treat timeouts as
+  terminal. The input is typed `term()` so the catch-all stays reachable;
   routing through this instead of matching `t:error_reason/0` directly trades Dialyzer
   exhaustiveness for a stable, library-maintained dispatch point.
   """

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -1304,7 +1304,10 @@ defmodule CDPEx.Page do
       UA Client Hints surface (`navigator.userAgentData`, the `Sec-CH-UA*` headers) so
       it stays consistent with the UA string. Overriding only the string leaves Client
       Hints at Chrome's defaults — a visible `navigator.userAgent` ↔ Client-Hints
-      mismatch. Passed through verbatim, so it must match the CDP shape.
+      mismatch. Passed through verbatim, so it must match the CDP shape: a partial or
+      empty map is **not** dropped — it's sent as-is and Chrome rejects the whole
+      `setUserAgentOverride` call. Omit the option entirely to leave Client Hints at
+      Chrome's default.
     * `:accept_language` — value for the `Accept-Language` header and `navigator.language`
       (e.g. `"en-US"`).
     * `:timeout` (default 10_000).

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -1298,12 +1298,42 @@ defmodule CDPEx.Page do
   @doc """
   Overrides the page's User-Agent (`Emulation.setUserAgentOverride`).
 
-  Options: `:timeout` (default 10_000).
+  Options:
+    * `:user_agent_metadata` — a CDP `Emulation.UserAgentMetadata` map (string keys,
+      e.g. `%{"platform" => "macOS", "mobile" => false, "brands" => [...]}`). Sets the
+      UA Client Hints surface (`navigator.userAgentData`, the `Sec-CH-UA*` headers) so
+      it stays consistent with the UA string. Overriding only the string leaves Client
+      Hints at Chrome's defaults — a visible `navigator.userAgent` ↔ Client-Hints
+      mismatch. Passed through verbatim, so it must match the CDP shape.
+    * `:accept_language` — value for the `Accept-Language` header and `navigator.language`
+      (e.g. `"en-US"`).
+    * `:timeout` (default 10_000).
+
+  ## Example
+
+      Page.set_user_agent(page, "Mozilla/5.0 (Macintosh…) Chrome/120.0.0.0 Safari/537.36",
+        user_agent_metadata: %{
+          "platform" => "macOS",
+          "platformVersion" => "14.0.0",
+          "architecture" => "arm",
+          "model" => "",
+          "mobile" => false,
+          "brands" => [
+            %{"brand" => "Chromium", "version" => "120"},
+            %{"brand" => "Not=A?Brand", "version" => "24"}
+          ]
+        },
+        accept_language: "en-US"
+      )
   """
   @spec set_user_agent(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def set_user_agent(%__MODULE__{} = page, user_agent, opts \\ []) when is_binary(user_agent) do
     timeout = Keyword.get(opts, :timeout, @command_timeout)
-    params = %{"userAgent" => user_agent}
+
+    params =
+      %{"userAgent" => user_agent}
+      |> put_present("userAgentMetadata", Keyword.get(opts, :user_agent_metadata))
+      |> put_present("acceptLanguage", Keyword.get(opts, :accept_language))
 
     case do_call(page, "Emulation.setUserAgentOverride", params, timeout) do
       {:ok, _} -> :ok

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -61,6 +61,56 @@ defmodule CDPEx.PageTest do
     }
   end
 
+  describe "set_user_agent/3" do
+    test "passes userAgentMetadata + acceptLanguage through to setUserAgentOverride", %{
+      fake: fake,
+      page: page
+    } do
+      meta = %{
+        "platform" => "macOS",
+        "mobile" => false,
+        "brands" => [%{"brand" => "Chromium", "version" => "120"}]
+      }
+
+      task =
+        Task.async(fn ->
+          Page.set_user_agent(page, "UA/1.0", user_agent_metadata: meta, accept_language: "en-US")
+        end)
+
+      assert_receive {:fake_cdp_recv, ^fake,
+                      %{
+                        "id" => id,
+                        "method" => "Emulation.setUserAgentOverride",
+                        "params" => params
+                      }},
+                     2_000
+
+      assert params["userAgent"] == "UA/1.0"
+      assert params["userAgentMetadata"] == meta
+      assert params["acceptLanguage"] == "en-US"
+
+      FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
+      assert :ok = Task.await(task)
+    end
+
+    test "omits userAgentMetadata/acceptLanguage when not given", %{fake: fake, page: page} do
+      task = Task.async(fn -> Page.set_user_agent(page, "UA/1.0") end)
+
+      assert_receive {:fake_cdp_recv, ^fake,
+                      %{
+                        "id" => id,
+                        "method" => "Emulation.setUserAgentOverride",
+                        "params" => params
+                      }},
+                     2_000
+
+      assert params == %{"userAgent" => "UA/1.0"}
+
+      FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
+      assert :ok = Task.await(task)
+    end
+  end
+
   describe "wait_for_navigation/2" do
     test "resolves only on a matching Page.lifecycleEvent — not another method or name", %{
       page: page,


### PR DESCRIPTION
Closes #34.

Overriding only the UA **string** leaves Chrome's UA Client Hints surface (`navigator.userAgentData`, the `Sec-CH-UA*` headers) at its defaults — a visible `navigator.userAgent` ↔ Client-Hints mismatch, and a detectable tell at verification walls.

- **`:user_agent_metadata`** — a CDP `Emulation.UserAgentMetadata` map, passed through to `Emulation.setUserAgentOverride` so Client Hints stay consistent with the string. Verbatim pass-through (must match the CDP shape), consistent with how cookies / fetch patterns are handled.
- **`:accept_language`** — sets the `Accept-Language` header + `navigator.language`; the natural companion for a consistent locale profile.

Both are omitted from the call when not given — no behavior change for existing callers. A real CDP field, not an evasion hack — squarely in scope (the README keeps anti-fingerprinting *frameworks* out of scope; this is a first-class capability).

Also folds in a **doc-only** note on `CDPEx.classify_error/1`: retrying a `:timeout` / `net::ERR_TIMED_OUT` is a judgment call for resource-constrained callers (a retry multiplies wall-time + browser memory), so treating timeouts as terminal is valid caller policy.

`mix ci` green (190 tests + 16 doctests; 2 new FakeCDP unit tests assert the params are passed through / omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)