### PR TITLE
feat(input)!: real trusted click + type/press (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Breaking
+- `CDPEx.Page.click/3` now dispatches a **trusted** `Input` mouse event by default
+  (real `event.isTrusted`, hit-tested at the element's center after scroll-into-view)
+  instead of a synthetic `el.click()`. Pass `trusted: false` for the old synthetic
+  behavior. A trusted click can newly fail with `{:error, {:not_clickable, css}}`
+  for an element with no usable box (zero-size / off-screen even after scroll) (#72).
+
+### Added
+- `CDPEx.Page.type/4` — focus an element and enter text via `Input.insertText` (#72).
+- `CDPEx.Page.press/4` — press a named key (`Enter`, `Tab`, `Escape`, `Backspace`,
+  `Delete`, the arrows, `Home`, `End`) with real `keyDown`/`keyUp` events; a `nil`
+  selector targets the currently-focused element. An unsupported key returns
+  `{:error, {:unknown_key, key}}` (#72).
+
 ## [0.8.0] - 2026-06-14
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ Playwright or Puppeteer), that's the gap CDPEx fills.
 > with `new_page(browser, transport: :session)`; the trade-off is shared fate (a
 > dropped browser connection drops all of its session pages).
 >
-> **`click/3`** dispatches a synthetic DOM `.click()` (via `Runtime.evaluate`),
-> not a trusted OS-level input event — it won't satisfy sites that gate on
-> `event.isTrusted` or real hit-testing. Real `Input`-domain dispatch is tracked
-> in [#72](https://github.com/patrols/cdp_ex/issues/72).
->
 > Stealth / anti-fingerprinting presets remain out of scope for now (evidence-gated).
 
 ## Installation
@@ -193,7 +188,9 @@ crashed browser is relaunched on demand.
 | `wait_for_response/3` | Block until a network response URL matches (fn / `Regex` / substring) |
 | `wait_for_network_idle/2` | Block until the network settles (Puppeteer "networkidle") |
 | `evaluate/3` | Run JS and return the value (`returnByValue`) |
-| `click/3` | Synthetic `.click()` on the first match |
+| `click/3` | Real trusted click on the first match (synthetic via `trusted: false`) |
+| `type/4` | Focus an element and enter text (`Input.insertText`) |
+| `press/4` | Press a named key — `Enter`, `Tab`, arrows, … — with real key events |
 | `html/2` | Full serialized DOM (`document.documentElement.outerHTML`) |
 | `screenshot/2` | PNG bytes, or write to `:path` |
 | `pdf/2` | Render the page to PDF bytes, or write to `:path` |

--- a/docs/design/2026-06-14-input-domain-interaction.md
+++ b/docs/design/2026-06-14-input-domain-interaction.md
@@ -24,10 +24,10 @@ keyboard entry, replacing the synthetic click as the default.
    escape hatch may be **deprecated and removed in a future release** (removal is
    breaking, so it goes through a deprecation cycle, not a yank). It is documented
    as an escape hatch, not an equal alternative.
-2. **Keyboard surface = `type/3` + `press/3`.** `type` uses `Input.insertText`
+2. **Keyboard surface = `type/4` + `press/4`.** `type` uses `Input.insertText`
    (fast; fires `input`/`change`; no per-character `keydown`/`keyup`). `press`
    uses `Input.dispatchKeyEvent` for a curated set of named keys. Realistic
-   per-character key events (a full keymap) are deferred — a future `type/3`
+   per-character key events (a full keymap) are deferred — a future `type/4`
    `realistic:`/`delay:` option if demand appears.
 3. **All functions live on `CDPEx.Page`** (consistent with the flat `Page.*` API;
    `click/3` already lives here so nothing moves). A dedicated `CDPEx.Input` /
@@ -99,13 +99,13 @@ Each requires, atomically (the compile-time coverage invariant, as in #75):
 ## Docs / release
 
 - Rewrite the `click/3` `@doc` (trusted default + `trusted: false` escape hatch);
-  add `type/3` and `press/3` docs.
+  add `type/4` and `press/4` docs.
 - README: add `type`/`press` to the Page-operations table, update the `click`
   row, and remove the "synthetic click" warning from the Status callout (it's
   real now). Update the `#72` reference to point at shipped behavior.
 - CHANGELOG `[Unreleased]`: `### Breaking` (click default now a trusted event;
-  may newly error on off-screen/zero-box elements) + `### Added` (`type/3`,
-  `press/3`). → **0.9.0**.
+  may newly error on off-screen/zero-box elements) + `### Added` (`type/4`,
+  `press/4`). → **0.9.0**.
 
 ## Testing (real Chrome — extend `test/support/fixture_server.ex`)
 

--- a/docs/design/2026-06-14-input-domain-interaction.md
+++ b/docs/design/2026-06-14-input-domain-interaction.md
@@ -1,0 +1,133 @@
+# Design: real Input-domain interaction (#72)
+
+**Status:** approved (brainstorm) — pending implementation
+**Target release:** 0.9.0 (breaking)
+**Issue:** [#72](https://github.com/patrols/cdp_ex/issues/72)
+
+## Context / problem
+
+`CDPEx.Page.click/3` dispatches a synthetic DOM `.click()` via `Runtime.evaluate`
+(`el.click()`), so `event.isTrusted` is `false` and there is no real hit-testing.
+There is no keyboard / typing surface at all (zero `Input.*` usage). For a library
+framed around scraping/automation this is the most visible gap — sites that gate on
+trusted input can't be driven, and "fill a field, press Enter" isn't expressible.
+
+This change introduces real `Input`-domain interaction: a trusted click plus
+keyboard entry, replacing the synthetic click as the default.
+
+## Decisions (resolved in brainstorm)
+
+1. **`click/3` is trusted by default**, with a `trusted: false` escape hatch that
+   keeps the old synthetic `el.click()`. Rationale: the default should be the
+   correct behavior (the whole point of the issue); the synthetic path is still
+   occasionally useful (fire a handler on an element not at a hittable point). The
+   escape hatch may be **deprecated and removed in a future release** (removal is
+   breaking, so it goes through a deprecation cycle, not a yank). It is documented
+   as an escape hatch, not an equal alternative.
+2. **Keyboard surface = `type/3` + `press/3`.** `type` uses `Input.insertText`
+   (fast; fires `input`/`change`; no per-character `keydown`/`keyup`). `press`
+   uses `Input.dispatchKeyEvent` for a curated set of named keys. Realistic
+   per-character key events (a full keymap) are deferred — a future `type/3`
+   `realistic:`/`delay:` option if demand appears.
+3. **All functions live on `CDPEx.Page`** (consistent with the flat `Page.*` API;
+   `click/3` already lives here so nothing moves). A dedicated `CDPEx.Input` /
+   `Mouse` / `Keyboard` module is only warranted if low-level coordinate/raw-key
+   primitives are added later — out of scope now.
+4. **Click robustness = scroll-into-view + center-point click, with a tagged
+   error** (no overlay hit-testing). `document.elementFromPoint` hit-test
+   verification (Puppeteer-style) is deferred as future hardening.
+
+## API surface (`CDPEx.Page`)
+
+All calls are session-scoped — they go through the existing `do_call/4`
+(`page.ex:1511` → `Connection.call(..., session_id:)`), so they work on both
+`:dedicated` and `:session` transports.
+
+- `click(page, css, opts \\ [])` :: `:ok | {:error, reason}`
+  - Default (trusted): resolve `css` → `scrollIntoViewIfNeeded()` → read
+    `getBoundingClientRect()` → `Input.dispatchMouseEvent` `mousePressed` then
+    `mouseReleased` at the box center (`button: "left"`, `clickCount: 1`).
+  - `trusted: false`: the current synthetic `el.click()`.
+  - opts: `:trusted` (default `true`), `:timeout`.
+- `type(page, css, text, opts \\ [])` :: `:ok | {:error, reason}`
+  - Resolve `css` → `el.focus()` (JS) → `Input.insertText(%{"text" => text})`.
+  - opts: `:timeout`.
+- `press(page, css, key, opts \\ [])` :: `:ok | {:error, reason}`
+  - When `css` is a selector: resolve → `el.focus()` → `Input.dispatchKeyEvent`
+    `keyDown` then `keyUp` for `key`.
+  - When `css` is `nil`: skip focus and press on the currently-focused element.
+  - Single signature (a `nil` selector, not a separate 2-arity `press`) — avoids
+    an arity-3 clash between `press(page, key, opts)` and `press(page, css, key)`.
+
+### Supported `press` keys (curated keymap)
+
+`Enter`, `Tab`, `Escape`, `Backspace`, `Delete`, `ArrowUp`, `ArrowDown`,
+`ArrowLeft`, `ArrowRight`, `Home`, `End` — each mapped to the correct
+`key` / `code` / `windowsVirtualKeyCode` so default actions fire (Enter submits a
+form, Tab moves focus, etc.). An unsupported key name is a validation error.
+
+## Error contract
+
+Two new `t:CDPEx.error_reason/0` members, both classified `:terminal` (deterministic):
+
+- `{:not_clickable, css}` — element matched but has no usable click box (zero-size
+  / not visible even after scroll). Distinct from the existing
+  `{:selector_not_found, css}` (no match at all).
+- `{:unknown_key, key}` — `press` given a key outside the curated set.
+
+Each requires, atomically (the compile-time coverage invariant, as in #75):
+- a `classify_error/1` `:terminal` clause in `lib/cdp_ex.ex`, and
+- an exemplar in the `@terminal` list in `test/cdp_ex_test.exs`.
+
+`type` and `press` reuse `{:selector_not_found, css}` when the element isn't found.
+
+## Implementation notes
+
+- **One `evaluate` round-trip** for click-prep: a JS snippet does
+  `querySelector` + null-check + `scrollIntoViewIfNeeded()` and returns
+  `{found, x, y, w, h}` (or a sentinel for not-found / zero-box). Elixir then
+  branches to the error tuples or dispatches the mouse events. Center is
+  `x + w/2`, `y + h/2` — `getBoundingClientRect` and `Input.dispatchMouseEvent`
+  both use CSS pixels, so no DPR conversion.
+- `type`/`press` target via `el.focus()` rather than a trusted click, so they
+  work even on elements a trusted click couldn't reach; the keystrokes are still
+  real `Input` events.
+- Reuse the visibility-check style already in `visible?/3` (`page.ex:726`).
+- Keymap is a small module-level map (`%{"Enter" => %{...}, ...}`); lookup miss →
+  `{:error, {:unknown_key, key}}`.
+
+## Docs / release
+
+- Rewrite the `click/3` `@doc` (trusted default + `trusted: false` escape hatch);
+  add `type/3` and `press/3` docs.
+- README: add `type`/`press` to the Page-operations table, update the `click`
+  row, and remove the "synthetic click" warning from the Status callout (it's
+  real now). Update the `#72` reference to point at shipped behavior.
+- CHANGELOG `[Unreleased]`: `### Breaking` (click default now a trusted event;
+  may newly error on off-screen/zero-box elements) + `### Added` (`type/3`,
+  `press/3`). → **0.9.0**.
+
+## Testing (real Chrome — extend `test/support/fixture_server.ex`)
+
+Add to the fixture page: an `<input id="name">`, a button whose handler records
+`event.isTrusted` (e.g. writes it into the DOM), and a `<form>` that submits on
+Enter (visible effect on submit).
+
+Integration (`@tag :integration`):
+- trusted `click` → handler observes `isTrusted: true`.
+- `click(trusted: false)` → handler observes `isTrusted: false` (escape hatch).
+- `type` → input value set and `input` event fired.
+- `press(…, "Enter")` on a form field → form submits.
+- hidden / zero-box element → `{:error, {:not_clickable, _}}`.
+- `selector_not_found` path unchanged.
+
+Unit (no Chrome): keymap lookup; `{:unknown_key, _}`; the `error_reason/0`
+coverage test gains the two new exemplars.
+
+## Out of scope / future
+
+- Overlay hit-test verification via `document.elementFromPoint` (D2).
+- Realistic per-character typing (full keymap, `keydown`/`keyup` per char).
+- Low-level primitives (raw-coordinate `mouse_move/3`, `key_down`/`key_up`) and a
+  possible `CDPEx.Input` home for them.
+- Deprecating/removing the `trusted: false` escape hatch.

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -114,6 +114,8 @@ defmodule CDPEx do
           | {:capture_failed, term()}
           | {:idle_wait_failed, term()}
           | {:selector_not_found, String.t()}
+          | {:not_clickable, String.t()}
+          | {:unknown_key, String.t()}
           | {:evaluate_exception, term()}
           | {:unserializable_value, String.t()}
           | {:unexpected_evaluate, term()}
@@ -204,6 +206,8 @@ defmodule CDPEx do
   # Terminal — deterministic; retrying the same call yields the same error.
   def classify_error({:chrome_not_found, _}), do: :terminal
   def classify_error({:selector_not_found, _}), do: :terminal
+  def classify_error({:not_clickable, _}), do: :terminal
+  def classify_error({:unknown_key, _}), do: :terminal
   def classify_error({:evaluate_exception, _}), do: :terminal
   def classify_error({:unserializable_value, _}), do: :terminal
   def classify_error({:unexpected_evaluate, _}), do: :terminal

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -53,7 +53,7 @@ defmodule CDPEx do
   > Pages default to one WebSocket each (strong crash isolation); opt into
   > `sessionId` multiplexing (many pages over the one browser socket) with
   > `new_page(browser, transport: :session)`, trading isolation for fewer sockets.
-  > Connection pooling, network interception, and stealth remain out of scope.
+  > Stealth / anti-fingerprinting presets remain out of scope.
   """
 
   alias CDPEx.Browser

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -125,6 +125,10 @@ defmodule CDPEx.Connection do
   tell those apart.
 
   Pass `opts` with `session_id: sid` to only match events from that session.
+
+  Keep `matcher` fast and side-effect-free: it runs inside the connection process
+  for each candidate event, so a slow or blocking matcher stalls the socket — and,
+  on a `:session`-transport connection, every page sharing it.
   """
   @spec await_event(GenServer.server(), (map() -> boolean()), timeout(), keyword()) ::
           {:ok, map()} | {:error, {:timeout, :await_event} | :noproc | {:ws_closed, term()}}

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -43,6 +43,24 @@ defmodule CDPEx.Page do
   # the scheduler starvation these deadlines guard against).
   @helper_grace 5_000
 
+  # Named keys supported by press/4, with the CDP fields Input.dispatchKeyEvent
+  # needs for default actions to fire (Enter submits, Tab moves focus, etc.).
+  @keymap %{
+    # `text: "\r"` is required for Enter's default action (implicit form submit) to
+    # fire under Input.dispatchKeyEvent; a bare keyDown is treated as a raw key.
+    "Enter" => %{"key" => "Enter", "code" => "Enter", "windowsVirtualKeyCode" => 13, "text" => "\r"},
+    "Tab" => %{"key" => "Tab", "code" => "Tab", "windowsVirtualKeyCode" => 9},
+    "Escape" => %{"key" => "Escape", "code" => "Escape", "windowsVirtualKeyCode" => 27},
+    "Backspace" => %{"key" => "Backspace", "code" => "Backspace", "windowsVirtualKeyCode" => 8},
+    "Delete" => %{"key" => "Delete", "code" => "Delete", "windowsVirtualKeyCode" => 46},
+    "ArrowUp" => %{"key" => "ArrowUp", "code" => "ArrowUp", "windowsVirtualKeyCode" => 38},
+    "ArrowDown" => %{"key" => "ArrowDown", "code" => "ArrowDown", "windowsVirtualKeyCode" => 40},
+    "ArrowLeft" => %{"key" => "ArrowLeft", "code" => "ArrowLeft", "windowsVirtualKeyCode" => 37},
+    "ArrowRight" => %{"key" => "ArrowRight", "code" => "ArrowRight", "windowsVirtualKeyCode" => 39},
+    "Home" => %{"key" => "Home", "code" => "Home", "windowsVirtualKeyCode" => 36},
+    "End" => %{"key" => "End", "code" => "End", "windowsVirtualKeyCode" => 35}
+  }
+
   @lifecycle_method "Page.lifecycleEvent"
   @request_will_be_sent "Network.requestWillBeSent"
   @response_received "Network.responseReceived"
@@ -737,18 +755,82 @@ defmodule CDPEx.Page do
   end
 
   @doc """
-  Clicks the first element matching `css` (a synthetic JS `.click()`).
+  Clicks the first element matching `css` with a real, trusted mouse event.
 
-  This dispatches a synthetic DOM `.click()` via `Runtime.evaluate`, **not** a
-  trusted OS-level input event: `event.isTrusted` is `false` and there's no real
-  hit-testing, so sites that gate on trusted input won't react. Real
-  `Input`-domain dispatch is tracked in
-  [#72](https://github.com/patrols/cdp_ex/issues/72).
+  Scrolls the element into view, then dispatches `Input.dispatchMouseEvent`
+  `mousePressed`/`mouseReleased` at its center, so `event.isTrusted` is `true` and
+  the click is hit-tested like a user's.
 
-  Returns `:ok`, or `{:error, {:selector_not_found, css}}` when nothing matches.
+  Options:
+    * `:trusted` — `false` falls back to a synthetic JS `.click()` (no
+      hit-testing, `event.isTrusted == false`); the escape hatch for elements not
+      at a clickable point. Default `true`.
+    * `:timeout` — default #{@evaluate_timeout}.
+
+  Returns `:ok`, `{:error, {:selector_not_found, css}}` when nothing matches, or
+  `{:error, {:not_clickable, css}}` when the element has no usable box (zero-size
+  or not visible even after scroll).
   """
   @spec click(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def click(%__MODULE__{} = page, css, opts \\ []) when is_binary(css) do
+    if Keyword.get(opts, :trusted, true) do
+      trusted_click(page, css, opts)
+    else
+      synthetic_click(page, css, opts)
+    end
+  end
+
+  @doc """
+  Types `text` into the first element matching `css`.
+
+  Focuses the element, then sends the text via `Input.insertText` (fires `input`
+  and `change`; does not emit per-character `keydown`/`keyup`).
+
+  Returns `:ok` or `{:error, {:selector_not_found, css}}`. Option: `:timeout`
+  (default #{@evaluate_timeout}).
+  """
+  @spec type(t(), String.t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def type(%__MODULE__{} = page, css, text, opts \\ [])
+      when is_binary(css) and is_binary(text) do
+    timeout = Keyword.get(opts, :timeout, @evaluate_timeout)
+
+    case focus(page, css, opts) do
+      :ok ->
+        case do_call(page, "Input.insertText", %{"text" => text}, timeout) do
+          {:ok, _} -> :ok
+          {:error, _} = error -> error
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Presses a single named `key`, dispatching real `keyDown`/`keyUp` events.
+
+  When `css` is a selector, the element is focused first; when `css` is `nil`, the
+  key goes to the currently-focused element. Supported keys: `Enter`, `Tab`,
+  `Escape`, `Backspace`, `Delete`, `ArrowUp`/`ArrowDown`/`ArrowLeft`/`ArrowRight`,
+  `Home`, `End`.
+
+  Returns `:ok`, `{:error, {:selector_not_found, css}}`, or
+  `{:error, {:unknown_key, key}}`. Option: `:timeout` (default #{@evaluate_timeout}).
+  """
+  @spec press(t(), String.t() | nil, String.t(), keyword()) :: :ok | {:error, term()}
+  def press(%__MODULE__{} = page, css, key, opts \\ [])
+      when (is_binary(css) or is_nil(css)) and is_binary(key) do
+    timeout = Keyword.get(opts, :timeout, @evaluate_timeout)
+
+    with {:ok, fields} <- keymap(key),
+         :ok <- maybe_focus(page, css, opts),
+         {:ok, _} <- do_call(page, "Input.dispatchKeyEvent", Map.put(fields, "type", "keyDown"), timeout),
+         {:ok, _} <- do_call(page, "Input.dispatchKeyEvent", Map.put(fields, "type", "keyUp"), timeout) do
+      :ok
+    end
+  end
+
+  defp synthetic_click(page, css, opts) do
     selector = Jason.encode!(css)
 
     js = """
@@ -766,6 +848,79 @@ defmodule CDPEx.Page do
       {:error, _} = error -> error
     end
   end
+
+  defp trusted_click(page, css, opts) do
+    selector = Jason.encode!(css)
+
+    js = """
+    (function () {
+      var el = document.querySelector(#{selector});
+      if (!el) { return {found: false}; }
+      if (el.scrollIntoViewIfNeeded) { el.scrollIntoViewIfNeeded(); }
+      else { el.scrollIntoView({block: "center", inline: "center"}); }
+      var r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) { return {found: true, clickable: false}; }
+      return {found: true, clickable: true, x: r.left + r.width / 2, y: r.top + r.height / 2};
+    })()
+    """
+
+    timeout = Keyword.get(opts, :timeout, @evaluate_timeout)
+
+    case evaluate(page, js, opts) do
+      {:ok, %{"found" => false}} ->
+        {:error, {:selector_not_found, css}}
+
+      {:ok, %{"clickable" => false}} ->
+        {:error, {:not_clickable, css}}
+
+      {:ok, %{"clickable" => true, "x" => x, "y" => y}} ->
+        with :ok <- dispatch_mouse(page, "mousePressed", x, y, 1, timeout),
+             :ok <- dispatch_mouse(page, "mouseReleased", x, y, 0, timeout) do
+          :ok
+        end
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp dispatch_mouse(page, type, x, y, buttons, timeout) do
+    params = %{
+      "type" => type,
+      "x" => x,
+      "y" => y,
+      "button" => "left",
+      "buttons" => buttons,
+      "clickCount" => 1
+    }
+
+    case do_call(page, "Input.dispatchMouseEvent", params, timeout) do
+      {:ok, _} -> :ok
+      {:error, _} = error -> error
+    end
+  end
+
+  defp focus(page, css, opts) do
+    selector = Jason.encode!(css)
+
+    js = """
+    (function () {
+      var el = document.querySelector(#{selector});
+      if (!el) { return false; }
+      el.focus();
+      return true;
+    })()
+    """
+
+    case evaluate(page, js, opts) do
+      {:ok, true} -> :ok
+      {:ok, false} -> {:error, {:selector_not_found, css}}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp maybe_focus(_page, nil, _opts), do: :ok
+  defp maybe_focus(page, css, opts), do: focus(page, css, opts)
 
   @doc """
   Captures a PNG screenshot.
@@ -1503,6 +1658,15 @@ defmodule CDPEx.Page do
     case Map.fetch(@error_reasons, reason) do
       {:ok, cdp} -> {:ok, cdp}
       :error -> {:error, {:invalid_error_reason, reason}}
+    end
+  end
+
+  @doc false
+  @spec keymap(String.t()) :: {:ok, map()} | {:error, {:unknown_key, String.t()}}
+  def keymap(key) do
+    case Map.fetch(@keymap, key) do
+      {:ok, fields} -> {:ok, fields}
+      :error -> {:error, {:unknown_key, key}}
     end
   end
 

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -16,7 +16,7 @@ defmodule CDPEx.Page do
     * **Navigation** — `navigate/3`, `wait_for_navigation/2`
     * **Evaluation** — `evaluate/3`, `call_function/4`, `html/2`
     * **Waiting** — `wait_for_selector/3`, `wait_for_function/3`
-    * **Elements** — `text/3`, `attribute/4`, `visible?/3`, `click/3`
+    * **Elements** — `text/3`, `attribute/4`, `visible?/3`, `click/3`, `type/4`, `press/4`
     * **Capture** — `screenshot/2`, `pdf/2`
     * **Emulation** — `set_viewport/4`, `set_user_agent/3`
     * **Cookies & headers** — `cookies/2`, `set_cookies/3`, `clear_cookies/2`, `set_extra_headers/3`
@@ -758,8 +758,14 @@ defmodule CDPEx.Page do
   Clicks the first element matching `css` with a real, trusted mouse event.
 
   Scrolls the element into view, then dispatches `Input.dispatchMouseEvent`
-  `mousePressed`/`mouseReleased` at its center, so `event.isTrusted` is `true` and
-  the click is hit-tested like a user's.
+  `mousePressed`/`mouseReleased` at its center, so `event.isTrusted` is `true`.
+
+  The click is dispatched at the element's center but is **not** verified against
+  what is actually on top — if an overlay covers the center, the overlay receives
+  the event and the call still returns `:ok`. `{:error, {:not_clickable, css}}`
+  reflects the layout at call time; on pages that animate or lazy-render content
+  in, the box may not be ready yet, so retry at the caller (e.g. after
+  `wait_for_selector/3`) rather than treating it as permanent.
 
   Options:
     * `:trusted` — `false` falls back to a synthetic JS `.click()` (no

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -1095,6 +1095,10 @@ defmodule CDPEx.Page do
     * a **`Regex`** (matched against the URL), or
     * a **binary** substring (matched with `String.contains?/2`).
 
+  A function `matcher` runs inside the connection process for each candidate
+  response, so keep it fast and side-effect-free (a slow matcher stalls the
+  socket, and every page on a `:session`-transport connection with it).
+
   Returns `{:ok, params}` — the full `Network.responseReceived` params (HTTP status
   under `params["response"]["status"]`, request id under `params["requestId"]`) — or
   `{:error, :timeout}` if nothing matched in time, or `{:error, reason}` if the

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -790,8 +790,7 @@ defmodule CDPEx.Page do
   (default #{@evaluate_timeout}).
   """
   @spec type(t(), String.t(), String.t(), keyword()) :: :ok | {:error, term()}
-  def type(%__MODULE__{} = page, css, text, opts \\ [])
-      when is_binary(css) and is_binary(text) do
+  def type(%__MODULE__{} = page, css, text, opts \\ []) when is_binary(css) and is_binary(text) do
     timeout = Keyword.get(opts, :timeout, @evaluate_timeout)
 
     case focus(page, css, opts) do
@@ -824,8 +823,10 @@ defmodule CDPEx.Page do
 
     with {:ok, fields} <- keymap(key),
          :ok <- maybe_focus(page, css, opts),
-         {:ok, _} <- do_call(page, "Input.dispatchKeyEvent", Map.put(fields, "type", "keyDown"), timeout),
-         {:ok, _} <- do_call(page, "Input.dispatchKeyEvent", Map.put(fields, "type", "keyUp"), timeout) do
+         {:ok, _} <-
+           do_call(page, "Input.dispatchKeyEvent", Map.put(fields, "type", "keyDown"), timeout),
+         {:ok, _} <-
+           do_call(page, "Input.dispatchKeyEvent", Map.put(fields, "type", "keyUp"), timeout) do
       :ok
     end
   end
@@ -874,9 +875,8 @@ defmodule CDPEx.Page do
         {:error, {:not_clickable, css}}
 
       {:ok, %{"clickable" => true, "x" => x, "y" => y}} ->
-        with :ok <- dispatch_mouse(page, "mousePressed", x, y, 1, timeout),
-             :ok <- dispatch_mouse(page, "mouseReleased", x, y, 0, timeout) do
-          :ok
+        with :ok <- dispatch_mouse(page, "mousePressed", x, y, 1, timeout) do
+          dispatch_mouse(page, "mouseReleased", x, y, 0, timeout)
         end
 
       {:error, _} = error ->

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -282,10 +282,13 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, {:selector_not_found, "#nope"}} = Page.click(page, "#nope")
     end
 
-    test "type/4 enters text into a field", %{page: page, fixture: fixture} do
+    test "type/4 enters text into a field and fires input events", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       assert :ok = Page.type(page, "#name", "Ada")
       assert {:ok, "Ada"} = Page.evaluate(page, "document.getElementById('name').value")
+      # #typed is written by an `oninput` handler, so this proves a real input
+      # event fired (a JS `.value =` assignment would not trigger it).
+      assert {:ok, "Ada"} = Page.text(page, "#typed")
     end
 
     test "type/4 returns :selector_not_found for no match", %{page: page, fixture: fixture} do
@@ -298,6 +301,19 @@ defmodule CDPEx.IntegrationTest do
       assert :ok = Page.type(page, "#search", "hi")
       assert :ok = Page.press(page, "#search", "Enter")
       assert {:ok, "submitted"} = Page.text(page, "#greeting")
+    end
+
+    test "press/4 with a nil selector targets the focused element", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      # type/4 focuses #search; press(nil, ...) must reach the still-focused field.
+      assert :ok = Page.type(page, "#search", "hi")
+      assert :ok = Page.press(page, nil, "Enter")
+      assert {:ok, "submitted"} = Page.text(page, "#greeting")
+    end
+
+    test "press/4 returns :selector_not_found for no match", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:error, {:selector_not_found, "#nope"}} = Page.press(page, "#nope", "Enter")
     end
 
     test "press/4 returns :unknown_key for an unsupported key", %{page: page, fixture: fixture} do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -260,6 +260,51 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, {:cdp_error, "Runtime.evaluate", _}} = Page.evaluate(page, "Symbol(\"x\")")
     end
 
+    test "click/3 dispatches a trusted event by default", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.click(page, "#trusted-btn")
+      assert {:ok, "trusted"} = Page.text(page, "#greeting")
+    end
+
+    test "click/3 trusted: false uses a synthetic event", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.click(page, "#trusted-btn", trusted: false)
+      assert {:ok, "untrusted"} = Page.text(page, "#greeting")
+    end
+
+    test "click/3 returns :not_clickable for a zero-box element", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:error, {:not_clickable, "#hidden-btn"}} = Page.click(page, "#hidden-btn")
+    end
+
+    test "click/3 returns :selector_not_found for no match", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:error, {:selector_not_found, "#nope"}} = Page.click(page, "#nope")
+    end
+
+    test "type/4 enters text into a field", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.type(page, "#name", "Ada")
+      assert {:ok, "Ada"} = Page.evaluate(page, "document.getElementById('name').value")
+    end
+
+    test "type/4 returns :selector_not_found for no match", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:error, {:selector_not_found, "#nope"}} = Page.type(page, "#nope", "x")
+    end
+
+    test "press/4 Enter submits a form from a focused field", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert :ok = Page.type(page, "#search", "hi")
+      assert :ok = Page.press(page, "#search", "Enter")
+      assert {:ok, "submitted"} = Page.text(page, "#greeting")
+    end
+
+    test "press/4 returns :unknown_key for an unsupported key", %{page: page, fixture: fixture} do
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:error, {:unknown_key, "F13"}} = Page.press(page, "#search", "F13")
+    end
+
     test "call_function applies JSON args and returns the result", %{page: page, fixture: fixture} do
       {:ok, _} = Page.navigate(page, fixture)
       assert {:ok, 5} = Page.call_function(page, "(a, b) => a + b", [2, 3])

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -62,9 +62,31 @@ defmodule CDPEx.PageTest do
   end
 
   describe "keymap/1" do
-    test "returns CDP key fields for a supported key" do
-      assert {:ok, %{"key" => "Enter", "code" => "Enter", "windowsVirtualKeyCode" => 13}} =
-               Page.keymap("Enter")
+    test "every supported key maps to its standard windows virtual key code" do
+      # Guards against a transposed keyCode (e.g. ArrowUp/ArrowDown), which Chrome
+      # would silently honor as the wrong key with no CDP error.
+      expected = %{
+        "Enter" => 13,
+        "Tab" => 9,
+        "Escape" => 27,
+        "Backspace" => 8,
+        "Delete" => 46,
+        "ArrowUp" => 38,
+        "ArrowDown" => 40,
+        "ArrowLeft" => 37,
+        "ArrowRight" => 39,
+        "Home" => 36,
+        "End" => 35
+      }
+
+      for {key, vk} <- expected do
+        assert {:ok, %{"key" => ^key, "code" => ^key, "windowsVirtualKeyCode" => ^vk}} =
+                 Page.keymap(key)
+      end
+    end
+
+    test "Enter carries text so its default action fires" do
+      assert {:ok, %{"text" => "\r"}} = Page.keymap("Enter")
     end
 
     test "unknown key is an error" do

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -61,6 +61,17 @@ defmodule CDPEx.PageTest do
     }
   end
 
+  describe "keymap/1" do
+    test "returns CDP key fields for a supported key" do
+      assert {:ok, %{"key" => "Enter", "code" => "Enter", "windowsVirtualKeyCode" => 13}} =
+               Page.keymap("Enter")
+    end
+
+    test "unknown key is an error" do
+      assert {:error, {:unknown_key, "F13"}} = Page.keymap("F13")
+    end
+  end
+
   describe "set_user_agent/3" do
     test "passes userAgentMetadata + acceptLanguage through to setUserAgentOverride", %{
       fake: fake,

--- a/test/cdp_ex_test.exs
+++ b/test/cdp_ex_test.exs
@@ -44,6 +44,8 @@ defmodule CDPExTest do
     @terminal [
       {:chrome_not_found, "/usr/bin/google-chrome"},
       {:selector_not_found, ".missing"},
+      {:not_clickable, ".hidden"},
+      {:unknown_key, "F13"},
       {:evaluate_exception, %{"text" => "ReferenceError"}},
       {:unserializable_value, "NaN"},
       {:unexpected_evaluate, %{"unexpected" => true}},

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -98,6 +98,12 @@ defmodule CDPEx.FixtureServer do
         <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
         <button id="fetch-btn" onclick="fetch('/data').then(r => r.text()).then(t => { document.getElementById('greeting').textContent = t; })">Fetch</button>
         <button id="redirect-fetch-btn" onclick="fetch('/redirect')">RedirectFetch</button>
+        <input id="name" />
+        <button id="trusted-btn" onclick="document.getElementById('greeting').textContent = event.isTrusted ? 'trusted' : 'untrusted'">Trusted?</button>
+        <button id="hidden-btn" style="display:none">Hidden</button>
+        <form id="search-form" onsubmit="document.getElementById('greeting').textContent = 'submitted'; return false;">
+          <input id="search" />
+        </form>
         <div id="echo-header">#{echo}</div>
       </body>
     </html>

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -98,7 +98,8 @@ defmodule CDPEx.FixtureServer do
         <button id="btn" onclick="document.getElementById('greeting').textContent = 'Clicked'">Go</button>
         <button id="fetch-btn" onclick="fetch('/data').then(r => r.text()).then(t => { document.getElementById('greeting').textContent = t; })">Fetch</button>
         <button id="redirect-fetch-btn" onclick="fetch('/redirect')">RedirectFetch</button>
-        <input id="name" />
+        <input id="name" oninput="document.getElementById('typed').textContent = this.value" />
+        <div id="typed"></div>
         <button id="trusted-btn" onclick="document.getElementById('greeting').textContent = event.isTrusted ? 'trusted' : 'untrusted'">Trusted?</button>
         <button id="hidden-btn" style="display:none">Hidden</button>
         <form id="search-form" onsubmit="document.getElementById('greeting').textContent = 'submitted'; return false;">


### PR DESCRIPTION
Closes #72. Replaces the synthetic `el.click()` with real `Input`-domain interaction. Targets **0.9.0**.

Design: `docs/design/2026-06-14-input-domain-interaction.md`.

## Changes (all on `CDPEx.Page`, all session-scoped via `do_call`)
- **`click/3` — trusted by default.** Scrolls into view, reads `getBoundingClientRect`, dispatches `Input.dispatchMouseEvent` `mousePressed`/`mouseReleased` at the center, so `event.isTrusted` is `true`. `trusted: false` keeps the synthetic `el.click()` escape hatch.
- **`type/4`** — focus + `Input.insertText` (fires `input`/`change`).
- **`press/4`** — `Input.dispatchKeyEvent` `keyDown`/`keyUp` over a curated named-key map (`Enter`, `Tab`, `Escape`, `Backspace`, `Delete`, arrows, `Home`, `End`); `css: nil` targets the focused element. Enter carries `text: "\r"` so its default action (implicit form submit) fires.

## ⚠️ Breaking (vs 0.8.0)
`click/3` is now a trusted event by default and can newly return `{:error, {:not_clickable, css}}` for an element with no usable box. `press` adds `{:error, {:unknown_key, key}}`. Both new reasons classify `:terminal` (coverage invariant satisfied).

## Verified against live Chrome
Integration tests cover: trusted click (`isTrusted: true`), `trusted: false` (`false`), `type` fills + fires `input`, `press(…, "Enter")` submits a form, zero-box → `:not_clickable`, no-match → `:selector_not_found`, `:unknown_key`. The Enter-submit test caught a real bug (needed `text: "\r"`) that a unit test would have missed.

`mix ci` green (236 passed, 17 doctests, dialyzer 0, credo clean); full integration suite green against real Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
