### PR TITLE
feat: connect to an existing/remote DevTools endpoint (connect/2, wss://)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   instead of a synthetic `el.click()`. Pass `trusted: false` for the old synthetic
   behavior. A trusted click can newly fail with `{:error, {:not_clickable, css}}`
   for an element with no usable box (zero-size / off-screen even after scroll) (#72).
+- `CDPEx.Protocol.parse_ws_url/1` now returns a 4-tuple `{scheme, host, port, path}`
+  (was `{host, port, path}`) and accepts `wss://` again (reversing the 0.8.0
+  rejection), enabling TLS DevTools endpoints / cloud browser providers behind
+  `connect/2`. The added leading `scheme` element is a breaking change for any caller
+  destructuring the old 3-tuple — update `{host, port, path} = parse_ws_url(url)` to
+  `{_scheme, host, port, path} = parse_ws_url(url)` (#73).
 
 ### Added
 - `CDPEx.connect/2` — drive an already-running Chrome instead of launching one.
@@ -23,10 +29,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `wss://` is verified against the OS trust store (`:public_key.cacerts_get()`),
   with `:insecure` / `:cacertfile` / `:cacerts` escape hatches. A failed endpoint
   discovery returns `{:error, {:connect_discovery_failed, reason}}` (classified
-  `:unknown`). `with_page([connect: endpoint], fun)` is the one-shot form (#73).
-- `CDPEx.Protocol.parse_ws_url/1` accepts `wss://` again (lifting the 0.8.0
-  rejection), enabling TLS DevTools endpoints / cloud browser providers behind
-  `connect/2` (#73).
+  `:unknown`). Combining `:proxy` with `:connect` is rejected with
+  `{:error, {:unsupported_with_connect, :proxy}}` (a `--proxy-server` flag can't
+  apply to a Chrome cdp_ex didn't launch). `with_page([connect: endpoint], fun)` is
+  the one-shot form (#73).
 - `CDPEx.Page.type/4` — focus an element and enter text via `Input.insertText` (#72).
 - `CDPEx.Page.press/4` — press a named key (`Enter`, `Tab`, `Escape`, `Backspace`,
   `Delete`, the arrows, `Home`, `End`) with real `keyDown`/`keyUp` events; a `nil`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   instead of a synthetic `el.click()`. Pass `trusted: false` for the old synthetic
   behavior. A trusted click can newly fail with `{:error, {:not_clickable, css}}`
   for an element with no usable box (zero-size / off-screen even after scroll) (#72).
-- `CDPEx.Protocol.parse_ws_url/1` now returns a 4-tuple `{scheme, host, port, path}`
+- `CDPEx.Protocol.parse_ws_url/1` now returns a 4-tuple `{scheme, host, port, target}`
   (was `{host, port, path}`) and accepts `wss://` again (reversing the 0.8.0
   rejection), enabling TLS DevTools endpoints / cloud browser providers behind
   `connect/2`. The added leading `scheme` element is a breaking change for any caller
   destructuring the old 3-tuple — update `{host, port, path} = parse_ws_url(url)` to
-  `{_scheme, host, port, path} = parse_ws_url(url)` (#73).
+  `{_scheme, host, port, target} = parse_ws_url(url)`. The fourth element is now the
+  WebSocket request target (path **plus any `?query`**), so a token-bearing cloud
+  endpoint (`wss://host/cdp?token=…`) keeps its query through the upgrade (#73).
 
 ### Added
 - `CDPEx.connect/2` — drive an already-running Chrome instead of launching one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   for an element with no usable box (zero-size / off-screen even after scroll) (#72).
 
 ### Added
+- `CDPEx.connect/2` — drive an already-running Chrome instead of launching one.
+  Accepts a `ws://`/`wss://` browser URL or an `http://`/`https://` base URL
+  (discovered via `GET /json/version`). Returns the same handle as `launch/1`;
+  `stop/1` closes only the pages cdp_ex opened and never reaps the remote Chrome.
+  Pages default to `:session` transport (`:dedicated` over a connected browser is
+  not yet supported — returns `{:error, {:unsupported_transport, :dedicated}}`).
+  `wss://` is verified against the OS trust store (`:public_key.cacerts_get()`),
+  with `:insecure` / `:cacertfile` / `:cacerts` escape hatches. A failed endpoint
+  discovery returns `{:error, {:connect_discovery_failed, reason}}` (classified
+  `:unknown`). `with_page([connect: endpoint], fun)` is the one-shot form (#73).
+- `CDPEx.Protocol.parse_ws_url/1` accepts `wss://` again (lifting the 0.8.0
+  rejection), enabling TLS DevTools endpoints / cloud browser providers behind
+  `connect/2` (#73).
 - `CDPEx.Page.type/4` — focus an element and enter text via `Input.insertText` (#72).
 - `CDPEx.Page.press/4` — press a named key (`Enter`, `Tab`, `Escape`, `Backspace`,
   `Delete`, the arrows, `Home`, `End`) with real `keyDown`/`keyUp` events; a `nil`
@@ -21,6 +34,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `{:error, {:unknown_key, key}}` (#72).
 
 ### Fixed
+- The page WebSocket URL now brackets an IPv6 host (`ws://[::1]:9222/…`) instead
+  of producing a malformed `ws://::1:9222/…`, so a `:dedicated` page can be opened
+  against a Chrome bound to an IPv6 address (#73).
 - `CDPEx.Page.observe_network/2` now scopes its subscription to the page's
   session, so on a `:session`-transport connection a caller receives only that
   page's `Network` events instead of every session's on the shared socket.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Pages default to `:session` transport (`:dedicated` over a connected browser is
   not yet supported — returns `{:error, {:unsupported_transport, :dedicated}}`).
   `wss://` is verified against the OS trust store (`:public_key.cacerts_get()`),
-  with `:insecure` / `:cacertfile` / `:cacerts` escape hatches. A failed endpoint
+  with `:insecure` / `:cacertfile` / `:cacerts` escape hatches; `:discovery_timeout`
+  bounds a slow remote `/json/version`. A failed endpoint
   discovery returns `{:error, {:connect_discovery_failed, reason}}` (classified
   `:unknown`). Combining `:proxy` with `:connect` is rejected with
   `{:error, {:unsupported_with_connect, :proxy}}` (a `--proxy-server` flag can't

--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ the OS trust store — pass `:cacertfile` for a private CA, or `insecure: true` 
 skip verification. `with_page([connect: "http://localhost:9222"], fun)` is the
 one-shot form.
 
+> **`http(s)://` discovery is IP/localhost only.** Chrome's DevTools HTTP endpoint
+> returns **403** for a non-IP/non-`localhost` `Host` (DNS-rebinding protection), so
+> for a **named** remote/sidecar/cloud Chrome pass the `ws(s)://` browser URL
+> directly rather than the `http(s)://` discovery form.
+
 ### Under your supervision tree
 
 Because `terminate/2` reaps Chrome, supervise the browser with a `:shutdown`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Playwright or Puppeteer), that's the gap CDPEx fills.
 > with `new_page(browser, transport: :session)`; the trade-off is shared fate (a
 > dropped browser connection drops all of its session pages).
 >
+> **Connect to a running Chrome:** attach to a Chrome you didn't launch — local,
+> a sidecar, or a remote/cloud `wss://` endpoint — with `connect/2` (`:session`
+> transport; it never reaps a process it didn't start). See below.
+>
 > Stealth / anti-fingerprinting presets remain out of scope for now (evidence-gated).
 
 ## Installation
@@ -165,7 +169,8 @@ container, or a cloud browser provider — with `connect/2`:
 A connected browser uses `:session` transport (many pages over the one socket);
 `:dedicated` over a connection isn't supported yet. `wss://` is verified against
 the OS trust store — pass `:cacertfile` for a private CA, or `insecure: true` to
-skip verification. `with_page([connect: "http://localhost:9222"], fun)` is the
+skip verification. Raise `:discovery_timeout` (default `5_000` ms) for a slow
+remote `/json/version`. `with_page([connect: "http://localhost:9222"], fun)` is the
 one-shot form.
 
 > **`http(s)://` discovery is IP/localhost only.** Chrome's DevTools HTTP endpoint
@@ -356,8 +361,9 @@ handle — a dead page keeps returning `:noproc`.
 
 CDPEx emits [`:telemetry`](https://hexdocs.pm/telemetry) events and attaches no
 handlers; attach your own to record them (emitting with nothing attached is a no-op).
-Events: `[:cdp_ex, :launch, …]` and `[:cdp_ex, :navigate, …]` spans,
-`[:cdp_ex, :page, :start | :stop]`, and `[:cdp_ex, :error]`. See
+Events: `[:cdp_ex, :launch, …]`, `[:cdp_ex, :connect, …]`, and
+`[:cdp_ex, :navigate, …]` spans, `[:cdp_ex, :page, :start | :stop]`, and
+`[:cdp_ex, :error]`. See
 [`CDPEx.Telemetry`](https://hexdocs.pm/cdp_ex/CDPEx.Telemetry.html) for the full
 taxonomy (measurements + metadata).
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ even if the function raises:
 :ok = CDPEx.stop(browser)
 ```
 
+### Connecting to an existing Chrome
+
+Drive a Chrome that CDPEx didn't launch — one you started yourself, a sidecar
+container, or a cloud browser provider — with `connect/2`:
+
+```elixir
+# An http(s):// base URL is discovered via GET /json/version:
+{:ok, browser} = CDPEx.connect("http://localhost:9222")
+# …or pass the browser WebSocket URL directly (ws:// or, for a TLS endpoint, wss://):
+{:ok, browser} = CDPEx.connect("wss://chrome.example.com/cdp?token=…")
+
+{:ok, page} = CDPEx.new_page(browser, transport: :session)
+{:ok, _}    = CDPEx.Page.navigate(page, "https://example.com")
+
+# stop/1 closes the pages YOU opened and disconnects — it never kills that Chrome.
+:ok = CDPEx.stop(browser)
+```
+
+A connected browser uses `:session` transport (many pages over the one socket);
+`:dedicated` over a connection isn't supported yet. `wss://` is verified against
+the OS trust store — pass `:cacertfile` for a private CA, or `insecure: true` to
+skip verification. `with_page([connect: "http://localhost:9222"], fun)` is the
+one-shot form.
+
 ### Under your supervision tree
 
 Because `terminate/2` reaps Chrome, supervise the browser with a `:shutdown`

--- a/docs/design/2026-06-14-connect-remote-endpoint.md
+++ b/docs/design/2026-06-14-connect-remote-endpoint.md
@@ -1,0 +1,132 @@
+# Design: connect to an existing/remote DevTools endpoint (#73)
+
+**Status:** approved (brainstorm) — pending implementation
+**Target release:** 0.9.0
+**Issue:** [#73](https://github.com/patrols/cdp_ex/issues/73)
+
+## Context / problem
+
+cdp_ex can only `launch/1` a throwaway Chrome on the same host and reap it. It
+cannot attach to a Chrome that is already running — a sidecar/remote Chrome
+container, a cloud browser provider (Browserless / Browserbase), a warm
+long-lived Chrome, or a real browser set up by hand. This is a standard capability
+(Puppeteer `browserWSEndpoint`/`browserURL`, Playwright `connectOverCDP`) and was
+the second functional gap flagged in the original review. It also re-enables
+`wss://`, which 0.8.0 deliberately rejected (no consumer then; this PR is that
+consumer).
+
+Scope is held to a **`:session`-transport MVP**; dedicated-transport over a
+remote browser is deferred (the per-page socket URL must target the remote host
+and derive a `wss://` page URL — fiddly, low-demand).
+
+## Decisions (resolved in brainstorm)
+
+1. **Accept both endpoint forms.** A `ws://`/`wss://` URL connects directly; an
+   `http://`/`https://` URL is discovered via `GET /json/version` →
+   `webSocketDebuggerUrl`. The http form is the ergonomic default (you know
+   `host:port`, not the per-launch GUID URL); the ws form is for TLS proxies /
+   providers that hand you the socket URL.
+2. **Teardown closes our targets, never Chrome.** `stop/1` on a connected browser
+   `Target.closeTarget`s the pages cdp_ex opened (best-effort), then drops the
+   socket; it never reaps Chrome and never touches pre-existing targets. Symmetric
+   with `launch` (which owns Chrome) — `connect` owns only the targets it created.
+3. **`:session` is the connected-browser default; explicit `:dedicated` errors.**
+   `new_page/2` on a connected browser defaults to `:session` (rides the shared
+   browser socket, works over remote/`wss://` as-is). `transport: :dedicated`
+   returns `{:error, {:unsupported_transport, :dedicated}}` — no silent downgrade.
+4. **TLS: verify by default via the OS trust store; escape hatches.** `wss://`
+   verifies the peer cert using `:public_key.cacerts_get()` (OTP 25+; cdp_ex's
+   floor is OTP 26) — **no new dependency** (preserving cdp_ex's dependency-light
+   identity, vs. adding `castore`). `insecure: true` drops to `verify_none` for
+   self-signed proxies; `cacertfile:`/`cacerts:` override the CA source.
+
+## Public API (`CDPEx`)
+
+- `connect(endpoint, opts \\ [])` :: `{:ok, browser} | {:error, term()}`
+  - Returns the same Browser handle as `launch/1`; `new_page/2`, `with_page/3`,
+    `close_page/2`, `stop/1` all work on it.
+  - `endpoint`: `ws(s)://…` (direct) or `http(s)://host:port` (discovered).
+  - opts: `:insecure` (bool, default `false`), `:cacertfile`, `:cacerts`, `:name`.
+- `with_page(opts, fun, page_opts \\ [])` gains a connect route: when the keyword
+  list contains `:connect`, it `connect`s a throwaway-handle browser for the call
+  (page is closed and the socket dropped afterward; Chrome is never killed),
+  otherwise it `launch`es as today.
+
+## Internals
+
+- `Browser.start_link([connect: endpoint] ++ opts)` — `init/1` detects `:connect`,
+  **skips `Chrome.launch`**, resolves `endpoint` → ws URL, and calls
+  `connect_browser/_` with **`chrome: nil`** + the resolved URL. The existing
+  `connect_browser` already parses host/port, starts the `Connection`, and
+  subscribes to `Target.detachedFromTarget`; its failure `catch` must guard
+  `Chrome.stop(chrome)` for `nil`.
+- **Endpoint resolution** (new private helper): ws/wss → passthrough; http/https →
+  `Mint.HTTP` `GET /json/version`, `Jason`-decode, read `webSocketDebuggerUrl`.
+  Any failure → `{:error, {:connect_discovery_failed, reason}}`.
+  - **Host derivation:** Chrome echoes the request `Host` into the returned
+    `webSocketDebuggerUrl` and can report `127.0.0.1`/`localhost` for a remote
+    endpoint. So combine the **endpoint's host/port** with the **discovered URL's
+    path** (the per-launch GUID), and carry the endpoint's `http→ws` /
+    `https→wss` scheme — don't trust the returned host verbatim.
+- **`CDPEx.Protocol.parse_ws_url/1`** re-accepts `wss://` and returns the scheme
+  (`{scheme, host, port, path}`), reversing the 0.8.0 rejection.
+- **`CDPEx.Connection.init/1`** selects `:http`/`:https` by scheme; for `wss`
+  passes `transport_opts` (verify_peer + `:public_key.cacerts_get()` by default;
+  `insecure`/`cacertfile`/`cacerts` from opts).
+- **`Browser.new_page/2`** on a connected browser (`state.chrome == nil`):
+  default `:session`; explicit `:dedicated` → `{:error, {:unsupported_transport, :dedicated}}`.
+- **IPv6 fix** (carried from the #78 review): `open_target/_`'s page URL brackets
+  an IPv6 host (`[::1]`) instead of `ws://::1:9222/…`. (Only reachable once
+  dedicated-over-remote lands, but a cheap correctness fix.)
+
+## Teardown
+
+`terminate/2` / `stop/1`:
+- `chrome != nil` (launched) — today's reap (kill Chrome, cleanup temp profile).
+- `chrome == nil` (connected) — if `browser_conn` is alive, `Target.closeTarget`
+  each tracked page/session (best-effort; ignore errors), then close the socket.
+  Never reap Chrome. On a crashed/dropped connection there is nothing to close
+  (the socket is gone) — just let go.
+
+## Error reasons
+
+- New `{:connect_discovery_failed, term()}` — `/json/version` GET or parse failed.
+  Add to `t:CDPEx.error_reason/0`, `classify_error/1` → `:unknown`
+  (payload-dependent: a network blip vs. a bad endpoint), and a coverage exemplar
+  (in the `@payload_dependent` list in `test/cdp_ex_test.exs`).
+- `:dedicated`-on-connected reuses the existing `{:unsupported_transport, term()}`.
+
+## Testing
+
+**Unit:**
+- endpoint resolution: `ws://`/`wss://` passthrough; `http://` → discovery against
+  a `/json/version` route added to `CDPEx.FixtureServer`; malformed/unreachable →
+  `{:connect_discovery_failed, _}`.
+- `parse_ws_url/1` accepts `wss://` and returns the scheme.
+- `Connection` scheme → `:http`/`:https` selection (and TLS opt assembly) — unit,
+  no real TLS server.
+- `new_page(transport: :dedicated)` on a connected browser → error.
+
+**Integration (real Chrome):**
+- `launch` browser A (owns Chrome) → read its http endpoint
+  (`:sys.get_state(A).host`/`port`) → `connect` browser B to `http://host:port` →
+  `new_page(B, transport: :session)` → navigate + evaluate → `stop(B)` → **assert
+  A's Chrome is still alive** (B still-open page closed; A unaffected). This is the
+  no-reap guarantee, the key test.
+- `with_page([connect: "http://host:port"], …)` smoke.
+
+**Out of scope:** dedicated-transport over a connected browser; a `wss://`
+integration test (needs a TLS-terminating proxy — the scheme/TLS selection is
+unit-tested instead).
+
+## Release
+
+0.9.0. CHANGELOG `### Added` (`connect/2` + `with_page(connect:)`, `wss://`
+support — noting the 0.8.0 rejection is lifted) and `### Fixed` (IPv6 page URL).
+
+## Out of scope / future
+
+- Dedicated transport over a connected/remote browser (per-page socket URL host +
+  `wss://` page URL).
+- `wss://` end-to-end integration test.
+- A dedicated `disconnect/1` alias (Puppeteer familiarity) — `stop/1` covers it.

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -57,6 +57,7 @@ defmodule CDPEx do
   """
 
   alias CDPEx.Browser
+  alias CDPEx.Connect
   alias CDPEx.Page
   alias CDPEx.Telemetry
 
@@ -347,7 +348,7 @@ defmodule CDPEx do
       {tls_opts, opts} = Keyword.split(opts, [:insecure, :cacertfile, :cacerts])
 
       result =
-        case CDPEx.Connect.resolve(endpoint) do
+        case Connect.resolve(endpoint) do
           {:ok, ws_url} -> Browser.start_link([connect: ws_url, conn_opts: tls_opts] ++ opts)
           {:error, _} = error -> error
         end

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -324,7 +324,39 @@ defmodule CDPEx do
   defp launch_metadata({:error, reason}), do: %{error: reason}
   defp launch_metadata(:ignore), do: %{error: :ignore}
 
-  @doc "Stops a browser started with `launch/1`, closing all pages and killing Chrome."
+  @doc """
+  Connects to an already-running Chrome instead of launching one.
+
+  `endpoint` is either a `ws://`/`wss://` browser WebSocket URL (used directly) or
+  an `http://`/`https://` base URL (the browser socket is discovered via
+  `GET /json/version`, with the host/port taken from `endpoint`). Returns the same
+  handle as `launch/1`, so `new_page/2`, `with_page/3`, `close_page/2`, and
+  `stop/1` all work — but `stop/1` only closes the pages cdp_ex opened and drops
+  the socket; it never kills the remote Chrome or touches pre-existing tabs.
+
+  Pages default to `:session` transport; `transport: :dedicated` returns
+  `{:error, {:unsupported_transport, :dedicated}}` (not yet supported over a
+  connected browser).
+
+  Options: `:insecure` (skip `wss://` cert verification, default `false`),
+  `:cacertfile` / `:cacerts` (custom CA for `wss://`), `:name` (register the process).
+  """
+  @spec connect(String.t(), keyword()) :: GenServer.on_start()
+  def connect(endpoint, opts \\ []) when is_binary(endpoint) do
+    Telemetry.span(:connect, %{}, fn ->
+      {tls_opts, opts} = Keyword.split(opts, [:insecure, :cacertfile, :cacerts])
+
+      result =
+        case CDPEx.Connect.resolve(endpoint) do
+          {:ok, ws_url} -> Browser.start_link([connect: ws_url, conn_opts: tls_opts] ++ opts)
+          {:error, _} = error -> error
+        end
+
+      {result, launch_metadata(result)}
+    end)
+  end
+
+  @doc "Stops a browser started with `launch/1` (kills Chrome) or `connect/2` (closes the pages it opened, leaves Chrome running)."
   @spec stop(pid()) :: :ok
   def stop(browser), do: Browser.stop(browser)
 
@@ -389,7 +421,16 @@ defmodule CDPEx do
   end
 
   def with_page(launch_opts, fun, opts) when is_list(launch_opts) and is_function(fun, 1) do
-    case launch(launch_opts) do
+    # `[connect: endpoint]` attaches to a running Chrome instead of launching one;
+    # the resource-safe trap/stop/drain machinery below is identical (stop/1 on a
+    # connected browser closes only the pages we opened — it never kills Chrome).
+    start =
+      case Keyword.pop(launch_opts, :connect) do
+        {nil, _} -> fn -> launch(launch_opts) end
+        {endpoint, rest} -> fn -> connect(endpoint, rest) end
+      end
+
+    case start.() do
       {:ok, browser} ->
         # launch/1 links `browser` to us. Trap exits for the duration of this call
         # so a browser crash (e.g. its connection dropping mid-call) arrives as a

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -127,6 +127,7 @@ defmodule CDPEx do
           | {:invalid_transport, term()}
           | {:invalid_proxy, term()}
           | {:unsupported_transport, term()}
+          | {:unsupported_with_connect, term()}
           | {:invalid_response_body, String.t()}
           | {:invalid_pdf_data, String.t()}
           | {:invalid_screenshot_data, String.t()}
@@ -178,9 +179,11 @@ defmodule CDPEx do
       crack: an ambiguous navigation `net::ERR_*` (DNS `ERR_NAME_NOT_RESOLVED`,
       `ERR_ABORTED`, `ERR_BLOCKED_BY_*` — unlike the connection-layer codes above), the
       CDP error code (`{:cdp_error, _, _}`), the file-write posix reason
-      (`{:write_failed, _}`), or whether a `{:no_document_response, _}` was a
-      same-document hop or a slow miss. Also covers any term `CDPEx` doesn't produce.
-      Decide the retry policy yourself.
+      (`{:write_failed, _}`), whether a `{:no_document_response, _}` was a
+      same-document hop or a slow miss, or a `connect/2` endpoint-discovery failure
+      (`{:connect_discovery_failed, _}` — a transient network blip and a permanently
+      bad endpoint are indistinguishable here). Also covers any term `CDPEx` doesn't
+      produce. Decide the retry policy yourself.
 
   Retries are the caller's responsibility: bound the attempts and back off. A
   `:transient` result means **re-establish the resource** — open a fresh page/browser
@@ -219,6 +222,7 @@ defmodule CDPEx do
   def classify_error({:invalid_transport, _}), do: :terminal
   def classify_error({:invalid_proxy, _}), do: :terminal
   def classify_error({:unsupported_transport, _}), do: :terminal
+  def classify_error({:unsupported_with_connect, _}), do: :terminal
   def classify_error({:invalid_response_body, _}), do: :terminal
   def classify_error({:invalid_pdf_data, _}), do: :terminal
   def classify_error({:invalid_screenshot_data, _}), do: :terminal
@@ -348,7 +352,7 @@ defmodule CDPEx do
       {tls_opts, opts} = Keyword.split(opts, [:insecure, :cacertfile, :cacerts])
 
       result =
-        case Connect.resolve(endpoint) do
+        case Connect.resolve(endpoint, tls_opts) do
           {:ok, ws_url} -> Browser.start_link([connect: ws_url, conn_opts: tls_opts] ++ opts)
           {:error, _} = error -> error
         end
@@ -378,8 +382,11 @@ defmodule CDPEx do
   options, the browser) is cleaned up afterwards — even if `fun` raises.
 
   Pass an existing browser pid to reuse it, or a keyword list of launch options
-  to spin up a throwaway browser for the duration of the call. Returns whatever
-  `fun` returns, or `{:error, reason}` if the page/browser could not be created.
+  to spin up a throwaway browser for the duration of the call. A `[connect:
+  endpoint]` list attaches to an already-running Chrome instead of launching one
+  (see `connect/2`); teardown then closes only the pages it opened and never reaps
+  that Chrome. Returns whatever `fun` returns, or `{:error, reason}` if the
+  page/browser could not be created.
 
   With launch options, the throwaway browser is linked but **contained**: if it
   crashes during the call (e.g. its connection drops) `with_page` returns
@@ -399,6 +406,9 @@ defmodule CDPEx do
 
       # throwaway browser + page
       CDPEx.with_page([headless: true], &CDPEx.Page.html/1)
+
+      # against an existing Chrome (discovered via /json/version)
+      CDPEx.with_page([connect: "http://localhost:9222"], &CDPEx.Page.html/1)
   """
   @spec with_page(pid() | keyword(), (Page.t() -> result), keyword()) ::
           result | {:error, term()}

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -339,6 +339,15 @@ defmodule CDPEx do
   `stop/1` all work — but `stop/1` only closes the pages cdp_ex opened and drops
   the socket; it never kills the remote Chrome or touches pre-existing tabs.
 
+  > #### http(s) discovery is IP/localhost only {: .warning}
+  >
+  > Chrome's DevTools HTTP endpoint rejects `/json/version` with **403** when the
+  > `Host` header is a non-IP, non-`localhost` name (DNS-rebinding protection), so
+  > the `http(s)://` discovery form works only for IP / `localhost` endpoints (a 403
+  > surfaces as `{:error, {:connect_discovery_failed, {:http_status, 403}}}`). For a
+  > **named** remote/sidecar/cloud host, pass the `ws(s)://` browser URL directly
+  > (or launch that Chrome with a permissive `--remote-allow-origins`/host).
+
   Pages default to `:session` transport; `transport: :dedicated` returns
   `{:error, {:unsupported_transport, :dedicated}}` (not yet supported over a
   connected browser).

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -111,6 +111,7 @@ defmodule CDPEx do
           | {:conflict, :authenticated | :intercepting}
           | {:navigate, String.t()}
           | {:no_document_response, String.t()}
+          | {:connect_discovery_failed, term()}
           | {:capture_failed, term()}
           | {:idle_wait_failed, term()}
           | {:selector_not_found, String.t()}
@@ -240,6 +241,7 @@ defmodule CDPEx do
   def classify_error({:cdp_error, _, _}), do: :unknown
   def classify_error({:write_failed, _}), do: :unknown
   def classify_error({:no_document_response, _}), do: :unknown
+  def classify_error({:connect_discovery_failed, _}), do: :unknown
   # Anything else — a reason CDPEx doesn't produce, or a future shape.
   def classify_error(_other), do: :unknown
 

--- a/lib/cdp_ex.ex
+++ b/lib/cdp_ex.ex
@@ -353,15 +353,20 @@ defmodule CDPEx do
   connected browser).
 
   Options: `:insecure` (skip `wss://` cert verification, default `false`),
-  `:cacertfile` / `:cacerts` (custom CA for `wss://`), `:name` (register the process).
+  `:cacertfile` / `:cacerts` (custom CA for `wss://`), `:discovery_timeout` (ceiling
+  in ms for the whole `http(s)://` `/json/version` exchange — TCP connect, recv, and
+  body — default `5_000`; raise it for a slow remote endpoint), `:name` (register the
+  process).
   """
   @spec connect(String.t(), keyword()) :: GenServer.on_start()
   def connect(endpoint, opts \\ []) when is_binary(endpoint) do
     Telemetry.span(:connect, %{}, fn ->
       {tls_opts, opts} = Keyword.split(opts, [:insecure, :cacertfile, :cacerts])
+      {disc_timeout, opts} = Keyword.pop(opts, :discovery_timeout)
+      disc_opts = if disc_timeout, do: [timeout: disc_timeout], else: []
 
       result =
-        case Connect.resolve(endpoint, tls_opts) do
+        case Connect.resolve(endpoint, tls_opts, disc_opts) do
           {:ok, ws_url} -> Browser.start_link([connect: ws_url, conn_opts: tls_opts] ++ opts)
           {:error, _} = error -> error
         end

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -8,9 +8,13 @@ defmodule CDPEx.Browser do
     * It **traps exits** and links every connection, so a page connection crash
       is isolated (the page is dropped; the browser and other pages survive),
       while a browser-connection or Chrome death stops the browser cleanly.
-    * `terminate/2` always runs `CDPEx.Chrome.stop/1` — the no-orphan guarantee.
-      Because that relies on `terminate/2`, supervise this with a `:shutdown`
-      timeout, **not** `:brutal_kill`.
+    * For a **launched** browser, `terminate/2` always runs `CDPEx.Chrome.stop/1`
+      — the no-orphan guarantee. Because that relies on `terminate/2`, supervise a
+      launched browser with a `:shutdown` timeout, **not** `:brutal_kill`.
+
+  A browser started via `CDPEx.connect/2` (connect-mode, `chrome: nil`) is the
+  exception: it never launched Chrome, so `terminate/2` only closes the pages it
+  opened and never reaps the remote process — `:brutal_kill` is harmless there.
 
   Most callers use the `CDPEx` facade rather than this module directly.
   """
@@ -137,7 +141,12 @@ defmodule CDPEx.Browser do
     :exit, _ -> :ok
   end
 
-  @doc "Stops the browser, closing all pages and killing Chrome."
+  @doc """
+  Stops the browser, closing all pages.
+
+  A launched browser also kills its Chrome; a connected one (`CDPEx.connect/2`)
+  closes only the pages it opened and leaves the remote Chrome running.
+  """
   @spec stop(GenServer.server()) :: :ok
   def stop(browser), do: GenServer.stop(browser, :normal)
 
@@ -155,26 +164,33 @@ defmodule CDPEx.Browser do
     {connect_ws, launch_opts} = Keyword.pop(launch_opts, :connect)
     {conn_opts, launch_opts} = Keyword.pop(launch_opts, :conn_opts, [])
 
-    if connect_ws do
-      # Connect-mode: attach to an already-running Chrome. No Chrome.launch, and
-      # chrome: nil so terminate/2 never reaps a process we didn't start.
-      connect_browser(nil, connect_ws, launch_opts, owner || parent_pid(), nil, conn_opts)
-    else
-      {proxy, launch_opts} = Keyword.pop(launch_opts, :proxy)
+    cond do
+      connect_ws && Keyword.has_key?(launch_opts, :proxy) ->
+        # :proxy is a Chrome launch flag (--proxy-server); connect-mode launches no
+        # Chrome, so it could never take effect. Reject rather than silently ignore it.
+        {:stop, {:unsupported_with_connect, :proxy}}
 
-      with {:ok, proxy_auth, launch_opts} <- apply_proxy(proxy, launch_opts),
-           {:ok, chrome} <- Chrome.launch(launch_opts) do
-        connect_browser(
-          chrome,
-          chrome.debug_url,
-          launch_opts,
-          owner || parent_pid(),
-          proxy_auth,
-          []
-        )
-      else
-        {:error, reason} -> {:stop, reason}
-      end
+      connect_ws ->
+        # Connect-mode: attach to an already-running Chrome. No Chrome.launch, and
+        # chrome: nil so terminate/2 never reaps a process we didn't start.
+        connect_browser(nil, connect_ws, launch_opts, owner || parent_pid(), nil, conn_opts)
+
+      true ->
+        {proxy, launch_opts} = Keyword.pop(launch_opts, :proxy)
+
+        with {:ok, proxy_auth, launch_opts} <- apply_proxy(proxy, launch_opts),
+             {:ok, chrome} <- Chrome.launch(launch_opts) do
+          connect_browser(
+            chrome,
+            chrome.debug_url,
+            launch_opts,
+            owner || parent_pid(),
+            proxy_auth,
+            []
+          )
+        else
+          {:error, reason} -> {:stop, reason}
+        end
     end
   end
 

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -84,11 +84,14 @@ defmodule CDPEx.Browser do
   Opens a new page (tab) and returns a `CDPEx.Page` handle.
 
   Options:
-    * `:transport` — `:dedicated` (default, one WebSocket per page, strong crash
-      isolation) or `:session` (multiplexed over the browser socket via a
-      flattened CDP session — fewer sockets, but all session pages share the
-      browser connection's fate: if it drops, they all go). Any other value
-      returns `{:error, {:invalid_transport, value}}`.
+    * `:transport` — `:dedicated` (one WebSocket per page, strong crash isolation)
+      or `:session` (multiplexed over the browser socket via a flattened CDP
+      session — fewer sockets, but all session pages share the browser
+      connection's fate: if it drops, they all go). A **launched** browser
+      defaults to `:dedicated`; a **connected** browser (`CDPEx.connect/2`)
+      defaults to `:session` and rejects `:dedicated` with
+      `{:error, {:unsupported_transport, :dedicated}}`. Any other value returns
+      `{:error, {:invalid_transport, value}}`.
     * `:prevent_alerts` — inject no-op `alert`/`confirm`/`prompt` (default `true`)
   """
   @spec new_page(GenServer.server(), keyword()) :: {:ok, Page.t()} | {:error, term()}
@@ -741,7 +744,7 @@ defmodule CDPEx.Browser do
   # page connection, if opened) — otherwise we leak a Chrome tab/socket that
   # isn't tracked in state.pages and can't be cleaned up deterministically.
   defp open_target(state, tid, opts) do
-    page_url = "ws://#{bracket_host(state.host)}:#{state.port}/devtools/page/#{tid}"
+    page_url = "ws://#{Protocol.bracket_host(state.host)}:#{state.port}/devtools/page/#{tid}"
 
     case Connection.start_link(page_url) do
       {:ok, conn} ->
@@ -865,12 +868,6 @@ defmodule CDPEx.Browser do
   defp close_target(browser_conn, tid) do
     _ = Connection.call(browser_conn, "Target.closeTarget", %{"targetId" => tid}, @create_timeout)
     :ok
-  end
-
-  # Bracket an IPv6 literal so the page WebSocket URL is well-formed
-  # (`ws://[::1]:9222/…` rather than the malformed `ws://::1:9222/…`).
-  defp bracket_host(host) do
-    if String.contains?(host, ":"), do: "[#{host}]", else: host
   end
 
   # Stop a page connection, tolerating an already-dead process. `Connection.close/1`

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -187,7 +187,7 @@ defmodule CDPEx.Browser do
   # returns {:stop, _} *before* the GenServer loop starts, so terminate/2 never
   # runs — we must reap Chrome here or leak the OS process and temp profile.
   defp connect_browser(chrome, launch_opts, parent, proxy_auth) do
-    {host, port, _path} = Protocol.parse_ws_url(chrome.debug_url)
+    {_scheme, host, port, _path} = Protocol.parse_ws_url(chrome.debug_url)
 
     case Connection.start_link(chrome.debug_url) do
       {:ok, conn} ->

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -15,6 +15,11 @@ defmodule CDPEx.Browser do
   A browser started via `CDPEx.connect/2` (connect-mode, `chrome: nil`) is the
   exception: it never launched Chrome, so `terminate/2` only closes the pages it
   opened and never reaps the remote process — `:brutal_kill` is harmless there.
+  That target cleanup is **best-effort**: each `Target.closeTarget` is bounded by
+  the call timeout, and against a slow-but-alive remote with several open pages the
+  supervised shutdown budget can elapse before every tab is closed, leaving some
+  open on the remote Chrome (it never affects the local process, which holds no
+  Chrome to reap).
 
   Most callers use the `CDPEx` facade rather than this module directly.
   """

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -148,13 +148,22 @@ defmodule CDPEx.Browser do
     # (the {:EXIT, parent, _} clause) still targets the real owner (the pool) rather than
     # the already-dead task — otherwise a hard-killed pool would orphan the browser.
     {owner, launch_opts} = Keyword.pop(launch_opts, :owner)
-    {proxy, launch_opts} = Keyword.pop(launch_opts, :proxy)
+    {connect_ws, launch_opts} = Keyword.pop(launch_opts, :connect)
+    {conn_opts, launch_opts} = Keyword.pop(launch_opts, :conn_opts, [])
 
-    with {:ok, proxy_auth, launch_opts} <- apply_proxy(proxy, launch_opts),
-         {:ok, chrome} <- Chrome.launch(launch_opts) do
-      connect_browser(chrome, launch_opts, owner || parent_pid(), proxy_auth)
+    if connect_ws do
+      # Connect-mode: attach to an already-running Chrome. No Chrome.launch, and
+      # chrome: nil so terminate/2 never reaps a process we didn't start.
+      connect_browser(nil, connect_ws, launch_opts, owner || parent_pid(), nil, conn_opts)
     else
-      {:error, reason} -> {:stop, reason}
+      {proxy, launch_opts} = Keyword.pop(launch_opts, :proxy)
+
+      with {:ok, proxy_auth, launch_opts} <- apply_proxy(proxy, launch_opts),
+           {:ok, chrome} <- Chrome.launch(launch_opts) do
+        connect_browser(chrome, chrome.debug_url, launch_opts, owner || parent_pid(), proxy_auth, [])
+      else
+        {:error, reason} -> {:stop, reason}
+      end
     end
   end
 
@@ -183,13 +192,14 @@ defmodule CDPEx.Browser do
     end
   end
 
-  # Chrome is running now. If the browser WebSocket fails to connect, init/1
+  # Connect the browser WebSocket (the launched Chrome's debug URL, or a remote
+  # endpoint for connect-mode where `chrome` is nil). If the connect fails, init/1
   # returns {:stop, _} *before* the GenServer loop starts, so terminate/2 never
-  # runs — we must reap Chrome here or leak the OS process and temp profile.
-  defp connect_browser(chrome, launch_opts, parent, proxy_auth) do
-    {_scheme, host, port, _path} = Protocol.parse_ws_url(chrome.debug_url)
+  # runs — reap Chrome here (when we own it) or leak the OS process and temp profile.
+  defp connect_browser(chrome, ws_url, launch_opts, parent, proxy_auth, conn_opts) do
+    {_scheme, host, port, _path} = Protocol.parse_ws_url(ws_url)
 
-    case Connection.start_link(chrome.debug_url) do
+    case Connection.start_link(ws_url, conn_opts) do
       {:ok, conn} ->
         # Prune session entries when their target ends (tab closed/crashed, or our
         # own close_page) so long-lived browsers don't accumulate stale sessions —
@@ -214,12 +224,12 @@ defmodule CDPEx.Browser do
         catch
           :exit, reason ->
             safe_close(conn)
-            Chrome.stop(chrome)
+            if chrome, do: Chrome.stop(chrome)
             {:stop, reason}
         end
 
       {:error, reason} ->
-        Chrome.stop(chrome)
+        if chrome, do: Chrome.stop(chrome)
         {:stop, reason}
     end
   end
@@ -237,10 +247,22 @@ defmodule CDPEx.Browser do
 
   @impl true
   def handle_call({:new_page, opts}, _from, state) do
-    case Keyword.get(opts, :transport, :dedicated) do
-      :dedicated -> reply_dedicated_page(state, opts)
-      :session -> reply_session_page(state, opts)
-      other -> {:reply, {:error, {:invalid_transport, other}}, state}
+    # A connected browser (chrome: nil) defaults to :session and can't do
+    # :dedicated yet — a per-page socket would have to target the remote host.
+    default = if state.chrome, do: :dedicated, else: :session
+
+    case Keyword.get(opts, :transport, default) do
+      :dedicated when is_nil(state.chrome) ->
+        {:reply, {:error, {:unsupported_transport, :dedicated}}, state}
+
+      :dedicated ->
+        reply_dedicated_page(state, opts)
+
+      :session ->
+        reply_session_page(state, opts)
+
+      other ->
+        {:reply, {:error, {:invalid_transport, other}}, state}
     end
   end
 
@@ -555,6 +577,14 @@ defmodule CDPEx.Browser do
     # dying — its exit must not abort us before Chrome.stop/1, the no-orphan
     # guarantee). Closing browser_conn here makes teardown deterministic instead
     # of leaving it to stop reactively when its socket drops on Chrome exit.
+    if is_nil(state.chrome) and Process.alive?(state.browser_conn) do
+      # Connect-mode: we don't own Chrome, so closing the socket wouldn't reap the
+      # tabs we opened. Close just OUR targets (best-effort; close_target tolerates
+      # a dead conn), leaving Chrome and any pre-existing tabs untouched.
+      for {tid, _sid} <- state.sessions, do: close_target(state.browser_conn, tid)
+      for {tid, _conn} <- state.pages, do: close_target(state.browser_conn, tid)
+    end
+
     Enum.each(state.pages, fn {_tid, conn} -> safe_close(conn) end)
     safe_close(state.browser_conn)
     if state.chrome, do: Chrome.stop(state.chrome)
@@ -682,7 +712,7 @@ defmodule CDPEx.Browser do
   # page connection, if opened) — otherwise we leak a Chrome tab/socket that
   # isn't tracked in state.pages and can't be cleaned up deterministically.
   defp open_target(state, tid, opts) do
-    page_url = "ws://#{state.host}:#{state.port}/devtools/page/#{tid}"
+    page_url = "ws://#{bracket_host(state.host)}:#{state.port}/devtools/page/#{tid}"
 
     case Connection.start_link(page_url) do
       {:ok, conn} ->
@@ -806,6 +836,12 @@ defmodule CDPEx.Browser do
   defp close_target(browser_conn, tid) do
     _ = Connection.call(browser_conn, "Target.closeTarget", %{"targetId" => tid}, @create_timeout)
     :ok
+  end
+
+  # Bracket an IPv6 literal so the page WebSocket URL is well-formed
+  # (`ws://[::1]:9222/…` rather than the malformed `ws://::1:9222/…`).
+  defp bracket_host(host) do
+    if String.contains?(host, ":"), do: "[#{host}]", else: host
   end
 
   # Stop a page connection, tolerating an already-dead process. `Connection.close/1`

--- a/lib/cdp_ex/browser.ex
+++ b/lib/cdp_ex/browser.ex
@@ -40,6 +40,10 @@ defmodule CDPEx.Browser do
     :opts,
     :parent,
     :proxy_auth,
+    # connect-mode (attached to a Chrome we didn't launch): drives the :session
+    # default + the :dedicated rejection in new_page. Distinct from `chrome: nil`,
+    # which a launched browser never is in production but a unit fixture can be.
+    connected: false,
     pages: %{},
     sessions: %{},
     auths: %{},
@@ -160,7 +164,14 @@ defmodule CDPEx.Browser do
 
       with {:ok, proxy_auth, launch_opts} <- apply_proxy(proxy, launch_opts),
            {:ok, chrome} <- Chrome.launch(launch_opts) do
-        connect_browser(chrome, chrome.debug_url, launch_opts, owner || parent_pid(), proxy_auth, [])
+        connect_browser(
+          chrome,
+          chrome.debug_url,
+          launch_opts,
+          owner || parent_pid(),
+          proxy_auth,
+          []
+        )
       else
         {:error, reason} -> {:stop, reason}
       end
@@ -214,6 +225,7 @@ defmodule CDPEx.Browser do
           {:ok,
            %__MODULE__{
              chrome: chrome,
+             connected: is_nil(chrome),
              browser_conn: conn,
              host: host,
              port: port,
@@ -247,12 +259,12 @@ defmodule CDPEx.Browser do
 
   @impl true
   def handle_call({:new_page, opts}, _from, state) do
-    # A connected browser (chrome: nil) defaults to :session and can't do
-    # :dedicated yet — a per-page socket would have to target the remote host.
-    default = if state.chrome, do: :dedicated, else: :session
+    # A connected browser defaults to :session and can't do :dedicated yet —
+    # a per-page socket would have to target the remote host.
+    default = if state.connected, do: :session, else: :dedicated
 
     case Keyword.get(opts, :transport, default) do
-      :dedicated when is_nil(state.chrome) ->
+      :dedicated when state.connected ->
         {:reply, {:error, {:unsupported_transport, :dedicated}}, state}
 
       :dedicated ->
@@ -577,13 +589,14 @@ defmodule CDPEx.Browser do
     # dying — its exit must not abort us before Chrome.stop/1, the no-orphan
     # guarantee). Closing browser_conn here makes teardown deterministic instead
     # of leaving it to stop reactively when its socket drops on Chrome exit.
-    if is_nil(state.chrome) and Process.alive?(state.browser_conn) do
-      # Connect-mode: we don't own Chrome, so closing the socket wouldn't reap the
-      # tabs we opened. Close just OUR targets (best-effort; close_target tolerates
-      # a dead conn), leaving Chrome and any pre-existing tabs untouched.
-      for {tid, _sid} <- state.sessions, do: close_target(state.browser_conn, tid)
-      for {tid, _conn} <- state.pages, do: close_target(state.browser_conn, tid)
-    end
+    _ =
+      if state.connected and Process.alive?(state.browser_conn) do
+        # Connect-mode: we don't own Chrome, so closing the socket wouldn't reap the
+        # tabs we opened. Close just OUR targets (best-effort; close_target tolerates
+        # a dead conn), leaving Chrome and any pre-existing tabs untouched.
+        Enum.each(state.sessions, fn {tid, _sid} -> close_target(state.browser_conn, tid) end)
+        Enum.each(state.pages, fn {tid, _conn} -> close_target(state.browser_conn, tid) end)
+      end
 
     Enum.each(state.pages, fn {_tid, conn} -> safe_close(conn) end)
     safe_close(state.browser_conn)

--- a/lib/cdp_ex/connect.ex
+++ b/lib/cdp_ex/connect.ex
@@ -11,6 +11,7 @@ defmodule CDPEx.Connect do
   # the Mint.HTTP facade) also keeps the conn a single opaque type, sidestepping a
   # `call_with_opaque` dialyzer false positive on the facade's struct union (OTP 26).
   alias CDPEx.Connection
+  alias CDPEx.Protocol
   alias Mint.HTTP1
 
   # Overall ceiling for the whole /json/version exchange (not per-recv) and a hard cap
@@ -23,7 +24,7 @@ defmodule CDPEx.Connect do
           {:ok, String.t()} | {:error, {:connect_discovery_failed, term()}}
   def resolve(endpoint, tls_opts \\ []) when is_binary(endpoint) do
     case URI.parse(endpoint) do
-      %URI{scheme: s} when s in ["ws", "wss"] ->
+      %URI{scheme: s, host: host} when s in ["ws", "wss"] and is_binary(host) and host != "" ->
         {:ok, endpoint}
 
       %URI{scheme: s, host: host, port: port} when s in ["http", "https"] and is_binary(host) ->
@@ -44,7 +45,8 @@ defmodule CDPEx.Connect do
          :ok <- check_status(status),
          {:ok, %{"webSocketDebuggerUrl" => url}} when is_binary(url) <- Jason.decode(body),
          %URI{path: path} = uri when is_binary(path) <- URI.parse(url) do
-      {:ok, "#{ws_scheme}://#{host}:#{port}#{path}#{query_suffix(uri.query)}"}
+      {:ok,
+       "#{ws_scheme}://#{Protocol.bracket_host(host)}:#{port}#{path}#{query_suffix(uri.query)}"}
     else
       {:error, reason} -> {:error, {:connect_discovery_failed, reason}}
       other -> {:error, {:connect_discovery_failed, other}}
@@ -56,9 +58,13 @@ defmodule CDPEx.Connect do
   # would fail discovery even when the caller explicitly opted out of verification.
   # Mint adds SNI + hostname verification itself when verify == :verify_peer.
   defp connect_opts(:https, tls_opts),
-    do: [mode: :passive, transport_opts: Connection.tls_opts(tls_opts)]
+    do: [
+      mode: :passive,
+      transport_opts: [{:timeout, @discovery_timeout} | Connection.tls_opts(tls_opts)]
+    ]
 
-  defp connect_opts(_http, _tls_opts), do: [mode: :passive]
+  defp connect_opts(_http, _tls_opts),
+    do: [mode: :passive, transport_opts: [timeout: @discovery_timeout]]
 
   # Issue the GET; on a request failure (after a successful connect) close the conn so
   # the socket isn't leaked. The happy path closes it in recv_body, and a failed

--- a/lib/cdp_ex/connect.ex
+++ b/lib/cdp_ex/connect.ex
@@ -1,0 +1,60 @@
+defmodule CDPEx.Connect do
+  @moduledoc false
+  # Resolves a `CDPEx.connect/2` endpoint to a `ws://` or `wss://` browser URL. A
+  # `ws(s)://` URL is used as-is; an `http(s)://` URL is discovered via
+  # `GET /json/version`. The final URL's host/port come from the *endpoint*, not
+  # the returned `webSocketDebuggerUrl`: Chrome echoes the request `Host` into that
+  # field and can report `127.0.0.1`/localhost for a remote endpoint.
+
+  alias Mint.HTTP
+
+  @discovery_timeout 5_000
+
+  @spec resolve(String.t()) :: {:ok, String.t()} | {:error, {:connect_discovery_failed, term()}}
+  def resolve(endpoint) when is_binary(endpoint) do
+    case URI.parse(endpoint) do
+      %URI{scheme: s} when s in ["ws", "wss"] ->
+        {:ok, endpoint}
+
+      %URI{scheme: s, host: host, port: port} when s in ["http", "https"] and is_binary(host) ->
+        discover(s, host, port)
+
+      _ ->
+        {:error, {:connect_discovery_failed, {:invalid_endpoint, endpoint}}}
+    end
+  end
+
+  defp discover(scheme, host, port) do
+    transport = if scheme == "https", do: :https, else: :http
+    ws_scheme = if scheme == "https", do: "wss", else: "ws"
+
+    with {:ok, conn} <- HTTP.connect(transport, host, port, mode: :passive),
+         {:ok, conn, ref} <- HTTP.request(conn, "GET", "/json/version", [], nil),
+         {:ok, body} <- recv_body(conn, ref, []),
+         {:ok, %{"webSocketDebuggerUrl" => discovered}} <- Jason.decode(body),
+         %URI{path: path} when is_binary(path) <- URI.parse(discovered) do
+      {:ok, "#{ws_scheme}://#{host}:#{port}#{path}"}
+    else
+      {:error, reason} -> {:error, {:connect_discovery_failed, reason}}
+      {:error, _conn, reason} -> {:error, {:connect_discovery_failed, reason}}
+      other -> {:error, {:connect_discovery_failed, other}}
+    end
+  end
+
+  defp recv_body(conn, ref, acc) do
+    case HTTP.recv(conn, 0, @discovery_timeout) do
+      {:ok, conn, responses} ->
+        acc = acc ++ for({:data, ^ref, chunk} <- responses, do: chunk)
+
+        if Enum.any?(responses, &match?({:done, ^ref}, &1)) do
+          HTTP.close(conn)
+          {:ok, IO.iodata_to_binary(acc)}
+        else
+          recv_body(conn, ref, acc)
+        end
+
+      {:error, _conn, reason, _responses} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/cdp_ex/connect.ex
+++ b/lib/cdp_ex/connect.ex
@@ -6,7 +6,10 @@ defmodule CDPEx.Connect do
   # the returned `webSocketDebuggerUrl`: Chrome echoes the request `Host` into that
   # field and can report `127.0.0.1`/localhost for a remote endpoint.
 
-  alias Mint.HTTP
+  # Chrome's /json/version endpoint is HTTP/1.1-only; using Mint.HTTP1 directly (vs
+  # the Mint.HTTP facade) also keeps the conn a single opaque type, sidestepping a
+  # `call_with_opaque` dialyzer false positive on the facade's struct union (OTP 26).
+  alias Mint.HTTP1
 
   @discovery_timeout 5_000
 
@@ -28,8 +31,8 @@ defmodule CDPEx.Connect do
     transport = if scheme == "https", do: :https, else: :http
     ws_scheme = if scheme == "https", do: "wss", else: "ws"
 
-    with {:ok, conn} <- HTTP.connect(transport, host, port, mode: :passive),
-         {:ok, conn, ref} <- HTTP.request(conn, "GET", "/json/version", [], nil),
+    with {:ok, conn} <- HTTP1.connect(transport, host, port, mode: :passive),
+         {:ok, conn, ref} <- HTTP1.request(conn, "GET", "/json/version", [], nil),
          {:ok, body} <- recv_body(conn, ref, []),
          {:ok, %{"webSocketDebuggerUrl" => discovered}} <- Jason.decode(body),
          %URI{path: path} when is_binary(path) <- URI.parse(discovered) do
@@ -42,12 +45,12 @@ defmodule CDPEx.Connect do
   end
 
   defp recv_body(conn, ref, acc) do
-    case HTTP.recv(conn, 0, @discovery_timeout) do
+    case HTTP1.recv(conn, 0, @discovery_timeout) do
       {:ok, conn, responses} ->
         acc = acc ++ for({:data, ^ref, chunk} <- responses, do: chunk)
 
         if Enum.any?(responses, &match?({:done, ^ref}, &1)) do
-          _ = HTTP.close(conn)
+          _ = HTTP1.close(conn)
           {:ok, IO.iodata_to_binary(acc)}
         else
           recv_body(conn, ref, acc)

--- a/lib/cdp_ex/connect.ex
+++ b/lib/cdp_ex/connect.ex
@@ -47,7 +47,7 @@ defmodule CDPEx.Connect do
         acc = acc ++ for({:data, ^ref, chunk} <- responses, do: chunk)
 
         if Enum.any?(responses, &match?({:done, ^ref}, &1)) do
-          HTTP.close(conn)
+          _ = HTTP.close(conn)
           {:ok, IO.iodata_to_binary(acc)}
         else
           recv_body(conn, ref, acc)

--- a/lib/cdp_ex/connect.ex
+++ b/lib/cdp_ex/connect.ex
@@ -4,60 +4,120 @@ defmodule CDPEx.Connect do
   # `ws(s)://` URL is used as-is; an `http(s)://` URL is discovered via
   # `GET /json/version`. The final URL's host/port come from the *endpoint*, not
   # the returned `webSocketDebuggerUrl`: Chrome echoes the request `Host` into that
-  # field and can report `127.0.0.1`/localhost for a remote endpoint.
+  # field and can report `127.0.0.1`/localhost for a remote endpoint. The discovered
+  # path AND query are kept (cloud browser providers carry an auth token in the query).
 
   # Chrome's /json/version endpoint is HTTP/1.1-only; using Mint.HTTP1 directly (vs
   # the Mint.HTTP facade) also keeps the conn a single opaque type, sidestepping a
   # `call_with_opaque` dialyzer false positive on the facade's struct union (OTP 26).
+  alias CDPEx.Connection
   alias Mint.HTTP1
 
+  # Overall ceiling for the whole /json/version exchange (not per-recv) and a hard cap
+  # on the body, so a slow/dripping or flooding endpoint can't hang the caller or
+  # exhaust memory. Chrome's real response is well under 1 KB.
   @discovery_timeout 5_000
+  @max_body_bytes 1_048_576
 
-  @spec resolve(String.t()) :: {:ok, String.t()} | {:error, {:connect_discovery_failed, term()}}
-  def resolve(endpoint) when is_binary(endpoint) do
+  @spec resolve(String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, {:connect_discovery_failed, term()}}
+  def resolve(endpoint, tls_opts \\ []) when is_binary(endpoint) do
     case URI.parse(endpoint) do
       %URI{scheme: s} when s in ["ws", "wss"] ->
         {:ok, endpoint}
 
       %URI{scheme: s, host: host, port: port} when s in ["http", "https"] and is_binary(host) ->
-        discover(s, host, port)
+        discover(s, host, port, tls_opts)
 
       _ ->
         {:error, {:connect_discovery_failed, {:invalid_endpoint, endpoint}}}
     end
   end
 
-  defp discover(scheme, host, port) do
-    transport = if scheme == "https", do: :https, else: :http
-    ws_scheme = if scheme == "https", do: "wss", else: "ws"
+  defp discover(scheme, host, port, tls_opts) do
+    {transport, ws_scheme} = if scheme == "https", do: {:https, "wss"}, else: {:http, "ws"}
+    deadline = System.monotonic_time(:millisecond) + @discovery_timeout
 
-    with {:ok, conn} <- HTTP1.connect(transport, host, port, mode: :passive),
-         {:ok, conn, ref} <- HTTP1.request(conn, "GET", "/json/version", [], nil),
-         {:ok, body} <- recv_body(conn, ref, []),
-         {:ok, %{"webSocketDebuggerUrl" => discovered}} <- Jason.decode(body),
-         %URI{path: path} when is_binary(path) <- URI.parse(discovered) do
-      {:ok, "#{ws_scheme}://#{host}:#{port}#{path}"}
+    with {:ok, conn} <- HTTP1.connect(transport, host, port, connect_opts(transport, tls_opts)),
+         {:ok, conn, ref} <- request(conn),
+         {:ok, status, body} <- recv_body(conn, ref, deadline),
+         :ok <- check_status(status),
+         {:ok, %{"webSocketDebuggerUrl" => url}} when is_binary(url) <- Jason.decode(body),
+         %URI{path: path} = uri when is_binary(path) <- URI.parse(url) do
+      {:ok, "#{ws_scheme}://#{host}:#{port}#{path}#{query_suffix(uri.query)}"}
     else
       {:error, reason} -> {:error, {:connect_discovery_failed, reason}}
-      {:error, _conn, reason} -> {:error, {:connect_discovery_failed, reason}}
       other -> {:error, {:connect_discovery_failed, other}}
     end
   end
 
-  defp recv_body(conn, ref, acc) do
-    case HTTP1.recv(conn, 0, @discovery_timeout) do
-      {:ok, conn, responses} ->
-        acc = acc ++ for({:data, ^ref, chunk} <- responses, do: chunk)
+  # https discovery honors the same TLS opts (:insecure / :cacertfile / :cacerts) the
+  # caller passed to connect/2 — without this, a private-CA /json/version endpoint
+  # would fail discovery even when the caller explicitly opted out of verification.
+  # Mint adds SNI + hostname verification itself when verify == :verify_peer.
+  defp connect_opts(:https, tls_opts),
+    do: [mode: :passive, transport_opts: Connection.tls_opts(tls_opts)]
 
-        if Enum.any?(responses, &match?({:done, ^ref}, &1)) do
-          _ = HTTP1.close(conn)
-          {:ok, IO.iodata_to_binary(acc)}
-        else
-          recv_body(conn, ref, acc)
-        end
+  defp connect_opts(_http, _tls_opts), do: [mode: :passive]
 
-      {:error, _conn, reason, _responses} ->
+  # Issue the GET; on a request failure (after a successful connect) close the conn so
+  # the socket isn't leaked. The happy path closes it in recv_body, and a failed
+  # connect above never produced a conn.
+  defp request(conn) do
+    case HTTP1.request(conn, "GET", "/json/version", [], nil) do
+      {:ok, conn, ref} ->
+        {:ok, conn, ref}
+
+      {:error, conn, reason} ->
+        _ = HTTP1.close(conn)
         {:error, reason}
     end
   end
+
+  defp check_status(status) when status in 200..299, do: :ok
+  defp check_status(status), do: {:error, {:http_status, status}}
+
+  # Drain the response under one absolute deadline (re-checked before each recv, so a
+  # dripping endpoint can't extend it) with a body cap. Closes the conn on every exit.
+  defp recv_body(conn, ref, deadline, status \\ nil, acc \\ []) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      _ = HTTP1.close(conn)
+      {:error, :discovery_timeout}
+    else
+      drain(conn, ref, deadline, status, acc, remaining)
+    end
+  end
+
+  defp drain(conn, ref, deadline, status, acc, remaining) do
+    case HTTP1.recv(conn, 0, remaining) do
+      {:ok, conn, responses} ->
+        status = Enum.reduce(responses, status, &status_of(&1, ref, &2))
+        acc = [acc | for({:data, ^ref, chunk} <- responses, do: chunk)]
+
+        cond do
+          IO.iodata_length(acc) > @max_body_bytes ->
+            _ = HTTP1.close(conn)
+            {:error, :discovery_body_too_large}
+
+          Enum.any?(responses, &match?({:done, ^ref}, &1)) ->
+            _ = HTTP1.close(conn)
+            {:ok, status, IO.iodata_to_binary(acc)}
+
+          true ->
+            recv_body(conn, ref, deadline, status, acc)
+        end
+
+      {:error, conn, reason, _responses} ->
+        _ = HTTP1.close(conn)
+        {:error, reason}
+    end
+  end
+
+  defp status_of({:status, ref, code}, ref, _acc), do: code
+  defp status_of(_other, _ref, acc), do: acc
+
+  defp query_suffix(nil), do: ""
+  defp query_suffix(query), do: "?" <> query
 end

--- a/lib/cdp_ex/connect.ex
+++ b/lib/cdp_ex/connect.ex
@@ -20,26 +20,27 @@ defmodule CDPEx.Connect do
   @discovery_timeout 5_000
   @max_body_bytes 1_048_576
 
-  @spec resolve(String.t(), keyword()) ::
+  @spec resolve(String.t(), keyword(), keyword()) ::
           {:ok, String.t()} | {:error, {:connect_discovery_failed, term()}}
-  def resolve(endpoint, tls_opts \\ []) when is_binary(endpoint) do
+  def resolve(endpoint, tls_opts \\ [], opts \\ []) when is_binary(endpoint) do
     case URI.parse(endpoint) do
       %URI{scheme: s, host: host} when s in ["ws", "wss"] and is_binary(host) and host != "" ->
         {:ok, endpoint}
 
       %URI{scheme: s, host: host, port: port} when s in ["http", "https"] and is_binary(host) ->
-        discover(s, host, port, tls_opts)
+        discover(s, host, port, tls_opts, Keyword.get(opts, :timeout, @discovery_timeout))
 
       _ ->
         {:error, {:connect_discovery_failed, {:invalid_endpoint, endpoint}}}
     end
   end
 
-  defp discover(scheme, host, port, tls_opts) do
+  defp discover(scheme, host, port, tls_opts, timeout) do
     {transport, ws_scheme} = if scheme == "https", do: {:https, "wss"}, else: {:http, "ws"}
-    deadline = System.monotonic_time(:millisecond) + @discovery_timeout
+    deadline = System.monotonic_time(:millisecond) + timeout
 
-    with {:ok, conn} <- HTTP1.connect(transport, host, port, connect_opts(transport, tls_opts)),
+    with {:ok, conn} <-
+           HTTP1.connect(transport, host, port, connect_opts(transport, host, tls_opts, timeout)),
          {:ok, conn, ref} <- request(conn),
          {:ok, status, body} <- recv_body(conn, ref, deadline),
          :ok <- check_status(status),
@@ -48,23 +49,37 @@ defmodule CDPEx.Connect do
       {:ok,
        "#{ws_scheme}://#{Protocol.bracket_host(host)}:#{port}#{path}#{query_suffix(uri.query)}"}
     else
-      {:error, reason} -> {:error, {:connect_discovery_failed, reason}}
-      other -> {:error, {:connect_discovery_failed, other}}
+      # Normalize every timeout layer (TCP connect, recv, or the absolute deadline)
+      # to one reason, so callers see a single :discovery_timeout regardless of which
+      # bound tripped first.
+      {:error, %Mint.TransportError{reason: :timeout}} ->
+        {:error, {:connect_discovery_failed, :discovery_timeout}}
+
+      {:error, reason} ->
+        {:error, {:connect_discovery_failed, reason}}
+
+      other ->
+        {:error, {:connect_discovery_failed, other}}
     end
   end
 
   # https discovery honors the same TLS opts (:insecure / :cacertfile / :cacerts) the
   # caller passed to connect/2 — without this, a private-CA /json/version endpoint
   # would fail discovery even when the caller explicitly opted out of verification.
-  # Mint adds SNI + hostname verification itself when verify == :verify_peer.
-  defp connect_opts(:https, tls_opts),
+  # Mint adds hostname verification itself when verify == :verify_peer; SNI is set to
+  # the host (disabled for an IP literal, per Protocol.sni/1). The TCP connect is
+  # bounded by `timeout` too, so a black-hole host can't stall past the deadline.
+  defp connect_opts(:https, host, tls_opts, timeout),
     do: [
       mode: :passive,
-      transport_opts: [{:timeout, @discovery_timeout} | Connection.tls_opts(tls_opts)]
+      transport_opts: [
+        {:timeout, timeout},
+        {:server_name_indication, Protocol.sni(host)} | Connection.tls_opts(tls_opts)
+      ]
     ]
 
-  defp connect_opts(_http, _tls_opts),
-    do: [mode: :passive, transport_opts: [timeout: @discovery_timeout]]
+  defp connect_opts(_http, _host, _tls_opts, timeout),
+    do: [mode: :passive, transport_opts: [timeout: timeout]]
 
   # Issue the GET; on a request failure (after a successful connect) close the conn so
   # the socket isn't leaked. The happy path closes it in recv_body, and a failed

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -167,13 +167,14 @@ defmodule CDPEx.Connection do
 
   @impl true
   def init({ws_url, opts}) do
-    {_scheme, host, port, path} = Protocol.parse_ws_url(ws_url)
+    {scheme, host, port, path} = Protocol.parse_ws_url(ws_url)
     upgrade_timeout = Keyword.get(opts, :upgrade_timeout, @upgrade_timeout)
+    {transport, ws_scheme, conn_opts} = transport_for(scheme, host, opts)
 
     # The handshake runs synchronously in init so its frames can't interleave
     # with post-upgrade CDP frames.
-    with {:ok, conn} <- HTTP.connect(:http, host, port, protocols: [:http1]),
-         {:ok, conn, ref} <- WebSocket.upgrade(:ws, conn, path, []),
+    with {:ok, conn} <- HTTP.connect(transport, host, port, conn_opts),
+         {:ok, conn, ref} <- WebSocket.upgrade(ws_scheme, conn, path, []),
          {:ok, conn, status, headers} <- recv_upgrade(conn, ref, upgrade_timeout),
          {:ok, conn, websocket} <- WebSocket.new(conn, ref, status, headers) do
       # Trap exits only AFTER the handshake. During the upgrade, recv_upgrade's
@@ -187,6 +188,33 @@ defmodule CDPEx.Connection do
     else
       {:error, reason} -> {:stop, {:ws_connect, reason}}
       {:error, _conn, reason} -> {:stop, {:ws_upgrade, reason}}
+    end
+  end
+
+  # `wss://` (a remote/TLS DevTools endpoint, see CDPEx.connect/2) connects over
+  # `:https`; everything else is plaintext `:http` to a local Chrome.
+  defp transport_for("wss", host, opts) do
+    tls = [{:server_name_indication, String.to_charlist(host)} | tls_opts(opts)]
+    {:https, :wss, [protocols: [:http1], transport_opts: tls]}
+  end
+
+  defp transport_for(_ws, _host, _opts), do: {:http, :ws, [protocols: [:http1]]}
+
+  @doc false
+  @spec tls_opts(keyword()) :: keyword()
+  def tls_opts(opts) do
+    cond do
+      Keyword.get(opts, :insecure, false) ->
+        [verify: :verify_none]
+
+      file = Keyword.get(opts, :cacertfile) ->
+        [verify: :verify_peer, cacertfile: file, depth: 99]
+
+      certs = Keyword.get(opts, :cacerts) ->
+        [verify: :verify_peer, cacerts: certs, depth: 99]
+
+      true ->
+        [verify: :verify_peer, cacerts: :public_key.cacerts_get(), depth: 99]
     end
   end
 

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -194,7 +194,7 @@ defmodule CDPEx.Connection do
   # `wss://` (a remote/TLS DevTools endpoint, see CDPEx.connect/2) connects over
   # `:https`; everything else is plaintext `:http` to a local Chrome.
   defp transport_for("wss", host, opts) do
-    tls = [{:server_name_indication, String.to_charlist(host)} | tls_opts(opts)]
+    tls = [{:server_name_indication, Protocol.sni(host)} | tls_opts(opts)]
     {:https, :wss, [protocols: [:http1], transport_opts: tls]}
   end
 

--- a/lib/cdp_ex/connection.ex
+++ b/lib/cdp_ex/connection.ex
@@ -167,7 +167,7 @@ defmodule CDPEx.Connection do
 
   @impl true
   def init({ws_url, opts}) do
-    {host, port, path} = Protocol.parse_ws_url(ws_url)
+    {_scheme, host, port, path} = Protocol.parse_ws_url(ws_url)
     upgrade_timeout = Keyword.get(opts, :upgrade_timeout, @upgrade_timeout)
 
     # The handshake runs synchronously in init so its frames can't interleave

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -239,6 +239,19 @@ defmodule CDPEx.Protocol do
   end
 
   @doc """
+  The `:server_name_indication` value for a TLS connection to `host`: the host as a
+  charlist for a DNS name, or `:disable` for an IP literal (RFC 6066 forbids an IP
+  address as an SNI server name, and some TLS peers reject it).
+  """
+  @spec sni(String.t()) :: charlist() | :disable
+  def sni(host) do
+    case :inet.parse_address(String.to_charlist(host)) do
+      {:ok, _ip} -> :disable
+      {:error, _} -> String.to_charlist(host)
+    end
+  end
+
+  @doc """
   JavaScript that neutralises `alert`/`confirm`/`prompt` so modal dialogs can't
   block automation. Injected via `Page.addScriptToEvaluateOnNewDocument`.
   """

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -192,11 +192,15 @@ defmodule CDPEx.Protocol do
   def evaluate_result(other), do: {:error, {:unexpected_evaluate, other}}
 
   @doc """
-  Splits a Chrome DevTools `ws://` or `wss://` URL into `{scheme, host, port, path}`.
+  Splits a Chrome DevTools `ws://` or `wss://` URL into `{scheme, host, port, target}`.
 
   Uses `URI.parse/1`, so IPv6 hosts, explicit ports, and paths are handled
   correctly; a non-`ws(s)://` URL or one missing a host/port raises `ArgumentError`.
   `wss://` denotes a remote/TLS DevTools endpoint (see `CDPEx.connect/2`).
+
+  The fourth element is the WebSocket-upgrade **request target** — the path *plus
+  any `?query`* — so a token-bearing cloud endpoint
+  (`wss://host/cdp?token=…`) reaches the provider with its query intact.
 
   ## Examples
 
@@ -205,18 +209,33 @@ defmodule CDPEx.Protocol do
 
       iex> CDPEx.Protocol.parse_ws_url("wss://[::1]:9222/devtools/browser/abc")
       {"wss", "::1", 9222, "/devtools/browser/abc"}
+
+      iex> CDPEx.Protocol.parse_ws_url("wss://chrome.example.com/cdp?token=abc")
+      {"wss", "chrome.example.com", 443, "/cdp?token=abc"}
   """
   @spec parse_ws_url(String.t()) :: {String.t(), String.t(), pos_integer(), String.t()}
   def parse_ws_url(ws_url) when is_binary(ws_url) do
     case URI.parse(ws_url) do
-      %URI{scheme: scheme, host: host, port: port, path: path}
+      %URI{scheme: scheme, host: host, port: port, path: path, query: query}
       when scheme in ["ws", "wss"] and is_binary(host) and host != "" and is_integer(port) ->
-        {scheme, host, port, path || "/"}
+        {scheme, host, port, request_target(path, query)}
 
       _ ->
         raise ArgumentError,
               "expected a ws:// or wss:// URL with a host and port, got: #{inspect(ws_url)}"
     end
+  end
+
+  defp request_target(path, nil), do: path || "/"
+  defp request_target(path, query), do: "#{path || "/"}?#{query}"
+
+  @doc """
+  Brackets an IPv6 host literal so it can be interpolated into a URL
+  (`::1` -> `[::1]`); other hosts pass through unchanged.
+  """
+  @spec bracket_host(String.t()) :: String.t()
+  def bracket_host(host) do
+    if String.contains?(host, ":"), do: "[#{host}]", else: host
   end
 
   @doc """

--- a/lib/cdp_ex/protocol.ex
+++ b/lib/cdp_ex/protocol.ex
@@ -192,35 +192,30 @@ defmodule CDPEx.Protocol do
   def evaluate_result(other), do: {:error, {:unexpected_evaluate, other}}
 
   @doc """
-  Splits a Chrome DevTools `ws://` URL into `{host, port, path}`.
+  Splits a Chrome DevTools `ws://` or `wss://` URL into `{scheme, host, port, path}`.
 
   Uses `URI.parse/1`, so IPv6 hosts, explicit ports, and paths are handled
-  correctly; a non-`ws://` URL or one missing a host/port raises `ArgumentError`.
-
-  Only `ws://` is accepted: CDPEx launches a local Chrome and talks plaintext to
-  its `DevToolsActivePort` (no TLS). `wss://` — a remote/TLS DevTools endpoint —
-  has no entry point yet (tracked in
-  [#73](https://github.com/patrols/cdp_ex/issues/73)).
+  correctly; a non-`ws(s)://` URL or one missing a host/port raises `ArgumentError`.
+  `wss://` denotes a remote/TLS DevTools endpoint (see `CDPEx.connect/2`).
 
   ## Examples
 
       iex> CDPEx.Protocol.parse_ws_url("ws://127.0.0.1:9222/devtools/browser/abc-123")
-      {"127.0.0.1", 9222, "/devtools/browser/abc-123"}
+      {"ws", "127.0.0.1", 9222, "/devtools/browser/abc-123"}
 
-      iex> CDPEx.Protocol.parse_ws_url("ws://[::1]:9222/devtools/browser/abc")
-      {"::1", 9222, "/devtools/browser/abc"}
+      iex> CDPEx.Protocol.parse_ws_url("wss://[::1]:9222/devtools/browser/abc")
+      {"wss", "::1", 9222, "/devtools/browser/abc"}
   """
-  @spec parse_ws_url(String.t()) :: {String.t(), pos_integer(), String.t()}
+  @spec parse_ws_url(String.t()) :: {String.t(), String.t(), pos_integer(), String.t()}
   def parse_ws_url(ws_url) when is_binary(ws_url) do
     case URI.parse(ws_url) do
-      %URI{scheme: "ws", host: host, port: port, path: path}
-      when is_binary(host) and host != "" and is_integer(port) ->
-        {host, port, path || "/"}
+      %URI{scheme: scheme, host: host, port: port, path: path}
+      when scheme in ["ws", "wss"] and is_binary(host) and host != "" and is_integer(port) ->
+        {scheme, host, port, path || "/"}
 
       _ ->
         raise ArgumentError,
-              "expected a ws:// URL with a host and port (wss:// / remote endpoints " <>
-                "are not supported yet), got: #{inspect(ws_url)}"
+              "expected a ws:// or wss:// URL with a host and port, got: #{inspect(ws_url)}"
     end
   end
 

--- a/lib/cdp_ex/telemetry.ex
+++ b/lib/cdp_ex/telemetry.ex
@@ -22,6 +22,12 @@ defmodule CDPEx.Telemetry do
   failed. A failed launch still completes through `:stop` (the browser never started);
   only a raised exception emits `:exception`.
 
+  ### `[:cdp_ex, :connect, :start | :stop | :exception]`
+
+  A span around `CDPEx.connect/2` — endpoint discovery plus the WebSocket connect.
+  Same `:stop` metadata shape as `:launch` (`%{}` on success, `%{error: reason}` on
+  failure).
+
   ### `[:cdp_ex, :navigate, :start | :stop | :exception]`
 
   A span around `CDPEx.Page.navigate/3`.
@@ -83,12 +89,12 @@ defmodule CDPEx.Telemetry do
   @moduledoc since: "0.4.0"
 
   @typedoc "The CDPEx operations wrapped in a `:telemetry` span."
-  @type span_name :: :launch | :navigate
+  @type span_name :: :launch | :connect | :navigate
 
   @doc false
   @spec span(span_name(), :telemetry.event_metadata(), (-> {result, map()})) :: result
         when result: var
-  def span(name, start_metadata, fun) when name in [:launch, :navigate] do
+  def span(name, start_metadata, fun) when name in [:launch, :connect, :navigate] do
     :telemetry.span([:cdp_ex, name], start_metadata, fun)
   end
 

--- a/test/cdp_ex/browser_test.exs
+++ b/test/cdp_ex/browser_test.exs
@@ -28,6 +28,19 @@ defmodule CDPEx.BrowserTest do
       assert {:reply, {:error, {:unsupported_transport, :session}}, ^state} =
                Browser.handle_call({:new_page, [transport: :session]}, {self(), make_ref()}, state)
     end
+
+    test "a :dedicated page is rejected on a connected (chrome-less) browser" do
+      # Connect-mode can't open a dedicated page yet (its socket would have to target
+      # the remote host); the rejection keys on `connected`, before any I/O.
+      state = %Browser{connected: true}
+
+      assert {:reply, {:error, {:unsupported_transport, :dedicated}}, ^state} =
+               Browser.handle_call(
+                 {:new_page, [transport: :dedicated]},
+                 {self(), make_ref()},
+                 state
+               )
+    end
   end
 
   describe "launch/1 :proxy validation" do
@@ -46,6 +59,18 @@ defmodule CDPEx.BrowserTest do
 
       assert {:error, {:invalid_proxy, :args_override}} =
                Browser.start_link(proxy: "http://host:8080", args: ["--headless=new"])
+    end
+
+    test "combining :proxy with :connect is rejected without launching Chrome" do
+      # --proxy-server is a launch flag; connect-mode launches no Chrome, so it could
+      # never take effect. init/1 rejects the combination before any connect attempt.
+      Process.flag(:trap_exit, true)
+
+      assert {:error, {:unsupported_with_connect, :proxy}} =
+               Browser.start_link(
+                 connect: "ws://127.0.0.1:1/devtools/browser/x",
+                 proxy: "http://u:p@host:8080"
+               )
     end
   end
 

--- a/test/cdp_ex/connect_test.exs
+++ b/test/cdp_ex/connect_test.exs
@@ -23,6 +23,36 @@ defmodule CDPEx.ConnectTest do
     assert ws == "ws://#{host}:#{port}/devtools/browser/FAKE-GUID"
   end
 
+  test "discovery preserves the query string from webSocketDebuggerUrl" do
+    {:ok, %{url: base}} = FixtureServer.start(json_version: :with_query)
+    %URI{host: host, port: port} = URI.parse(base)
+
+    assert {:ok, ws} = Connect.resolve("http://#{host}:#{port}")
+    assert ws == "ws://#{host}:#{port}/devtools/browser/GUID?token=abc"
+  end
+
+  test "a non-200 /json/version is a discovery failure carrying the status" do
+    {:ok, %{url: base}} = FixtureServer.start(json_version: :server_error)
+    %URI{host: host, port: port} = URI.parse(base)
+
+    assert {:error, {:connect_discovery_failed, {:http_status, 500}}} =
+             Connect.resolve("http://#{host}:#{port}")
+  end
+
+  test "a /json/version without webSocketDebuggerUrl is a discovery failure" do
+    {:ok, %{url: base}} = FixtureServer.start(json_version: :no_key)
+    %URI{host: host, port: port} = URI.parse(base)
+
+    assert {:error, {:connect_discovery_failed, _}} = Connect.resolve("http://#{host}:#{port}")
+  end
+
+  test "a non-string webSocketDebuggerUrl is a discovery failure, not a caller crash" do
+    {:ok, %{url: base}} = FixtureServer.start(json_version: :non_string)
+    %URI{host: host, port: port} = URI.parse(base)
+
+    assert {:error, {:connect_discovery_failed, _}} = Connect.resolve("http://#{host}:#{port}")
+  end
+
   test "an unreachable endpoint is a discovery failure" do
     assert {:error, {:connect_discovery_failed, _}} = Connect.resolve("http://127.0.0.1:1")
   end

--- a/test/cdp_ex/connect_test.exs
+++ b/test/cdp_ex/connect_test.exs
@@ -53,6 +53,22 @@ defmodule CDPEx.ConnectTest do
     assert {:error, {:connect_discovery_failed, _}} = Connect.resolve("http://#{host}:#{port}")
   end
 
+  test "an oversized /json/version body is rejected by the size cap" do
+    {:ok, %{url: base}} = FixtureServer.start(json_version: :oversized)
+    %URI{host: host, port: port} = URI.parse(base)
+
+    assert {:error, {:connect_discovery_failed, :discovery_body_too_large}} =
+             Connect.resolve("http://#{host}:#{port}")
+  end
+
+  test "a hanging /json/version trips the discovery timeout" do
+    {:ok, %{url: base}} = FixtureServer.start(json_version: :hang)
+    %URI{host: host, port: port} = URI.parse(base)
+
+    assert {:error, {:connect_discovery_failed, :discovery_timeout}} =
+             Connect.resolve("http://#{host}:#{port}", [], timeout: 50)
+  end
+
   test "an unreachable endpoint is a discovery failure" do
     assert {:error, {:connect_discovery_failed, _}} = Connect.resolve("http://127.0.0.1:1")
   end

--- a/test/cdp_ex/connect_test.exs
+++ b/test/cdp_ex/connect_test.exs
@@ -61,4 +61,9 @@ defmodule CDPEx.ConnectTest do
     assert {:error, {:connect_discovery_failed, {:invalid_endpoint, _}}} =
              Connect.resolve("ftp://nope")
   end
+
+  test "a host-less ws:// endpoint is a structured failure, not a later ArgumentError" do
+    assert {:error, {:connect_discovery_failed, {:invalid_endpoint, _}}} =
+             Connect.resolve("ws:///devtools/browser/x")
+  end
 end

--- a/test/cdp_ex/connect_test.exs
+++ b/test/cdp_ex/connect_test.exs
@@ -1,0 +1,34 @@
+defmodule CDPEx.ConnectTest do
+  use ExUnit.Case, async: true
+
+  alias CDPEx.Connect
+  alias CDPEx.FixtureServer
+
+  test "passes a ws:// endpoint through unchanged" do
+    assert {:ok, "ws://host:9222/devtools/browser/x"} =
+             Connect.resolve("ws://host:9222/devtools/browser/x")
+  end
+
+  test "passes a wss:// endpoint through unchanged" do
+    assert {:ok, "wss://host/devtools/browser/x"} = Connect.resolve("wss://host/devtools/browser/x")
+  end
+
+  test "discovers via /json/version and derives host/port from the endpoint" do
+    {:ok, %{url: base}} = FixtureServer.start()
+    %URI{host: host, port: port} = URI.parse(base)
+
+    # The fixture returns ws://127.0.0.1:1/...; the resolver must rewrite host/port
+    # to the endpoint's, keeping only the discovered path.
+    assert {:ok, ws} = Connect.resolve("http://#{host}:#{port}")
+    assert ws == "ws://#{host}:#{port}/devtools/browser/FAKE-GUID"
+  end
+
+  test "an unreachable endpoint is a discovery failure" do
+    assert {:error, {:connect_discovery_failed, _}} = Connect.resolve("http://127.0.0.1:1")
+  end
+
+  test "a non-ws/http endpoint is a discovery failure" do
+    assert {:error, {:connect_discovery_failed, {:invalid_endpoint, _}}} =
+             Connect.resolve("ftp://nope")
+  end
+end

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -148,6 +148,13 @@ defmodule CDPEx.ConnectionTest do
       assert opts[:cacertfile] == "/tmp/ca.pem"
       assert opts[:verify] == :verify_peer
     end
+
+    test "cacerts pins explicit DER-encoded CA certs" do
+      opts = Connection.tls_opts(cacerts: [<<1, 2, 3>>])
+      assert opts[:cacerts] == [<<1, 2, 3>>]
+      assert opts[:verify] == :verify_peer
+      refute Keyword.has_key?(opts, :cacertfile)
+    end
   end
 
   test "subscribe/3 honours an explicit timeout and still registers (#49)", %{

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -132,6 +132,24 @@ defmodule CDPEx.ConnectionTest do
     assert_receive {:cdp_event, ^conn, "Page.lifecycleEvent", %{"name" => "load"}, nil}, 2_000
   end
 
+  describe "tls_opts/1" do
+    test "verifies the peer via the OS trust store by default" do
+      opts = Connection.tls_opts([])
+      assert opts[:verify] == :verify_peer
+      assert is_list(opts[:cacerts]) and opts[:cacerts] != []
+    end
+
+    test "insecure: true disables verification" do
+      assert Connection.tls_opts(insecure: true)[:verify] == :verify_none
+    end
+
+    test "cacertfile overrides the CA source" do
+      opts = Connection.tls_opts(cacertfile: "/tmp/ca.pem")
+      assert opts[:cacertfile] == "/tmp/ca.pem"
+      assert opts[:verify] == :verify_peer
+    end
+  end
+
   test "subscribe/3 honours an explicit timeout and still registers (#49)", %{
     conn: conn,
     fake: fake

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -111,15 +111,31 @@ defmodule CDPEx.IntegrationTest do
       {:ok, b} = CDPEx.connect("http://#{host}:#{port}")
 
       {:ok, page} = CDPEx.new_page(b, transport: :session)
+      b_target = page.target_id
       {:ok, _} = Page.navigate(page, fixture)
       assert {:ok, "Hello"} = Page.text(page, "#greeting")
+
+      # A tab opened directly on A (a "pre-existing" tab from B's perspective) that
+      # B's teardown must leave untouched.
+      {:ok, a_pre} = CDPEx.new_page(a, transport: :session)
+      a_pre_target = a_pre.target_id
 
       # Dedicated transport is not supported over a connected browser yet.
       assert {:error, {:unsupported_transport, :dedicated}} =
                CDPEx.new_page(b, transport: :dedicated)
 
-      # Stopping B must NOT kill the Chrome A owns: A still works afterward.
+      # Stopping B must NOT kill the Chrome A owns...
       assert :ok = CDPEx.stop(b)
+
+      # ...and it must close only the tabs B opened, leaving pre-existing ones alone.
+      # (Query the live targets through A's own browser connection.)
+      %{browser_conn: a_conn} = :sys.get_state(a)
+      {:ok, %{"targetInfos" => infos}} = Connection.call(a_conn, "Target.getTargets", %{})
+      live = Enum.map(infos, & &1["targetId"])
+      refute b_target in live, "B's session tab should have been closed on the remote by stop(b)"
+      assert a_pre_target in live, "a pre-existing tab on A must survive B's teardown"
+
+      # A still works afterward.
       assert {:ok, a_page} = CDPEx.new_page(a, transport: :session)
       {:ok, _} = Page.navigate(a_page, fixture)
       assert {:ok, "Hello"} = Page.text(a_page, "#greeting")

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -98,6 +98,49 @@ defmodule CDPEx.IntegrationTest do
     end
   end
 
+  describe "connect" do
+    test "connects via http discovery, drives a page, and leaves Chrome alive on stop", %{
+      fixture: fixture
+    } do
+      # A: a normally-launched browser that OWNS the Chrome process.
+      {:ok, a} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(a) end)
+      %{host: host, port: port} = :sys.get_state(a)
+
+      # B: connect to the SAME Chrome via its http endpoint (/json/version discovery).
+      {:ok, b} = CDPEx.connect("http://#{host}:#{port}")
+
+      {:ok, page} = CDPEx.new_page(b, transport: :session)
+      {:ok, _} = Page.navigate(page, fixture)
+      assert {:ok, "Hello"} = Page.text(page, "#greeting")
+
+      # Dedicated transport is not supported over a connected browser yet.
+      assert {:error, {:unsupported_transport, :dedicated}} =
+               CDPEx.new_page(b, transport: :dedicated)
+
+      # Stopping B must NOT kill the Chrome A owns: A still works afterward.
+      assert :ok = CDPEx.stop(b)
+      assert {:ok, a_page} = CDPEx.new_page(a, transport: :session)
+      {:ok, _} = Page.navigate(a_page, fixture)
+      assert {:ok, "Hello"} = Page.text(a_page, "#greeting")
+    end
+
+    test "with_page(connect:) runs against a running Chrome and leaves it alive", %{fixture: fixture} do
+      {:ok, a} = CDPEx.launch()
+      on_exit(fn -> stop_quietly(a) end)
+      %{host: host, port: port} = :sys.get_state(a)
+
+      result =
+        CDPEx.with_page([connect: "http://#{host}:#{port}"], fn page ->
+          {:ok, _} = Page.navigate(page, fixture)
+          Page.text(page, "#greeting")
+        end)
+
+      assert {:ok, "Hello"} = result
+      assert {:ok, _} = CDPEx.new_page(a, transport: :session)
+    end
+  end
+
   describe "session transport" do
     test "two session pages share one browser connection and stay isolated", %{fixture: fixture} do
       {:ok, browser} = CDPEx.launch()

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -125,7 +125,9 @@ defmodule CDPEx.IntegrationTest do
       assert {:ok, "Hello"} = Page.text(a_page, "#greeting")
     end
 
-    test "with_page(connect:) runs against a running Chrome and leaves it alive", %{fixture: fixture} do
+    test "with_page(connect:) runs against a running Chrome and leaves it alive", %{
+      fixture: fixture
+    } do
       {:ok, a} = CDPEx.launch()
       on_exit(fn -> stop_quietly(a) end)
       %{host: host, port: port} = :sys.get_state(a)

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -132,23 +132,22 @@ defmodule CDPEx.ProtocolTest do
   end
 
   describe "parse_ws_url/1" do
-    test "splits host, port, and path" do
+    test "splits scheme, host, port, and path" do
       assert Protocol.parse_ws_url("ws://127.0.0.1:9222/devtools/browser/abc-123") ==
-               {"127.0.0.1", 9222, "/devtools/browser/abc-123"}
+               {"ws", "127.0.0.1", 9222, "/devtools/browser/abc-123"}
     end
 
     test "handles a page target path" do
       assert Protocol.parse_ws_url("ws://localhost:5000/devtools/page/DEADBEEF") ==
-               {"localhost", 5000, "/devtools/page/DEADBEEF"}
+               {"ws", "localhost", 5000, "/devtools/page/DEADBEEF"}
     end
 
-    test "rejects wss:// (no remote/TLS endpoint support yet)" do
-      assert_raise ArgumentError, ~r{ws:// URL}, fn ->
-        Protocol.parse_ws_url("wss://127.0.0.1:9222/devtools/browser/abc-123")
-      end
+    test "accepts wss:// and reports the scheme" do
+      assert Protocol.parse_ws_url("wss://example.com:443/devtools/browser/abc") ==
+               {"wss", "example.com", 443, "/devtools/browser/abc"}
     end
 
-    test "rejects a non-ws scheme" do
+    test "rejects a non-ws(s) scheme" do
       assert_raise ArgumentError, fn -> Protocol.parse_ws_url("http://127.0.0.1:9222/x") end
     end
   end

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -147,8 +147,30 @@ defmodule CDPEx.ProtocolTest do
                {"wss", "example.com", 443, "/devtools/browser/abc"}
     end
 
+    test "carries the query string into the request target (token-auth cloud endpoints)" do
+      assert Protocol.parse_ws_url("wss://chrome.example.com/cdp?token=abc") ==
+               {"wss", "chrome.example.com", 443, "/cdp?token=abc"}
+    end
+
+    test "a query with no explicit path targets / plus the query" do
+      assert Protocol.parse_ws_url("wss://chrome.browserless.io?token=X") ==
+               {"wss", "chrome.browserless.io", 443, "/?token=X"}
+    end
+
     test "rejects a non-ws(s) scheme" do
       assert_raise ArgumentError, fn -> Protocol.parse_ws_url("http://127.0.0.1:9222/x") end
+    end
+  end
+
+  describe "bracket_host/1" do
+    test "brackets an IPv6 literal" do
+      assert Protocol.bracket_host("::1") == "[::1]"
+      assert Protocol.bracket_host("fe80::1") == "[fe80::1]"
+    end
+
+    test "passes a non-IPv6 host through unchanged" do
+      assert Protocol.bracket_host("127.0.0.1") == "127.0.0.1"
+      assert Protocol.bracket_host("localhost") == "localhost"
     end
   end
 

--- a/test/cdp_ex/protocol_test.exs
+++ b/test/cdp_ex/protocol_test.exs
@@ -174,6 +174,17 @@ defmodule CDPEx.ProtocolTest do
     end
   end
 
+  describe "sni/1" do
+    test "disables SNI for IP literals (RFC 6066)" do
+      assert Protocol.sni("127.0.0.1") == :disable
+      assert Protocol.sni("::1") == :disable
+    end
+
+    test "keeps a DNS name as a charlist" do
+      assert Protocol.sni("chrome.example.com") == ~c"chrome.example.com"
+    end
+  end
+
   test "prevent_alerts_js/0 overrides the three modal dialog functions" do
     js = Protocol.prevent_alerts_js()
     assert js =~ "window.alert"

--- a/test/cdp_ex_test.exs
+++ b/test/cdp_ex_test.exs
@@ -75,7 +75,8 @@ defmodule CDPExTest do
       {:cdp_error, "Page.navigate", %{"code" => -32_000, "message" => "boom"}},
       {:write_failed, :eacces},
       {:write_failed, :enospc},
-      {:no_document_response, "https://example.com/#hash"}
+      {:no_document_response, "https://example.com/#hash"},
+      {:connect_discovery_failed, :econnrefused}
     ]
 
     # Reasons CDPEx never produces — a future shape or a foreign wrapped term.

--- a/test/cdp_ex_test.exs
+++ b/test/cdp_ex_test.exs
@@ -55,6 +55,7 @@ defmodule CDPExTest do
       {:invalid_transport, :bogus},
       {:invalid_proxy, {:malformed_url, "nope"}},
       {:unsupported_transport, :session},
+      {:unsupported_with_connect, :proxy},
       {:invalid_response_body, "not-base64"},
       {:invalid_pdf_data, "not-base64"},
       {:invalid_screenshot_data, "not-base64"},

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -35,6 +35,14 @@ defmodule CDPEx.FixtureServer do
     end
   end
 
+  # :hang accepts the request then holds the socket without responding, so a client
+  # with a short discovery timeout trips :discovery_timeout deterministically.
+  defp serve(socket, :hang) do
+    _ = HttpFixture.recv_request(socket)
+    Process.sleep(2_000)
+    :gen_tcp.close(socket)
+  end
+
   defp serve(socket, json_version) do
     # Read the full request headers (they may arrive across TCP segments) so the
     # header reflection and auth check are deterministic, then respond.
@@ -102,6 +110,11 @@ defmodule CDPEx.FixtureServer do
 
   defp json_version_response(:server_error),
     do: HttpFixture.http_response("500 Internal Server Error", "boom")
+
+  # > 1 MB body, to trip CDPEx.Connect's @max_body_bytes cap (content is irrelevant —
+  # the cap fires before the body is parsed).
+  defp json_version_response(:oversized),
+    do: HttpFixture.http_response("200 OK", String.duplicate("x", 1_100_000), @json_ct)
 
   defp json_version_response(_ok) do
     body = ~s({"webSocketDebuggerUrl":"ws://127.0.0.1:1/devtools/browser/FAKE-GUID"})

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -73,6 +73,12 @@ defmodule CDPEx.FixtureServer do
       String.starts_with?(path, "/data") ->
         HttpFixture.http_response("200 OK", "fetched-data")
 
+      String.starts_with?(path, "/json/version") ->
+        # The host/port here are deliberately bogus (127.0.0.1:1): CDPEx.Connect must
+        # rewrite them to the endpoint's host/port, keeping only the discovered path.
+        body = ~s({"webSocketDebuggerUrl":"ws://127.0.0.1:1/devtools/browser/FAKE-GUID"})
+        HttpFixture.http_response("200 OK", body, ["Content-Type: application/json"])
+
       true ->
         HttpFixture.http_response("200 OK", render(request))
     end

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -12,31 +12,34 @@ defmodule CDPEx.FixtureServer do
 
   alias CDPEx.HttpFixture
 
-  @spec start() :: {:ok, %{port: non_neg_integer(), url: String.t()}}
-  def start do
+  @spec start(keyword()) :: {:ok, %{port: non_neg_integer(), url: String.t()}}
+  def start(opts \\ []) do
+    # `:json_version` selects the /json/version variant the connect-discovery tests
+    # exercise: :ok (default), :no_key, :non_string, :with_query, :server_error.
+    json_version = Keyword.get(opts, :json_version, :ok)
     {:ok, listen} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
     {:ok, port} = :inet.port(listen)
-    pid = spawn_link(fn -> accept_loop(listen) end)
+    pid = spawn_link(fn -> accept_loop(listen, json_version) end)
     _ = :gen_tcp.controlling_process(listen, pid)
     {:ok, %{port: port, url: "http://127.0.0.1:#{port}/"}}
   end
 
-  defp accept_loop(listen) do
+  defp accept_loop(listen, json_version) do
     case :gen_tcp.accept(listen) do
       {:ok, socket} ->
-        spawn(fn -> serve(socket) end)
-        accept_loop(listen)
+        spawn(fn -> serve(socket, json_version) end)
+        accept_loop(listen, json_version)
 
       {:error, :closed} ->
         :ok
     end
   end
 
-  defp serve(socket) do
+  defp serve(socket, json_version) do
     # Read the full request headers (they may arrive across TCP segments) so the
     # header reflection and auth check are deterministic, then respond.
     request = HttpFixture.recv_request(socket)
-    _ = :gen_tcp.send(socket, respond(request))
+    _ = :gen_tcp.send(socket, respond(request, json_version))
     :gen_tcp.close(socket)
   end
 
@@ -52,7 +55,7 @@ defmodule CDPEx.FixtureServer do
   #   /data       — a tiny XHR/fetch target (the #fetch-btn calls it), for the
   #     wait_for_response/3 and wait_for_network_idle/2 paths.
   #   anything else serves the page.
-  defp respond(request) do
+  defp respond(request, json_version) do
     path = request_path(request)
 
     cond do
@@ -74,14 +77,35 @@ defmodule CDPEx.FixtureServer do
         HttpFixture.http_response("200 OK", "fetched-data")
 
       String.starts_with?(path, "/json/version") ->
-        # The host/port here are deliberately bogus (127.0.0.1:1): CDPEx.Connect must
-        # rewrite them to the endpoint's host/port, keeping only the discovered path.
-        body = ~s({"webSocketDebuggerUrl":"ws://127.0.0.1:1/devtools/browser/FAKE-GUID"})
-        HttpFixture.http_response("200 OK", body, ["Content-Type: application/json"])
+        json_version_response(json_version)
 
       true ->
         HttpFixture.http_response("200 OK", render(request))
     end
+  end
+
+  @json_ct ["Content-Type: application/json"]
+
+  # The host/port in the returned ws URL are deliberately bogus (127.0.0.1:1):
+  # CDPEx.Connect must rewrite them to the endpoint's host/port, keeping only the
+  # discovered path (and query).
+  defp json_version_response(:no_key),
+    do: HttpFixture.http_response("200 OK", ~s({"browser":"Chrome/1.0"}), @json_ct)
+
+  defp json_version_response(:non_string),
+    do: HttpFixture.http_response("200 OK", ~s({"webSocketDebuggerUrl":123}), @json_ct)
+
+  defp json_version_response(:with_query) do
+    body = ~s({"webSocketDebuggerUrl":"ws://127.0.0.1:1/devtools/browser/GUID?token=abc"})
+    HttpFixture.http_response("200 OK", body, @json_ct)
+  end
+
+  defp json_version_response(:server_error),
+    do: HttpFixture.http_response("500 Internal Server Error", "boom")
+
+  defp json_version_response(_ok) do
+    body = ~s({"webSocketDebuggerUrl":"ws://127.0.0.1:1/devtools/browser/FAKE-GUID"})
+    HttpFixture.http_response("200 OK", body, @json_ct)
   end
 
   defp authorized?(request), do: HttpFixture.header_value(request, "authorization") == @basic_auth


### PR DESCRIPTION
Closes #73. Last functional gap before the soft launch: CDPEx could only launch its own Chrome — there was no way to attach to a Chrome it didn't start (a very common CDP pattern: a sidecar container, a shared/long-lived Chrome, or a cloud browser provider).

## What this adds

- **`CDPEx.connect/2`** — drive an already-running Chrome. Accepts either:
  - a `ws://` / `wss://` **browser** WebSocket URL (used directly), or
  - an `http://` / `https://` **base** URL — the browser socket is discovered via `GET /json/version`, deriving the final ws host/port from the *endpoint* (Chrome echoes the request `Host` into `webSocketDebuggerUrl`, so a remote endpoint would otherwise report `127.0.0.1`).
- Returns the **same handle as `launch/1`** — `new_page/2`, `with_page/3`, `close_page/2`, `stop/1` all work.
- **Never reaps the remote Chrome.** `stop/1` (and `terminate/2`) close only the targets cdp_ex opened and drop the socket; the Chrome we didn't launch — and any pre-existing tabs — are left untouched. This is the headline guarantee and is proven by the integration test.
- **`with_page([connect: endpoint], fun)`** — the one-shot form.
- **`wss://` re-enabled** (lifted the 0.8.0 `parse_ws_url/1` rejection), verified against the OS trust store via `:public_key.cacerts_get()` — **no new deps** (no castore). Escape hatches: `insecure: true`, `cacertfile:`, `cacerts:`.
- A failed discovery returns `{:error, {:connect_discovery_failed, reason}}` (classified `:unknown`).
- **Fixed:** the page WebSocket URL now brackets an IPv6 host (`ws://[::1]:9222/…`) instead of a malformed `ws://::1:9222/…`.

## Scope (MVP)

Pages over a connected browser use **`:session`** transport (many pages over the one browser socket). `:dedicated` over a connection returns `{:error, {:unsupported_transport, :dedicated}}` — a per-page socket would have to target the remote host; deferred as a follow-up.

## Design note

Connect-mode is tracked by an explicit `connected` field on `CDPEx.Browser`, **not** by `chrome: nil`. In production a launched browser always has a Chrome handle, but white-box unit fixtures build `%Browser{}` with none — keying connect behavior off `chrome: nil` conflated the two and flipped a launched proxy-auth page to the `:session` default. The explicit flag (set in `connect_browser` from `is_nil(chrome)`) drives the `:session` default, the `:dedicated` rejection, and the terminate close-our-targets branch.

## Verification

- `mix ci` green — format, `compile --warnings-as-errors`, docs, credo, dialyzer (0 errors), 248 tests.
- Real-Chrome integration (77 passed): launch Chrome A, `connect/2` to it via http discovery, drive a `:session` page, then `stop/1` the connected browser and assert **A's Chrome still works** (no-reap). Plus the `with_page(connect:)` form and the `:dedicated`-rejection path.
- `mix hex.build` packages `lib/cdp_ex/connect.ex`.

Lands under `[Unreleased]`; the **0.9.0** version bump + tag is a separate release step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)