### PR TITLE
chore: pre-promotion polish (reject wss://, document click/3 + evaluate/3 limits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- `CDPEx.Protocol.parse_ws_url/1` now rejects `wss://` (and any non-`ws://`
+  scheme) with an `ArgumentError`. CDPEx launches a local Chrome and speaks
+  plaintext `ws://` to its `DevToolsActivePort`, and there is no public
+  connect-to-remote API, so the connect path was always plaintext — accepting
+  `wss://` only to fail at connect was a latent contract mismatch. Connecting to
+  a remote/TLS DevTools endpoint is tracked in #73.
+
+### Docs
+- `CDPEx.Page.click/3` documents that it dispatches a **synthetic** DOM `.click()`
+  (not a trusted OS-level input event); real `Input`-domain dispatch is tracked
+  in #72.
+- `CDPEx.Page.evaluate/3` documents that non-serializable results (DOM nodes,
+  `window`, functions, circular structures) return `{:error, {:unexpected_evaluate, _}}`.
+
 ## [0.7.0] - 2026-06-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   connect-to-remote API, so the connect path was always plaintext — accepting
   `wss://` only to fail at connect was a latent contract mismatch. Connecting to
   a remote/TLS DevTools endpoint is tracked in #73.
-
-### Docs
-- `CDPEx.Page.click/3` documents that it dispatches a **synthetic** DOM `.click()`
+- `CDPEx.Page.click/3` doc now states it dispatches a **synthetic** DOM `.click()`
   (not a trusted OS-level input event); real `Input`-domain dispatch is tracked
   in #72.
-- `CDPEx.Page.evaluate/3` documents that non-serializable results (DOM nodes,
+- `CDPEx.Page.evaluate/3` doc now notes non-serializable results (DOM nodes,
   `window`, functions, circular structures) return `{:error, {:unexpected_evaluate, _}}`.
 
 ## [0.7.0] - 2026-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.click/3` doc now states it dispatches a **synthetic** DOM `.click()`
   (not a trusted OS-level input event); real `Input`-domain dispatch is tracked
   in #72.
-- `CDPEx.Page.evaluate/3` doc now notes non-serializable results (DOM nodes,
-  `window`, functions, circular structures) return `{:error, {:unexpected_evaluate, _}}`.
+- `CDPEx.Page.evaluate/3` / `CDPEx.Protocol.evaluate_result/1` docs now describe
+  the real `returnByValue` outcomes (verified against live Chrome): a DOM node or
+  function serializes lossily to `{:ok, %{}}`; an unserializable number (`NaN` /
+  `Infinity` / `-0` / `BigInt`) surfaces as `{:error, {:unexpected_evaluate, _}}`;
+  a value Chrome can't serialize (`window`, a circular object, a `Symbol`) fails
+  the call as `{:error, {:cdp_error, "Runtime.evaluate", _}}`. Covered by a unit
+  test (the `unserializableValue` shape) and an integration test (live shapes).
 
 ## [0.7.0] - 2026-06-06
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Playwright or Puppeteer), that's the gap CDPEx fills.
 > with `new_page(browser, transport: :session)`; the trade-off is shared fate (a
 > dropped browser connection drops all of its session pages).
 >
