### PR TITLE
feat(evaluate)!: distinguish unserializable_value from a malformed result (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Breaking
+- `CDPEx.Page.evaluate/3` (and `call_function/3`, which delegates to it) now
+  return `{:error, {:unserializable_value, uv}}` for a result Chrome can only
+  express as an `unserializableValue` (`NaN` / `Infinity` / `-0` / `BigInt`),
+  carrying the raw string. These previously fell through to
+  `{:error, {:unexpected_evaluate, _}}` — which now means only an *unrecognized*
+  result envelope. Update any matcher; the new reason classifies as `:terminal`.
+  This lets callers tell a recoverable unserializable value from a malformed
+  result (#75).
+
 ### Changed
 - `CDPEx.Protocol.parse_ws_url/1` now rejects `wss://` (and any non-`ws://`
   scheme) with an `ArgumentError`. CDPEx launches a local Chrome and speaks
@@ -19,10 +29,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page.evaluate/3` / `CDPEx.Protocol.evaluate_result/1` docs now describe
   the real `returnByValue` outcomes (verified against live Chrome): a DOM node or
   function serializes lossily to `{:ok, %{}}`; an unserializable number (`NaN` /
-  `Infinity` / `-0` / `BigInt`) surfaces as `{:error, {:unexpected_evaluate, _}}`;
-  a value Chrome can't serialize (`window`, a circular object, a `Symbol`) fails
-  the call as `{:error, {:cdp_error, "Runtime.evaluate", _}}`. Covered by a unit
-  test (the `unserializableValue` shape) and an integration test (live shapes).
+  `Infinity` / `-0` / `BigInt`) surfaces as `{:error, {:unserializable_value, _}}`
+  (see Breaking, above); a value Chrome can't serialize (`window`, a circular
+  object, a `Symbol`) fails the call as `{:error, {:cdp_error, "Runtime.evaluate", _}}`.
+  Covered by unit, doctest, and integration tests.
 
 ## [0.7.0] - 2026-06-06
 

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -115,6 +115,7 @@ defmodule CDPEx do
           | {:idle_wait_failed, term()}
           | {:selector_not_found, String.t()}
           | {:evaluate_exception, term()}
+          | {:unserializable_value, String.t()}
           | {:unexpected_evaluate, term()}
           | {:invalid_args, term()}
           | {:invalid_source, term()}
@@ -204,6 +205,7 @@ defmodule CDPEx do
   def classify_error({:chrome_not_found, _}), do: :terminal
   def classify_error({:selector_not_found, _}), do: :terminal
   def classify_error({:evaluate_exception, _}), do: :terminal
+  def classify_error({:unserializable_value, _}), do: :terminal
   def classify_error({:unexpected_evaluate, _}), do: :terminal
   def classify_error({:invalid_args, _}), do: :terminal
   def classify_error({:invalid_source, _}), do: :terminal

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -554,7 +554,7 @@ defmodule CDPEx.Page do
       map, not the object and not an error;
     * an unserializable number Chrome reports only as an `unserializableValue`
       (`NaN`, `Infinity`, `-0`, a `BigInt`) has no by-value value and surfaces as
-      `{:error, {:unexpected_evaluate, _}}`;
+      `{:error, {:unserializable_value, uv}}` (the raw string, e.g. `"NaN"`);
     * a value Chrome can't serialize at all — a self-referential object like
       `window`, a circular structure, or a `Symbol` — fails the call as
       `{:error, {:cdp_error, "Runtime.evaluate", _}}`.

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -155,10 +155,12 @@ defmodule CDPEx.Protocol do
   A thrown JS exception becomes `{:error, {:evaluate_exception, details}}`; a
   returned value (with `returnByValue: true`) becomes `{:ok, value}`; `undefined`
   becomes `{:ok, nil}`. A result Chrome can only express as an `unserializableValue`
-  — `NaN`, `Infinity`, `-0`, or a `BigInt` — has no by-value `value` and falls
-  through to `{:error, {:unexpected_evaluate, _}}`. (Inputs Chrome can't serialize
-  at all, like `window` or a circular object, never reach here — the
-  `Runtime.evaluate` call fails first; see `CDPEx.Page.evaluate/3`.)
+  — `NaN`, `Infinity`, `-0`, or a `BigInt` — has no by-value `value` and becomes
+  `{:error, {:unserializable_value, uv}}`, carrying the raw `unserializableValue`
+  string. Anything else (an unrecognized result envelope) falls through to
+  `{:error, {:unexpected_evaluate, _}}`. (Inputs Chrome can't serialize at all,
+  like `window` or a circular object, never reach here — the `Runtime.evaluate`
+  call fails first; see `CDPEx.Page.evaluate/3`.)
 
   ## Examples
 
@@ -174,8 +176,8 @@ defmodule CDPEx.Protocol do
       iex> {:error, {:evaluate_exception, _}} =
       ...>   CDPEx.Protocol.evaluate_result(%{"exceptionDetails" => %{"text" => "Uncaught"}})
 
-      iex> {:error, {:unexpected_evaluate, _}} =
-      ...>   CDPEx.Protocol.evaluate_result(%{"result" => %{"type" => "bigint", "unserializableValue" => "10n"}})
+      iex> CDPEx.Protocol.evaluate_result(%{"result" => %{"type" => "bigint", "unserializableValue" => "10n"}})
+      {:error, {:unserializable_value, "10n"}}
   """
   @spec evaluate_result(map()) :: {:ok, term()} | {:error, term()}
   def evaluate_result(%{"exceptionDetails" => details}),
@@ -183,6 +185,10 @@ defmodule CDPEx.Protocol do
 
   def evaluate_result(%{"result" => %{"value" => value}}), do: {:ok, value}
   def evaluate_result(%{"result" => %{"type" => "undefined"}}), do: {:ok, nil}
+
+  def evaluate_result(%{"result" => %{"unserializableValue" => uv}}),
+    do: {:error, {:unserializable_value, uv}}
+
   def evaluate_result(other), do: {:error, {:unexpected_evaluate, other}}
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,8 @@ defmodule CDPEx.MixProject do
   defp deps do
     [
       # CDP wire layer: WebSocket over Mint (brings in :mint + :hpax). No hackney;
-      # castore is not needed because CDP speaks ws:// to localhost (no TLS).
+      # castore is not needed because CDPEx speaks plaintext ws:// to a local
+      # Chrome DevToolsActivePort (no TLS) — wss:// is rejected (see Protocol).
       {:mint_web_socket, "~> 1.0"},
       # JSON-RPC encoding/decoding for the CDP protocol.
       {:jason, "~> 1.4"},

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -240,17 +240,23 @@ defmodule CDPEx.IntegrationTest do
       assert {:ok, %{}} = Page.evaluate(page, "(function () { return 1; })")
 
       # An unserializable number (returned by Chrome as `unserializableValue`,
-      # so no by-value `value` key) falls through to the catch-all.
-      assert {:error, {:unexpected_evaluate, _}} = Page.evaluate(page, "10n")
-      assert {:error, {:unexpected_evaluate, _}} = Page.evaluate(page, "NaN")
-      assert {:error, {:unexpected_evaluate, _}} = Page.evaluate(page, "1 / 0")
+      # so no by-value `value` key) gets the dedicated recoverable tag, carrying
+      # the raw string.
+      assert {:error, {:unserializable_value, "10n"}} = Page.evaluate(page, "10n")
+      assert {:error, {:unserializable_value, "NaN"}} = Page.evaluate(page, "NaN")
+      assert {:error, {:unserializable_value, "Infinity"}} = Page.evaluate(page, "1 / 0")
 
-      # A value Chrome can't serialize at all (self-referential / circular)
-      # fails the Runtime.evaluate call itself.
+      # call_function/3 delegates to evaluate/3, so it surfaces the same tag.
+      assert {:error, {:unserializable_value, "NaN"}} = Page.call_function(page, "() => NaN", [])
+
+      # A value Chrome can't serialize at all (self-referential / circular / a
+      # Symbol) fails the Runtime.evaluate call itself.
       assert {:error, {:cdp_error, "Runtime.evaluate", _}} = Page.evaluate(page, "window")
 
       assert {:error, {:cdp_error, "Runtime.evaluate", _}} =
                Page.evaluate(page, "(function () { var o = {}; o.self = o; return o; })()")
+
+      assert {:error, {:cdp_error, "Runtime.evaluate", _}} = Page.evaluate(page, "Symbol(\"x\")")
     end
 
     test "call_function applies JSON args and returns the result", %{page: page, fixture: fixture} do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -245,6 +245,7 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, {:unserializable_value, "10n"}} = Page.evaluate(page, "10n")
       assert {:error, {:unserializable_value, "NaN"}} = Page.evaluate(page, "NaN")
       assert {:error, {:unserializable_value, "Infinity"}} = Page.evaluate(page, "1 / 0")
+      assert {:error, {:unserializable_value, "-0"}} = Page.evaluate(page, "-0")
 
       # call_function/3 delegates to evaluate/3, so it surfaces the same tag.
       assert {:error, {:unserializable_value, "NaN"}} = Page.call_function(page, "() => NaN", [])

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -113,11 +113,12 @@ defmodule CDPEx.ProtocolTest do
       assert {:error, {:unexpected_evaluate, %{}}} = Protocol.evaluate_result(%{})
     end
 
-    test "an unserializableValue result (BigInt/NaN/Infinity) is unexpected_evaluate" do
+    test "an unserializableValue result (BigInt/NaN/Infinity/-0) is unserializable_value" do
       # Chrome returns these with `unserializableValue` and no by-value `value`
-      # key under returnByValue, so they hit the catch-all rather than {:ok, _}.
-      # `type` mirrors what real Chrome reports (bigint for 10n, number for the
-      # rest); `evaluate_result/1` keys only off the missing `value`, not `type`.
+      # key under returnByValue, so they get the dedicated recoverable tag rather
+      # than {:ok, _} or the unrecognized-envelope catch-all. `type` mirrors what
+      # real Chrome reports (bigint for 10n, number for the rest); the clause keys
+      # only off `unserializableValue`, and the tag carries that raw string.
       for {type, uv} <- [
             {"bigint", "10n"},
             {"number", "NaN"},
@@ -125,7 +126,7 @@ defmodule CDPEx.ProtocolTest do
             {"number", "-0"}
           ] do
         result = %{"result" => %{"type" => type, "unserializableValue" => uv}}
-        assert {:error, {:unexpected_evaluate, ^result}} = Protocol.evaluate_result(result)
+        assert {:error, {:unserializable_value, ^uv}} = Protocol.evaluate_result(result)
       end
     end
   end

--- a/test/cdp_ex_test.exs
+++ b/test/cdp_ex_test.exs
@@ -45,6 +45,7 @@ defmodule CDPExTest do
       {:chrome_not_found, "/usr/bin/google-chrome"},
       {:selector_not_found, ".missing"},
       {:evaluate_exception, %{"text" => "ReferenceError"}},
+      {:unserializable_value, "NaN"},
       {:unexpected_evaluate, %{"unexpected" => true}},
       {:invalid_args, :badarg},
       {:invalid_source, :bogus},


### PR DESCRIPTION
Closes #75.

Splits the `{:error, {:unexpected_evaluate, _}}` catch-all into two, so callers can tell a **recoverable** non-JSON result from a genuinely malformed one — the seam #74 documented but deliberately didn't fix.

## Change
`CDPEx.Page.evaluate/3` (and `call_function/3`, which delegates to it) now return:
- **`{:error, {:unserializable_value, uv}}`** — a result Chrome can only express as an `unserializableValue` (`NaN` / `Infinity` / `-0` / `BigInt`), carrying the raw string. *Previously `{:unexpected_evaluate, _}`.*
- `{:error, {:unexpected_evaluate, _}}` — now means only an **unrecognized result envelope**.

Unchanged: a thrown JS exception → `{:evaluate_exception, _}`; a DOM node/function → lossy `{:ok, %{}}`; `window`/circular/`Symbol` → `{:cdp_error, "Runtime.evaluate", _}` (these fail the CDP call; mapping them would need fragile Chrome-message sniffing — intentionally out of scope).

## ⚠️ Breaking (vs 0.7.0)
Matchers on `{:unexpected_evaluate, _}` for `NaN`/`Infinity`/`-0`/`BigInt` must switch to `{:unserializable_value, _}`. New reason classifies as `:terminal`. Ships in **0.8.0**.

## Verified against live Chrome
The integration test asserts the real shapes: BigInt/NaN/Infinity → `{:unserializable_value, "<str>"}` (exact string), `call_function` inherits it, `window`/circular/`Symbol` → `{:cdp_error, _, _}`, node/function → `{:ok, %{}}`.

## Coverage
- `protocol.ex`: new `evaluate_result/1` clause above the catch-all; doc + doctest.
- `cdp_ex.ex`: `{:unserializable_value, String.t()}` added to `error_reason/0` + `classify_error/1` (`:terminal`) — the compile-time coverage test enforces the pairing.
- Tests: unit (carries raw string), `@terminal` exemplar, integration (+ `Symbol`, + a `call_function` consistency assertion).
- CHANGELOG `### Breaking`; `mix.exs` dep comment notes the enforced `ws://`-only contract.

`mix ci` green (234 passed, 17 doctests, dialyzer 0, credo clean); integration test green against real Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
