### PR TITLE
Fix flaky wait_for_navigation no-nav timeout test (#67)

### DIFF
--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -286,6 +286,17 @@ defmodule CDPEx.IntegrationTest do
     } do
       {:ok, _} = Page.navigate(page, fixture)
       assert :ok = Page.wait_for_navigation(page, wait_until: :none)
+
+      # navigate/3 waits for networkAlmostIdle, which for a trivial page can fire before
+      # the main-frame `load` (lifecycle is matched by name, not loaderId, so there is no
+      # guaranteed ordering between the two). Gate on document.readyState == "complete" so
+      # the no-nav :load wait below starts from a definitively post-load state and cannot
+      # catch a trailing `load` event — the source of the #67 flake (a fresh subscriber
+      # only receives future events, so once `load` is in the past the wait must time out).
+      assert eventually(fn ->
+               match?({:ok, "complete"}, Page.evaluate(page, "document.readyState"))
+             end)
+
       assert {:error, :timeout} = Page.wait_for_navigation(page, wait_until: :load, timeout: 300)
     end
 


### PR DESCRIPTION
Closes #67.

The `wait_for_navigation: :none is immediate, a no-nav wait times out` integration test flaked on CI (PR #66's run): the no-nav `:load` wait got `:ok` instead of `{:error, :timeout}`.

## Root cause

`navigate/3` defaults to `wait_until: :network_almost_idle`, and `await_lifecycle/4` matches lifecycle events **by name only** (no `loaderId` correlation). For a trivial page, `networkAlmostIdle` and the main-frame `load` fire near-simultaneously with **no guaranteed ordering**. When `navigate` returned on an early `networkAlmostIdle` (before `load`), the test's subsequent fresh `wait_for_navigation(:load, 300)` caught the trailing `load` event and resolved — instead of timing out. Intermittent, hence green on adjacent runs.

## Fix

Gate the no-nav assertion on `document.readyState == "complete"` (deterministic — set exactly when `load` fires). A fresh subscriber only receives *future* events, so once `load` is in the past the `:load` wait reliably times out. Test-only; `navigate/3`'s name-only matching (an intentional best-effort design) is untouched.

## Verification

- `mix ci` green.
- The previously-flaky test passed **25/25** local real-Chrome runs (varied seeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)