### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-14
+
 ### Breaking
 - `CDPEx.Page.click/3` now dispatches a **trusted** `Input` mouse event by default
   (real `event.isTrusted`, hit-tested at the element's center after scroll-into-view)
@@ -205,7 +207,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CDPEx.Page`: `navigate/3`, `wait_for_selector/3`, `evaluate/3`, `click/3`,
   `html/2`, `screenshot/2`.
 
-[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/patrols/cdp_ex/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/patrols/cdp_ex/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/patrols/cdp_ex/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/patrols/cdp_ex/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/patrols/cdp_ex/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Add `cdp_ex` to your deps in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:cdp_ex, "~> 0.8.0"}
+    {:cdp_ex, "~> 0.9.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule CDPEx.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.9.0"
   @source_url "https://github.com/patrols/cdp_ex"
 
   def project do


### PR DESCRIPTION
Release 0.9.0.

- `mix.exs` 0.8.0 → 0.9.0
- CHANGELOG `[Unreleased]` → `[0.9.0] - 2026-06-14` + compare link
- README install pin `~> 0.9.0`

### Highlights
- **`CDPEx.connect/2`** — attach to an already-running/remote Chrome (`ws://`, `wss://`, or `http(s)://` `/json/version` discovery); `:session`-transport MVP, never reaps the remote Chrome (#73, #80).
- `wss://` re-enabled with OS-trust-store TLS (`:insecure`/`:cacertfile`/`:cacerts`, `:discovery_timeout`).
- Real trusted `Input` click + `type/4`/`press/4` (#72).
- Session-scoped `observe_network/2` (#27).
- `{:error, {:unserializable_value, _}}` evaluate result (#75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)