+> **`click/3`** dispatches a synthetic DOM `.click()` (via `Runtime.evaluate`),
+> not a trusted OS-level input event — it won't satisfy sites that gate on
+> `event.isTrusted` or real hit-testing. Real `Input`-domain dispatch is tracked
+> in [#72](https://github.com/patrols/cdp_ex/issues/72).
+>
 > Stealth / anti-fingerprinting presets remain out of scope for now (evidence-gated).
 
 ## Installation

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -546,10 +546,18 @@ defmodule CDPEx.Page do
 
   A thrown JS exception is `{:error, {:evaluate_exception, details}}`.
 
-  The value must be JSON-serializable. A non-serializable result — a DOM node,
-  `window`, a function, a circular structure — comes back as
-  `{:error, {:unexpected_evaluate, _}}`; return a serializable projection
-  instead (e.g. `el.outerHTML` or `el.id`, not the element).
+  The value must be JSON-serializable. Under `returnByValue`, three results are
+  worth knowing (return a serializable projection like `el.outerHTML` / `el.id`
+  to avoid them):
+
+    * a DOM node or function serializes **lossily** to `{:ok, %{}}` — an empty
+      map, not the object and not an error;
+    * an unserializable number Chrome reports only as an `unserializableValue`
+      (`NaN`, `Infinity`, `-0`, a `BigInt`) has no by-value value and surfaces as
+      `{:error, {:unexpected_evaluate, _}}`;
+    * a value Chrome can't serialize at all — a self-referential object like
+      `window`, a circular structure, or a `Symbol` — fails the call as
+      `{:error, {:cdp_error, "Runtime.evaluate", _}}`.
 
   Options: `:timeout` (default 15_000), `:await_promise` (default `false`).
   """

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -546,6 +546,11 @@ defmodule CDPEx.Page do
 
   A thrown JS exception is `{:error, {:evaluate_exception, details}}`.
 
+  The value must be JSON-serializable. A non-serializable result — a DOM node,
+  `window`, a function, a circular structure — comes back as
+  `{:error, {:unexpected_evaluate, _}}`; return a serializable projection
+  instead (e.g. `el.outerHTML` or `el.id`, not the element).
+
   Options: `:timeout` (default 15_000), `:await_promise` (default `false`).
   """
   @spec evaluate(t(), String.t(), keyword()) :: {:ok, term()} | {:error, term()}
@@ -725,6 +730,12 @@ defmodule CDPEx.Page do
 
   @doc """
   Clicks the first element matching `css` (a synthetic JS `.click()`).
+
+  This dispatches a synthetic DOM `.click()` via `Runtime.evaluate`, **not** a
+  trusted OS-level input event: `event.isTrusted` is `false` and there's no real
+  hit-testing, so sites that gate on trusted input won't react. Real
+  `Input`-domain dispatch is tracked in
+  [#72](https://github.com/patrols/cdp_ex/issues/72).
 
   Returns `:ok`, or `{:error, {:selector_not_found, css}}` when nothing matches.
   """

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -154,7 +154,9 @@ defmodule CDPEx.Protocol do
 
   A thrown JS exception becomes `{:error, {:evaluate_exception, details}}`; a
   returned value (with `returnByValue: true`) becomes `{:ok, value}`; `undefined`
-  becomes `{:ok, nil}`.
+  becomes `{:ok, nil}`. A non-serializable result (a DOM node, `window`, a
+  function, a circular structure) has no `returnByValue` value and falls through
+  to `{:error, {:unexpected_evaluate, _}}`.
 
   ## Examples
 
@@ -179,10 +181,14 @@ defmodule CDPEx.Protocol do
   def evaluate_result(other), do: {:error, {:unexpected_evaluate, other}}
 
   @doc """
-  Splits a Chrome DevTools `ws://` (or `wss://`) URL into `{host, port, path}`.
+  Splits a Chrome DevTools `ws://` URL into `{host, port, path}`.
 
   Uses `URI.parse/1`, so IPv6 hosts, explicit ports, and paths are handled
-  correctly; a non-`ws(s)://` URL or one missing a host/port raises `ArgumentError`.
+  correctly; a non-`ws://` URL or one missing a host/port raises `ArgumentError`.
+
+  Only `ws://` is accepted: CDPEx launches a local Chrome and talks plaintext to
+  its `DevToolsActivePort` (no TLS). `wss://` — a remote/TLS DevTools endpoint —
+  has no entry point yet (see the connect-to-remote-endpoint tracker on GitHub).
 
   ## Examples
 
@@ -195,13 +201,14 @@ defmodule CDPEx.Protocol do
   @spec parse_ws_url(String.t()) :: {String.t(), pos_integer(), String.t()}
   def parse_ws_url(ws_url) when is_binary(ws_url) do
     case URI.parse(ws_url) do
-      %URI{scheme: scheme, host: host, port: port, path: path}
-      when scheme in ["ws", "wss"] and is_binary(host) and host != "" and is_integer(port) ->
+      %URI{scheme: "ws", host: host, port: port, path: path}
+      when is_binary(host) and host != "" and is_integer(port) ->
         {host, port, path || "/"}
 
       _ ->
         raise ArgumentError,
-              "expected a ws:// or wss:// URL with a host and port, got: #{inspect(ws_url)}"
+              "expected a ws:// URL with a host and port (wss:// / remote endpoints " <>
+                "are not supported yet), got: #{inspect(ws_url)}"
     end
   end
 

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -154,9 +154,11 @@ defmodule CDPEx.Protocol do
 
   A thrown JS exception becomes `{:error, {:evaluate_exception, details}}`; a
   returned value (with `returnByValue: true`) becomes `{:ok, value}`; `undefined`
-  becomes `{:ok, nil}`. A non-serializable result (a DOM node, `window`, a
-  function, a circular structure) has no `returnByValue` value and falls through
-  to `{:error, {:unexpected_evaluate, _}}`.
+  becomes `{:ok, nil}`. A result Chrome can only express as an `unserializableValue`
+  — `NaN`, `Infinity`, `-0`, or a `BigInt` — has no by-value `value` and falls
+  through to `{:error, {:unexpected_evaluate, _}}`. (Inputs Chrome can't serialize
+  at all, like `window` or a circular object, never reach here — the
+  `Runtime.evaluate` call fails first; see `CDPEx.Page.evaluate/3`.)
 
   ## Examples
 
@@ -171,6 +173,9 @@ defmodule CDPEx.Protocol do
 
       iex> {:error, {:evaluate_exception, _}} =
       ...>   CDPEx.Protocol.evaluate_result(%{"exceptionDetails" => %{"text" => "Uncaught"}})
+
+      iex> {:error, {:unexpected_evaluate, _}} =
+      ...>   CDPEx.Protocol.evaluate_result(%{"result" => %{"type" => "bigint", "unserializableValue" => "10n"}})
   """
   @spec evaluate_result(map()) :: {:ok, term()} | {:error, term()}
   def evaluate_result(%{"exceptionDetails" => details}),
@@ -188,7 +193,8 @@ defmodule CDPEx.Protocol do
 
   Only `ws://` is accepted: CDPEx launches a local Chrome and talks plaintext to
   its `DevToolsActivePort` (no TLS). `wss://` — a remote/TLS DevTools endpoint —
-  has no entry point yet (see the connect-to-remote-endpoint tracker on GitHub).
+  has no entry point yet (tracked in
+  [#73](https://github.com/patrols/cdp_ex/issues/73)).
 
   ## Examples
 

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -228,6 +228,31 @@ defmodule CDPEx.IntegrationTest do
                Page.evaluate(page, "throw new Error('boom')")
     end
 
+    test "evaluate's non-serializable outcomes match the documented shapes", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+
+      # A DOM node or function is serialized lossily to an empty object under
+      # returnByValue — NOT an error, and NOT the object itself.
+      assert {:ok, %{}} = Page.evaluate(page, "document.body")
+      assert {:ok, %{}} = Page.evaluate(page, "(function () { return 1; })")
+
+      # An unserializable number (returned by Chrome as `unserializableValue`,
+      # so no by-value `value` key) falls through to the catch-all.
+      assert {:error, {:unexpected_evaluate, _}} = Page.evaluate(page, "10n")
+      assert {:error, {:unexpected_evaluate, _}} = Page.evaluate(page, "NaN")
+      assert {:error, {:unexpected_evaluate, _}} = Page.evaluate(page, "1 / 0")
+
+      # A value Chrome can't serialize at all (self-referential / circular)
+      # fails the Runtime.evaluate call itself.
+      assert {:error, {:cdp_error, "Runtime.evaluate", _}} = Page.evaluate(page, "window")
+
+      assert {:error, {:cdp_error, "Runtime.evaluate", _}} =
+               Page.evaluate(page, "(function () { var o = {}; o.self = o; return o; })()")
+    end
+
     test "call_function applies JSON args and returns the result", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       assert {:ok, 5} = Page.call_function(page, "(a, b) => a + b", [2, 3])

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -118,7 +118,12 @@ defmodule CDPEx.ProtocolTest do
       # key under returnByValue, so they hit the catch-all rather than {:ok, _}.
       # `type` mirrors what real Chrome reports (bigint for 10n, number for the
       # rest); `evaluate_result/1` keys only off the missing `value`, not `type`.
-      for {type, uv} <- [{"bigint", "10n"}, {"number", "NaN"}, {"number", "Infinity"}, {"number", "-0"}] do
+      for {type, uv} <- [
+            {"bigint", "10n"},
+            {"number", "NaN"},
+            {"number", "Infinity"},
+            {"number", "-0"}
+          ] do
         result = %{"result" => %{"type" => type, "unserializableValue" => uv}}
         assert {:error, {:unexpected_evaluate, ^result}} = Protocol.evaluate_result(result)
       end

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -112,6 +112,15 @@ defmodule CDPEx.ProtocolTest do
     test "unrecognised shape is an error" do
       assert {:error, {:unexpected_evaluate, %{}}} = Protocol.evaluate_result(%{})
     end
+
+    test "an unserializableValue result (BigInt/NaN/Infinity) is unexpected_evaluate" do
+      # Chrome returns these with `unserializableValue` and no by-value `value`
+      # key under returnByValue, so they hit the catch-all rather than {:ok, _}.
+      for uv <- ["10n", "NaN", "Infinity", "-0"] do
+        result = %{"result" => %{"type" => "number", "unserializableValue" => uv}}
+        assert {:error, {:unexpected_evaluate, ^result}} = Protocol.evaluate_result(result)
+      end
+    end
   end
 
   describe "parse_ws_url/1" do

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -124,6 +124,16 @@ defmodule CDPEx.ProtocolTest do
       assert Protocol.parse_ws_url("ws://localhost:5000/devtools/page/DEADBEEF") ==
                {"localhost", 5000, "/devtools/page/DEADBEEF"}
     end
+
+    test "rejects wss:// (no remote/TLS endpoint support yet)" do
+      assert_raise ArgumentError, ~r{ws:// URL}, fn ->
+        Protocol.parse_ws_url("wss://127.0.0.1:9222/devtools/browser/abc-123")
+      end
+    end
+
+    test "rejects a non-ws scheme" do
+      assert_raise ArgumentError, fn -> Protocol.parse_ws_url("http://127.0.0.1:9222/x") end
+    end
   end
 
   test "prevent_alerts_js/0 overrides the three modal dialog functions" do

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -116,8 +116,10 @@ defmodule CDPEx.ProtocolTest do
     test "an unserializableValue result (BigInt/NaN/Infinity) is unexpected_evaluate" do
       # Chrome returns these with `unserializableValue` and no by-value `value`
       # key under returnByValue, so they hit the catch-all rather than {:ok, _}.
-      for uv <- ["10n", "NaN", "Infinity", "-0"] do
-        result = %{"result" => %{"type" => "number", "unserializableValue" => uv}}
+      # `type` mirrors what real Chrome reports (bigint for 10n, number for the
+      # rest); `evaluate_result/1` keys only off the missing `value`, not `type`.
+      for {type, uv} <- [{"bigint", "10n"}, {"number", "NaN"}, {"number", "Infinity"}, {"number", "-0"}] do
+        result = %{"result" => %{"type" => type, "unserializableValue" => uv}}
         assert {:error, {:unexpected_evaluate, ^result}} = Protocol.evaluate_result(result)
       end
     end


### PR DESCRIPTION
Pre-soft-launch polish: close the few cheap sharp edges two reviews flagged. **None changes the default local-Chrome path's behavior.**

## Changes
- **`parse_ws_url/1` rejects `wss://`** (and any non-`ws://` scheme) with an `ArgumentError`. CDPEx launches a local Chrome and speaks plaintext `ws://` to its `DevToolsActivePort`, and there's no public connect-to-remote API — so the connect path (`Connection.init/1` hardcodes `HTTP.connect(:http, …)`) was always plaintext. Accepting `wss://` only to fail at connect was a latent, unreachable contract mismatch. Closing the door rather than half-wiring TLS. Remote/TLS endpoint support tracked in #73.
- **`click/3` doc** now states plainly it's a synthetic DOM `.click()` via `Runtime.evaluate` — `event.isTrusted` is `false`, no real hit-testing — so trusted-input-gated sites won't react. Real `Input`-domain dispatch tracked in #72.
- **`evaluate/3` doc** notes non-serializable results (DOM nodes, `window`, functions, circular structures) return `{:error, {:unexpected_evaluate, _}}`; return a serializable projection instead.
- **Regression test** for the `wss://` / non-ws rejection.
- CHANGELOG updated under `[Unreleased]`.

## Deferred (filed, not built)
- #72 — real Input-domain click (the one hard-push blocker; not needed for soft launch)
- #73 — connect to a remote/existing DevTools endpoint (ws/wss); pairs with the rejection here

## Out of scope (left open, intentionally)
- #26 / #27 — `:session`-transport-only; default `:dedicated` path unaffected
- #35 — stealth presets; evidence-gated by its own DoD

## Verification
`mix ci` green: format, deps.audit, `compile --warnings-as-errors`, `docs --warnings-as-errors`, credo, dialyzer (0 errors), 232 tests passed (63 integration excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
