### PR TITLE
Test the proxy auto-auth round-trip end-to-end (#65)

### DIFF
--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -1,7 +1,11 @@
 defmodule CDPEx.BrowserTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias CDPEx.Browser
+  alias CDPEx.Connection
+  alias CDPEx.FakeCDP
   alias CDPEx.Page
 
   describe "new_page/2 transport validation" do
@@ -309,6 +313,77 @@ defmodule CDPEx.BrowserTest do
 
       assert {:noreply, ^state} =
                Browser.handle_info({:DOWN, make_ref(), :process, self(), :noproc}, state)
+    end
+  end
+
+  describe "proxy auto-auth cleanup (FakeCDP fault injection)" do
+    test "an arm failure during new_page tears down the just-created page and surfaces the error" do
+      # Drive the full new_page → reply_proxy_authed_page path against a fake Chrome and
+      # make Fetch.enable fail, so the synchronous arm (await_fetch_armed) returns an error
+      # and close_failed_auth_page must close the page that was never handed back. Runs the
+      # handle_call in a Task (it blocks on the CDP conversation) while this process plays
+      # the fake Chrome, answering each frame — and failing Fetch.enable.
+      {:ok, server} = FakeCDP.start()
+      {:ok, browser_conn} = Connection.start_link(server.url)
+      assert_receive {:fake_cdp_connected, _fake_browser}, 1_000
+
+      state = %Browser{
+        browser_conn: browser_conn,
+        host: "127.0.0.1",
+        port: server.port,
+        proxy_auth: %{username: "u", password: "p"}
+      }
+
+      log =
+        capture_log(fn ->
+          task =
+            Task.async(fn ->
+              Browser.handle_call({:new_page, []}, {self(), make_ref()}, state)
+            end)
+
+          choreograph_failing_arm()
+
+          assert {:reply, {:error, {:cdp_error, "Fetch.enable", _}}, new_state} =
+                   Task.await(task, 5_000)
+
+          # The page was opened then torn down: not retained, and never recorded as authed.
+          assert new_state.pages == %{}
+          assert new_state.auths == %{}
+        end)
+
+      assert log =~ "arming failed"
+
+      Connection.close(browser_conn)
+    end
+  end
+
+  # Answer the CDP frames new_page issues against the fake Chrome: a targetId for
+  # Target.createTarget, an OK for the bootstrap calls (and the teardown Fetch.disable),
+  # but an ERROR for Fetch.enable — the fault that makes the proxy-auth arm fail. Returns
+  # once Target.closeTarget arrives, which is the last frame close_failed_auth_page sends.
+  defp choreograph_failing_arm do
+    receive do
+      {:fake_cdp_connected, _fake} ->
+        # The dedicated page's connection came up; keep answering.
+        choreograph_failing_arm()
+
+      {:fake_cdp_recv, fake, %{"id" => id, "method" => "Target.createTarget"}} ->
+        FakeCDP.send_text(fake, ~s({"id":#{id},"result":{"targetId":"T1"}}))
+        choreograph_failing_arm()
+
+      {:fake_cdp_recv, fake, %{"id" => id, "method" => "Fetch.enable"}} ->
+        FakeCDP.send_text(fake, ~s({"id":#{id},"error":{"code":-32000,"message":"boom"}}))
+        choreograph_failing_arm()
+
+      {:fake_cdp_recv, fake, %{"id" => id, "method" => "Target.closeTarget"}} ->
+        FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
+        :ok
+
+      {:fake_cdp_recv, fake, %{"id" => id}} ->
+        FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
+        choreograph_failing_arm()
+    after
+      5_000 -> flunk("timed out waiting for new_page CDP frames")
     end
   end
 end

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -320,12 +320,13 @@ defmodule CDPEx.BrowserTest do
     test "an arm failure during new_page tears down the just-created page and surfaces the error" do
       # Drive the full new_page → reply_proxy_authed_page path against a fake Chrome and
       # make Fetch.enable fail, so the synchronous arm (await_fetch_armed) returns an error
-      # and close_failed_auth_page must close the page that was never handed back. Runs the
-      # handle_call in a Task (it blocks on the CDP conversation) while this process plays
-      # the fake Chrome, answering each frame — and failing Fetch.enable.
-      {:ok, server} = FakeCDP.start()
+      # and close_failed_auth_page must close the page that was never handed back. A
+      # dedicated process plays the fake Chrome (the FakeCDP controller, answering every
+      # CDP frame and erroring only Fetch.enable), leaving this process free to run the
+      # blocking handle_call in a Task and await its reply.
+      fake = spawn_link(&fake_chrome_failing_arm/0)
+      {:ok, server} = FakeCDP.start(fake)
       {:ok, browser_conn} = Connection.start_link(server.url)
-      assert_receive {:fake_cdp_connected, _fake_browser}, 1_000
 
       state = %Browser{
         browser_conn: browser_conn,
@@ -341,10 +342,8 @@ defmodule CDPEx.BrowserTest do
               Browser.handle_call({:new_page, []}, {self(), make_ref()}, state)
             end)
 
-          choreograph_failing_arm()
-
           assert {:reply, {:error, {:cdp_error, "Fetch.enable", _}}, new_state} =
-                   Task.await(task, 5_000)
+                   Task.await(task, 15_000)
 
           # The page was opened then torn down: not retained, and never recorded as authed.
           assert new_state.pages == %{}
@@ -357,33 +356,26 @@ defmodule CDPEx.BrowserTest do
     end
   end
 
-  # Answer the CDP frames new_page issues against the fake Chrome: a targetId for
-  # Target.createTarget, an OK for the bootstrap calls (and the teardown Fetch.disable),
-  # but an ERROR for Fetch.enable — the fault that makes the proxy-auth arm fail. Returns
-  # once Target.closeTarget arrives, which is the last frame close_failed_auth_page sends.
-  defp choreograph_failing_arm do
+  # A fake Chrome for the test above: answer every CDP frame the new_page conversation
+  # issues — a targetId for Target.createTarget, an OK for the bootstrap calls (and the
+  # teardown Fetch.disable/closeTarget), but an ERROR for Fetch.enable, the fault that
+  # makes the proxy-auth arm fail. Loops until its linker (the test process) exits, so
+  # there's no per-message timeout to race CI load — Task.await is the sole deadline.
+  defp fake_chrome_failing_arm do
     receive do
-      {:fake_cdp_connected, _fake} ->
-        # The dedicated page's connection came up; keep answering.
-        choreograph_failing_arm()
-
       {:fake_cdp_recv, fake, %{"id" => id, "method" => "Target.createTarget"}} ->
         FakeCDP.send_text(fake, ~s({"id":#{id},"result":{"targetId":"T1"}}))
-        choreograph_failing_arm()
 
       {:fake_cdp_recv, fake, %{"id" => id, "method" => "Fetch.enable"}} ->
         FakeCDP.send_text(fake, ~s({"id":#{id},"error":{"code":-32000,"message":"boom"}}))
-        choreograph_failing_arm()
-
-      {:fake_cdp_recv, fake, %{"id" => id, "method" => "Target.closeTarget"}} ->
-        FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
-        :ok
 
       {:fake_cdp_recv, fake, %{"id" => id}} ->
         FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
-        choreograph_failing_arm()
-    after
-      5_000 -> flunk("timed out waiting for new_page CDP frames")
+
+      {:fake_cdp_connected, _fake} ->
+        :ok
     end
+
+    fake_chrome_failing_arm()
   end
 end

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -324,7 +324,8 @@ defmodule CDPEx.BrowserTest do
       # dedicated process plays the fake Chrome (the FakeCDP controller, answering every
       # CDP frame and erroring only Fetch.enable), leaving this process free to run the
       # blocking handle_call in a Task and await its reply.
-      fake = spawn_link(&fake_chrome_failing_arm/0)
+      test = self()
+      fake = spawn_link(fn -> fake_chrome_failing_arm(test) end)
       {:ok, server} = FakeCDP.start(fake)
       {:ok, browser_conn} = Connection.start_link(server.url)
 
@@ -343,11 +344,13 @@ defmodule CDPEx.BrowserTest do
             end)
 
           assert {:reply, {:error, {:cdp_error, "Fetch.enable", _}}, new_state} =
-                   Task.await(task, 15_000)
+                   Task.await(task, 30_000)
 
-          # The page was opened then torn down: not retained, and never recorded as authed.
+          # The page was opened then torn down: dropped from state, never recorded as
+          # authed, and its orphaned Chrome tab actually closed (Target.closeTarget sent).
           assert new_state.pages == %{}
           assert new_state.auths == %{}
+          assert_receive :close_target_sent, 1_000
         end)
 
       assert log =~ "arming failed"
@@ -358,16 +361,21 @@ defmodule CDPEx.BrowserTest do
 
   # A fake Chrome for the test above: answer every CDP frame the new_page conversation
   # issues — a targetId for Target.createTarget, an OK for the bootstrap calls (and the
-  # teardown Fetch.disable/closeTarget), but an ERROR for Fetch.enable, the fault that
-  # makes the proxy-auth arm fail. Loops until its linker (the test process) exits, so
-  # there's no per-message timeout to race CI load — Task.await is the sole deadline.
-  defp fake_chrome_failing_arm do
+  # teardown Fetch.disable), but an ERROR for Fetch.enable, the fault that makes the
+  # proxy-auth arm fail. Tells `test` when it sees Target.closeTarget, so the test can
+  # assert the orphaned tab was actually closed. Loops until its linker (the test process)
+  # exits, so there's no per-message timeout to race CI load — Task.await is the deadline.
+  defp fake_chrome_failing_arm(test) do
     receive do
       {:fake_cdp_recv, fake, %{"id" => id, "method" => "Target.createTarget"}} ->
         FakeCDP.send_text(fake, ~s({"id":#{id},"result":{"targetId":"T1"}}))
 
       {:fake_cdp_recv, fake, %{"id" => id, "method" => "Fetch.enable"}} ->
         FakeCDP.send_text(fake, ~s({"id":#{id},"error":{"code":-32000,"message":"boom"}}))
+
+      {:fake_cdp_recv, fake, %{"id" => id, "method" => "Target.closeTarget"}} ->
+        send(test, :close_target_sent)
+        FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
 
       {:fake_cdp_recv, fake, %{"id" => id}} ->
         FakeCDP.send_text(fake, ~s({"id":#{id},"result":{}}))
@@ -376,6 +384,6 @@ defmodule CDPEx.BrowserTest do
         :ok
     end
 
-    fake_chrome_failing_arm()
+    fake_chrome_failing_arm(test)
   end
 end

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -17,6 +17,7 @@ defmodule CDPEx.IntegrationTest do
   alias CDPEx.FixtureServer
   alias CDPEx.Page
   alias CDPEx.Pool
+  alias CDPEx.ProxyAuthServer
 
   @moduletag :integration
   # Real Chrome launches are slower than the default 60s in aggregate.
@@ -586,6 +587,32 @@ defmodule CDPEx.IntegrationTest do
       on_exit(fn -> stop_quietly(browser) end)
 
       assert {:ok, _page} = CDPEx.new_page(browser, transport: :session)
+    end
+
+    # The above use an unreachable proxy and never navigate. These two drive the full
+    # round-trip against a real authenticating proxy: the auto-armed handler answers a
+    # 407 (source: Proxy) with the launch credentials so traffic flows. The target host
+    # is non-resolvable on purpose — a load can only happen THROUGH the proxy.
+    test "auto-auth answers a proxy 407 so a navigation succeeds through the proxy" do
+      {:ok, %{port: proxy_port}} = ProxyAuthServer.start(username: "puser", password: "ppass")
+      {:ok, browser} = CDPEx.launch(proxy: "http://puser:ppass@127.0.0.1:#{proxy_port}")
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, page} = CDPEx.new_page(browser)
+      assert {:ok, _} = Page.navigate(page, "http://proxied.test/")
+      assert {:ok, "Proxied"} = Page.text(page, "#greeting")
+    end
+
+    test "without credentials a proxy 407 blocks the navigation (the proxy enforces auth)" do
+      # Same proxy, but launched with a credential-less URL: no Fetch handler is armed,
+      # so Chrome can't answer the 407 and the navigation fails — which also proves the
+      # positive test above isn't a no-op (the proxy genuinely challenges).
+      {:ok, %{port: proxy_port}} = ProxyAuthServer.start(username: "puser", password: "ppass")
+      {:ok, browser} = CDPEx.launch(proxy: "http://127.0.0.1:#{proxy_port}")
+      on_exit(fn -> stop_quietly(browser) end)
+
+      {:ok, page} = CDPEx.new_page(browser)
+      assert {:error, {:navigate, _}} = Page.navigate(page, "http://proxied.test/")
     end
   end
 

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -606,15 +606,18 @@ defmodule CDPEx.IntegrationTest do
     test "without credentials a proxy 407 blocks the navigation (the proxy enforces auth)" do
       # Same proxy, but launched with a credential-less URL: no Fetch handler is armed,
       # so Chrome can't answer the 407 and the navigation fails — which also proves the
-      # positive test above isn't a no-op (the proxy genuinely challenges). The assertion
-      # hinges on Chrome surfacing the unanswered 407 as a navigate errorText (net::ERR_*),
-      # not on a readiness-wait timeout (which navigate/3 reports as a best-effort {:ok, _}).
+      # positive test above isn't a no-op (the proxy genuinely challenges). `wait_until:
+      # :none` pins the assertion to Page.navigate's synchronous errorText (net::ERR_*) for
+      # the blocked load, rather than the default readiness wait (whose timeout navigate/3
+      # reports as a best-effort {:ok, _}).
       {:ok, %{port: proxy_port}} = ProxyAuthServer.start(username: "puser", password: "ppass")
       {:ok, browser} = CDPEx.launch(proxy: "http://127.0.0.1:#{proxy_port}")
       on_exit(fn -> stop_quietly(browser) end)
 
       {:ok, page} = CDPEx.new_page(browser)
-      assert {:error, {:navigate, _}} = Page.navigate(page, "http://proxied.test/")
+
+      assert {:error, {:navigate, _}} =
+               Page.navigate(page, "http://proxied.test/", wait_until: :none)
     end
   end
 

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -606,7 +606,9 @@ defmodule CDPEx.IntegrationTest do
     test "without credentials a proxy 407 blocks the navigation (the proxy enforces auth)" do
       # Same proxy, but launched with a credential-less URL: no Fetch handler is armed,
       # so Chrome can't answer the 407 and the navigation fails — which also proves the
-      # positive test above isn't a no-op (the proxy genuinely challenges).
+      # positive test above isn't a no-op (the proxy genuinely challenges). The assertion
+      # hinges on Chrome surfacing the unanswered 407 as a navigate errorText (net::ERR_*),
+      # not on a readiness-wait timeout (which navigate/3 reports as a best-effort {:ok, _}).
       {:ok, %{port: proxy_port}} = ProxyAuthServer.start(username: "puser", password: "ppass")
       {:ok, browser} = CDPEx.launch(proxy: "http://127.0.0.1:#{proxy_port}")
       on_exit(fn -> stop_quietly(browser) end)

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -10,6 +10,8 @@ defmodule CDPEx.FixtureServer do
   #     {:ok, %{url: url}} = FixtureServer.start()
   #     CDPEx.Page.navigate(page, url)
 
+  alias CDPEx.HttpFixture
+
   @spec start() :: {:ok, %{port: non_neg_integer(), url: String.t()}}
   def start do
     {:ok, listen} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
@@ -33,7 +35,7 @@ defmodule CDPEx.FixtureServer do
   defp serve(socket) do
     # Read the full request headers (they may arrive across TCP segments) so the
     # header reflection and auth check are deterministic, then respond.
-    request = recv_request(socket, "")
+    request = HttpFixture.recv_request(socket)
     _ = :gen_tcp.send(socket, respond(request))
     :gen_tcp.close(socket)
   end
@@ -56,46 +58,36 @@ defmodule CDPEx.FixtureServer do
     cond do
       String.starts_with?(path, "/basic-auth") and not authorized?(request) ->
         body = ~s(<!doctype html><html><body><p id="status">401</p></body></html>)
-        http_response("401 Unauthorized", body, ["WWW-Authenticate: Basic realm=\"cdpex\""])
+
+        HttpFixture.http_response("401 Unauthorized", body, [
+          "WWW-Authenticate: Basic realm=\"cdpex\""
+        ])
 
       String.starts_with?(path, "/redirect") ->
-        http_response("302 Found", "", ["Location: /"])
+        HttpFixture.http_response("302 Found", "", ["Location: /"])
 
       String.starts_with?(path, "/missing") ->
         body = ~s(<!doctype html><html><body><p id="status">404</p></body></html>)
-        http_response("404 Not Found", body, [])
+        HttpFixture.http_response("404 Not Found", body)
 
       String.starts_with?(path, "/data") ->
-        http_response("200 OK", "fetched-data", [])
+        HttpFixture.http_response("200 OK", "fetched-data")
 
       true ->
-        http_response("200 OK", render(request), [])
+        HttpFixture.http_response("200 OK", render(request))
     end
   end
 
-  defp authorized?(request), do: header_value(request, "authorization") == @basic_auth
+  defp authorized?(request), do: HttpFixture.header_value(request, "authorization") == @basic_auth
 
   defp request_path(request) do
     request |> String.split("\r\n", parts: 2) |> hd() |> String.split(" ") |> Enum.at(1, "/")
   end
 
-  defp http_response(status, body, extra_headers) do
-    headers =
-      [
-        "HTTP/1.1 #{status}",
-        "Content-Type: text/html; charset=utf-8",
-        "Content-Length: #{byte_size(body)}",
-        "Connection: close"
-        | extra_headers
-      ]
-
-    Enum.join(headers, "\r\n") <> "\r\n\r\n" <> body
-  end
-
   # Reflects the X-CDPEx-Test request header into #echo-header so integration
   # tests can assert that extra headers were actually sent on the request.
   defp render(request) do
-    echo = html_escape(header_value(request, "x-cdpex-test"))
+    echo = html_escape(HttpFixture.header_value(request, "x-cdpex-test"))
 
     """
     <!doctype html>
@@ -110,37 +102,6 @@ defmodule CDPEx.FixtureServer do
       </body>
     </html>
     """
-  end
-
-  defp header_value(request, name) do
-    request
-    |> String.split("\r\n")
-    |> Enum.find_value("", &match_header(&1, name))
-  end
-
-  defp match_header(line, name) do
-    case String.split(line, ":", parts: 2) do
-      [k, v] -> if String.downcase(String.trim(k)) == name, do: String.trim(v)
-      _ -> nil
-    end
-  end
-
-  # Read until the end-of-headers marker (or a sane cap), so a request split
-  # across TCP segments still yields the full headers for reflection.
-  defp recv_request(socket, acc) do
-    cond do
-      String.contains?(acc, "\r\n\r\n") ->
-        acc
-
-      byte_size(acc) > 65_536 ->
-        acc
-
-      true ->
-        case :gen_tcp.recv(socket, 0, 5_000) do
-          {:ok, data} -> recv_request(socket, acc <> data)
-          _ -> acc
-        end
-    end
   end
 
   defp html_escape(value) do

--- a/test/support/http_fixture.ex
+++ b/test/support/http_fixture.ex
@@ -1,0 +1,63 @@
+defmodule CDPEx.HttpFixture do
+  @moduledoc false
+  # Shared HTTP/1.1 plumbing for the dependency-free test fixture servers
+  # (`CDPEx.FixtureServer`, `CDPEx.ProxyAuthServer`): read a full request off a
+  # raw socket, pull a header value, and build a `Connection: close` response.
+  #
+  # Kept deliberately tiny — just enough for a single request/response per socket,
+  # so the fixtures stay readable and don't each re-implement the same parsing.
+
+  @doc """
+  Read request bytes until the end-of-headers marker (or a sane cap), so a request
+  split across TCP segments still yields the full headers. Returns what it has on
+  a recv error/timeout rather than blocking forever.
+  """
+  @spec recv_request(:gen_tcp.socket()) :: String.t()
+  def recv_request(socket), do: recv_request(socket, "")
+
+  defp recv_request(socket, acc) do
+    cond do
+      String.contains?(acc, "\r\n\r\n") ->
+        acc
+
+      byte_size(acc) > 65_536 ->
+        acc
+
+      true ->
+        case :gen_tcp.recv(socket, 0, 5_000) do
+          {:ok, data} -> recv_request(socket, acc <> data)
+          _ -> acc
+        end
+    end
+  end
+
+  @doc "The (case-insensitive) value of request header `name`, or `\"\"` if absent."
+  @spec header_value(String.t(), String.t()) :: String.t()
+  def header_value(request, name) do
+    request
+    |> String.split("\r\n")
+    |> Enum.find_value("", &match_header(&1, name))
+  end
+
+  defp match_header(line, name) do
+    case String.split(line, ":", parts: 2) do
+      [k, v] -> if String.downcase(String.trim(k)) == name, do: String.trim(v)
+      _ -> nil
+    end
+  end
+
+  @doc "Build a complete `Connection: close` HTTP/1.1 response with the given status and body."
+  @spec http_response(String.t(), String.t(), [String.t()]) :: String.t()
+  def http_response(status, body, extra_headers \\ []) do
+    headers =
+      [
+        "HTTP/1.1 #{status}",
+        "Content-Type: text/html; charset=utf-8",
+        "Content-Length: #{byte_size(body)}",
+        "Connection: close"
+        | extra_headers
+      ]
+
+    Enum.join(headers, "\r\n") <> "\r\n\r\n" <> body
+  end
+end

--- a/test/support/http_fixture.ex
+++ b/test/support/http_fixture.ex
@@ -7,11 +7,9 @@ defmodule CDPEx.HttpFixture do
   # Kept deliberately tiny — just enough for a single request/response per socket,
   # so the fixtures stay readable and don't each re-implement the same parsing.
 
-  @doc """
-  Read request bytes until the end-of-headers marker (or a sane cap), so a request
-  split across TCP segments still yields the full headers. Returns what it has on
-  a recv error/timeout rather than blocking forever.
-  """
+  # Read request bytes until the end-of-headers marker (or a sane cap), so a request
+  # split across TCP segments still yields the full headers. Returns what it has on a
+  # recv error/timeout rather than blocking forever.
   @spec recv_request(:gen_tcp.socket()) :: String.t()
   def recv_request(socket), do: recv_request(socket, "")
 
@@ -31,7 +29,7 @@ defmodule CDPEx.HttpFixture do
     end
   end
 
-  @doc "The (case-insensitive) value of request header `name`, or `\"\"` if absent."
+  # The (case-insensitive) value of request header `name`, or "" if absent.
   @spec header_value(String.t(), String.t()) :: String.t()
   def header_value(request, name) do
     request
@@ -46,7 +44,7 @@ defmodule CDPEx.HttpFixture do
     end
   end
 
-  @doc "Build a complete `Connection: close` HTTP/1.1 response with the given status and body."
+  # Build a complete `Connection: close` HTTP/1.1 response with the given status and body.
   @spec http_response(String.t(), String.t(), [String.t()]) :: String.t()
   def http_response(status, body, extra_headers \\ []) do
     headers =

--- a/test/support/proxy_auth_server.ex
+++ b/test/support/proxy_auth_server.ex
@@ -1,0 +1,64 @@
+defmodule CDPEx.ProxyAuthServer do
+  @moduledoc false
+  # A tiny, dependency-free HTTP forward proxy that REQUIRES Basic proxy
+  # authentication — for exercising the `:proxy` auto-auth path end-to-end.
+  #
+  # Chrome launched with `--proxy-server=http://127.0.0.1:<port>` sends each
+  # http:// request here in absolute-URI form (`GET http://host/path HTTP/1.1`).
+  # Without a valid `Proxy-Authorization` header this answers `407` +
+  # `Proxy-Authenticate: Basic`, which Chrome surfaces as a `Fetch.authRequired`
+  # challenge with `source: "Proxy"`; an armed CDPEx proxy-auth handler answers it
+  # with the configured credentials and Chrome retries authenticated. On a valid
+  # header it serves a fixed HTML page — no real upstream forwarding, since the
+  # point is the auth round-trip. A navigation to an otherwise non-resolvable host
+  # (e.g. `http://proxied.test/`) therefore succeeds ONLY if the request actually
+  # traversed the proxy and the 407 was answered.
+  #
+  #     {:ok, %{port: port}} = ProxyAuthServer.start(username: "u", password: "p")
+  #     CDPEx.launch(proxy: "http://u:p@127.0.0.1:#{port}")
+
+  alias CDPEx.HttpFixture
+
+  @body ~s(<!doctype html><html><body><h1 id="greeting">Proxied</h1></body></html>)
+
+  @spec start(keyword()) :: {:ok, %{port: non_neg_integer()}}
+  def start(opts) do
+    username = Keyword.fetch!(opts, :username)
+    password = Keyword.fetch!(opts, :password)
+    expected = "Basic " <> Base.encode64("#{username}:#{password}")
+
+    {:ok, listen} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(listen)
+    pid = spawn_link(fn -> accept_loop(listen, expected) end)
+    _ = :gen_tcp.controlling_process(listen, pid)
+    {:ok, %{port: port}}
+  end
+
+  defp accept_loop(listen, expected) do
+    case :gen_tcp.accept(listen) do
+      {:ok, socket} ->
+        spawn(fn -> serve(socket, expected) end)
+        accept_loop(listen, expected)
+
+      {:error, :closed} ->
+        :ok
+    end
+  end
+
+  defp serve(socket, expected) do
+    request = HttpFixture.recv_request(socket)
+    _ = :gen_tcp.send(socket, respond(request, expected))
+    :gen_tcp.close(socket)
+  end
+
+  defp respond(request, expected) do
+    if HttpFixture.header_value(request, "proxy-authorization") == expected do
+      HttpFixture.http_response("200 OK", @body)
+    else
+      # 407 + a Basic challenge → Chrome emits Fetch.authRequired (source: Proxy).
+      HttpFixture.http_response("407 Proxy Authentication Required", "", [
+        "Proxy-Authenticate: Basic realm=\"cdpex-proxy\""
+      ])
+    end
+  end
+end


### PR DESCRIPTION
Closes #65.

Closes the one real coverage gap the proxy auto-auth feature (#62) left behind: the existing `:proxy` integration tests deliberately never navigate, so they exercise the local arm wiring (Fetch enabled, transport/conflict guards) but not the actual `407 → continueWithAuth → authenticated retry` round-trip.

## What's added

**Real-Chrome E2E (the headline proof)** — a tiny authenticating-proxy fixture (`CDPEx.ProxyAuthServer`) issues `407 Proxy Authentication Required`, and:
- **positive:** the auto-armed handler answers it (`source: "Proxy"`) with the launch credentials, so a navigation through the proxy succeeds. The target host is non-resolvable on purpose (`http://proxied.test/`) — a load can only happen *via* the proxy, so the test can't false-pass on a direct fetch.
- **negative:** the same proxy launched with a credential-less URL → the `407` blocks the navigation. This proves the proxy genuinely enforces auth (so the positive test isn't a no-op).

**FakeCDP fault-injection unit test** — drives the full `new_page` path against a fake Chrome and fails `Fetch.enable`, exercising `reply_proxy_authed_page`'s cleanup (`close_failed_auth_page`): the just-created page is torn down and the error surfaced, with nothing left in `pages`/`auths`.

**DRY** — extracted the HTTP/1.1 plumbing both fixture servers need (`recv_request`, `header_value`, `http_response`) into `CDPEx.HttpFixture` rather than copy it into the new fixture; `FixtureServer` now delegates to it (behavior-preserving).

## Scope note

The remaining `reply_proxy_authed_page` branches — the 15s `@arm_timeout` and the `Fetch.start_link` `{:error, _}` return — are defensive paths not cleanly reachable without a 15s wait or a test-only prod seam, so they're left to convention rather than padded with contrived tests. The post-arm teardown of a proxy handler is already covered by the generic drop-on-`{:EXIT}` test.

## Verification

- `mix ci` green (format, compile/docs `--warnings-as-errors`, credo, dialyzer 0 errors, 230 tests).
- FakeCDP cleanup test stable across many seeds.
- Both E2E tests pass against real Chrome (~2–3s each — genuine round-trip timing).
- Reviewed by a 3-agent panel (false-pass / flakiness / extraction); findings addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)