### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-14
+
 ### Breaking
 - `CDPEx.Page.evaluate/3` (and `call_function/3`, which delegates to it) now
   return `{:error, {:unserializable_value, uv}}` for a result Chrome can only
@@ -155,7 +157,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page`: `navigate/3`, `wait_for_selector/3`, `evaluate/3`, `click/3`,
   `html/2`, `screenshot/2`.
 
-[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/patrols/cdp_ex/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/patrols/cdp_ex/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/patrols/cdp_ex/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/patrols/cdp_ex/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add `cdp_ex` to your deps in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:cdp_ex, "~> 0.7.0"}
+    {:cdp_ex, "~> 0.8.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CDPEx.MixProject do
   use Mix.Project
 
-  @version "0.7.0"
+  @version "0.8.0"
   @source_url "https://github.com/patrols/cdp_ex"
 
   def project do


### PR DESCRIPTION
Cuts **0.8.0**.

## Release mechanics
- `mix.exs`: `@version` → `0.8.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.8.0] - 2026-06-14` + fresh empty `[Unreleased]` + compare links
- `README.md`: install pin → `~> 0.8.0`

## What's in 0.8.0
- **Breaking** — `evaluate/3` (and `call_function/3`) return `{:error, {:unserializable_value, uv}}` for `NaN`/`Infinity`/`-0`/`BigInt` (was `{:unexpected_evaluate, _}`); added to `error_reason/0` + `classify_error/1` (`:terminal`) (#75).
- **Changed** — `parse_ws_url/1` rejects `wss://` (#73 tracks remote endpoints); `evaluate/3` + `click/3` docs clarified to live-verified behavior.

## Verification
`mix ci` green (234 passed, 17 doctests, dialyzer 0, credo clean). `mix hex.build` assembles cleanly as `cdp_ex-0.8.0` (MIT, all files present).

After merge: tag `v0.8.0` on the release commit + push tag, then `mix hex.publish` (maintainer, 2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
