### PR TITLE
test(wait): lock in wait_for_selector quote-safety + JS-exception surfacing

### DIFF
--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -654,8 +654,11 @@ defmodule CDPEx.Page do
 
   The expression is coerced with `!!(...)`, so JS truthiness applies. Returns
   `:ok`, `{:error, :timeout}`, or `{:error, reason}` if a non-transient evaluate
-  error occurs (e.g. a thrown exception or a dropped connection). Options:
-  `:timeout` (default 5_000), `:interval` (poll interval ms, default 100).
+  error occurs. A transient CDP error (e.g. the execution context is rebuilding
+  mid-navigation) keeps polling; a non-transient one is fatal — including
+  `{:error, {:evaluate_exception, _}}` when the expression itself throws, and a
+  dropped connection. This is the shared error taxonomy behind `wait_for_selector/3`.
+  Options: `:timeout` (default 5_000), `:interval` (poll interval ms, default 100).
   """
   @spec wait_for_function(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def wait_for_function(%__MODULE__{} = page, js, opts \\ []) when is_binary(js) do

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -632,9 +632,17 @@ defmodule CDPEx.Page do
   @doc """
   Polls until `css` matches an element, or `timeout` elapses.
 
+  The selector is `Jason.encode!`-ed into the injected `document.querySelector(...)`
+  call, so quote characters in attribute selectors (`[id^='ticket-card-']`,
+  `[data-x="foo"]`) reach the page intact — no naive string concatenation.
+
   Returns `:ok`, `{:error, :timeout}`, or `{:error, reason}` if a non-transient
-  evaluate error occurs (e.g. the connection drops). Options: `:timeout`
-  (default 5_000), `:interval` (poll interval ms, default 100).
+  evaluate error occurs — including `{:error, {:evaluate_exception, _}}` when
+  `querySelector` itself throws (e.g. a syntactically invalid CSS selector). A
+  transient CDP error (e.g. the execution context is rebuilding mid-navigation)
+  keeps polling; a thrown JS exception is fatal so a bad selector doesn't hide as
+  a perpetual no-match. Options: `:timeout` (default 5_000), `:interval` (poll
+  interval ms, default 100).
   """
   @spec wait_for_selector(t(), String.t(), keyword()) :: :ok | {:error, term()}
   def wait_for_selector(%__MODULE__{} = page, css, opts \\ []) when is_binary(css) do

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -453,6 +453,41 @@ defmodule CDPEx.IntegrationTest do
       assert {:error, :timeout} = Page.wait_for_selector(page, "#does-not-exist", timeout: 300)
     end
 
+    test "wait_for_selector matches attribute selectors regardless of CSS quote style", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+
+      # Single-quoted attribute value — the selector itself contains characters
+      # ('\'') that must not corrupt the JS expression injected into Runtime.evaluate.
+      assert :ok = Page.wait_for_selector(page, "[id^='ticket-card-']", timeout: 2_000)
+
+      # Double-quoted attribute value — same property, with the inner-quote char
+      # swapped. A single-pattern JS literal can only escape one of the two safely.
+      assert :ok = Page.wait_for_selector(page, ~S([id^="ticket-card-"]), timeout: 2_000)
+
+      # An attribute value that itself contains a literal embedded quote, which
+      # any naive string-concat path would break on.
+      assert :ok = Page.wait_for_selector(page, ~S([data-name="foo bar"]), timeout: 2_000)
+    end
+
+    test "wait_for_selector surfaces a JS exception instead of polling forever", %{
+      page: page,
+      fixture: fixture
+    } do
+      {:ok, _} = Page.navigate(page, fixture)
+
+      # A syntactically invalid CSS selector that querySelector throws on.
+      # (Chrome is lenient about some malformed selectors — e.g. an unclosed
+      # `[foo` returns null silently — so pick one that actually throws.) A
+      # deterministic JS exception must surface immediately rather than collapse
+      # into a perpetual no-match and time out; a long timeout makes a "we waited
+      # it out" regression unmistakable.
+      assert {:error, {:evaluate_exception, _}} =
+               Page.wait_for_selector(page, ":::", timeout: 10_000)
+    end
+
     test "wait_for_function resolves when truthy and times out otherwise", %{
       page: page,
       fixture: fixture

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -467,9 +467,13 @@ defmodule CDPEx.IntegrationTest do
       # swapped. A single-pattern JS literal can only escape one of the two safely.
       assert :ok = Page.wait_for_selector(page, ~S([id^="ticket-card-"]), timeout: 2_000)
 
-      # An attribute value that itself contains a literal embedded quote, which
-      # any naive string-concat path would break on.
+      # A double-quoted attribute selector whose value contains a space.
       assert :ok = Page.wait_for_selector(page, ~S([data-name="foo bar"]), timeout: 2_000)
+
+      # The deepest case: a double-quoted attribute selector whose value itself
+      # contains a literal quote character (`a'b`). This is exactly what a naive
+      # string-concat path is most likely to break on.
+      assert :ok = Page.wait_for_selector(page, ~S([data-label="a'b"]), timeout: 2_000)
     end
 
     test "wait_for_selector surfaces a JS exception instead of polling forever", %{

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -484,12 +484,15 @@ defmodule CDPEx.IntegrationTest do
 
       # A syntactically invalid CSS selector that querySelector throws on.
       # (Chrome is lenient about some malformed selectors — e.g. an unclosed
-      # `[foo` returns null silently — so pick one that actually throws.) A
-      # deterministic JS exception must surface immediately rather than collapse
-      # into a perpetual no-match and time out; a long timeout makes a "we waited
-      # it out" regression unmistakable.
-      assert {:error, {:evaluate_exception, _}} =
-               Page.wait_for_selector(page, ":::", timeout: 10_000)
+      # `[foo` returns null silently — so pick one that actually throws.) The
+      # fatal arm returns the exception instantly, so a passing run never nears
+      # the timeout; the short 2s ceiling only bounds a regression. Asserting on
+      # the SyntaxError text makes a future Chrome-leniency change fail loudly
+      # here rather than silently degrade into a slow not-found timeout.
+      assert {:error, {:evaluate_exception, details}} =
+               Page.wait_for_selector(page, ":::", timeout: 2_000)
+
+      assert get_in(details, ["exception", "description"]) =~ "not a valid selector"
     end
 
     test "wait_for_function resolves when truthy and times out otherwise", %{

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -248,9 +248,17 @@ defmodule CDPEx.PageTest do
         "exception" => %{"className" => "DOMException", "description" => "SyntaxError"}
       }
 
+      # Wire-faithful Runtime.evaluate reply: real Chrome returns `exceptionDetails`
+      # as a sibling of the `result` RemoteObject, not nested under it.
       FakeCDP.send_text(
         fake,
-        Jason.encode!(%{"id" => id, "result" => %{"exceptionDetails" => exception_details}})
+        Jason.encode!(%{
+          "id" => id,
+          "result" => %{
+            "result" => %{"type" => "object", "subtype" => "error", "className" => "DOMException"},
+            "exceptionDetails" => exception_details
+          }
+        })
       )
 
       assert {:error, {:evaluate_exception, ^exception_details}} = Task.await(task, 2_000)

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -211,6 +211,21 @@ defmodule CDPEx.PageTest do
       )
     end
 
+    test "encodes an attribute value that itself contains a quote character", %{
+      page: page,
+      fake: fake
+    } do
+      # The deepest case: a double-quoted attribute selector whose value carries a
+      # literal single quote (`a'b`). JSON escapes only the wrapping double quotes,
+      # leaving the inner single quote untouched — pinned here Chrome-free.
+      assert_wait_for_selector_expression(
+        page,
+        fake,
+        ~S([data-label="a'b"]),
+        ~s{!!(document.querySelector("[data-label=\\"a'b\\"]") !== null)}
+      )
+    end
+
     test "surfaces an exceptionDetails response as :fatal instead of polling on", %{
       page: page,
       fake: fake
@@ -239,6 +254,39 @@ defmodule CDPEx.PageTest do
       )
 
       assert {:error, {:evaluate_exception, ^exception_details}} = Task.await(task, 2_000)
+    end
+
+    test "keeps polling on a transient cdp_error, then resolves when the element appears", %{
+      page: page,
+      fake: fake
+    } do
+      # The mirror of the exceptionDetails case: a CDP-level error (e.g. the
+      # execution context is being rebuilt mid-navigation) is transient, so the
+      # wait must keep polling rather than surface it. Answer the first
+      # Runtime.evaluate with a CDP error, prove a SECOND evaluate is issued
+      # (it polled on), then resolve truthy. A regression that merged the
+      # transient and fatal arms of probe_truthy/2 would terminate on the first
+      # error and never issue the second poll — failing this test.
+      task =
+        Task.async(fn ->
+          Page.wait_for_selector(page, "#late", timeout: 2_000, interval: 10)
+        end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => id1, "method" => "Runtime.evaluate"}}, 2_000
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"id":#{id1},"error":{"code":-32000,"message":"Cannot find context with specified id"}})
+      )
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => id2, "method" => "Runtime.evaluate"}}, 2_000
+
+      FakeCDP.send_text(
+        fake,
+        ~s({"id":#{id2},"result":{"result":{"type":"boolean","value":true}}})
+      )
+
+      assert :ok = Task.await(task, 2_000)
     end
   end
 

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -182,6 +182,66 @@ defmodule CDPEx.PageTest do
     end
   end
 
+  describe "wait_for_selector/3 encoding" do
+    # These tests pin the wire-level Runtime.evaluate expression so the selector's
+    # quote characters can't be re-introduced into the JS source by a future refactor
+    # that drops the Jason.encode! boundary. They run without Chrome so they always
+    # run in CI's default lane, unlike the integration coverage.
+    test "encodes a single-quoted attribute selector as a double-quoted JS string", %{
+      page: page,
+      fake: fake
+    } do
+      assert_wait_for_selector_expression(
+        page,
+        fake,
+        "[id^='ticket-card-']",
+        ~s{!!(document.querySelector("[id^='ticket-card-']") !== null)}
+      )
+    end
+
+    test "encodes a double-quoted attribute selector by escaping the embedded quotes", %{
+      page: page,
+      fake: fake
+    } do
+      assert_wait_for_selector_expression(
+        page,
+        fake,
+        ~S([id^="ticket-card-"]),
+        ~s{!!(document.querySelector("[id^=\\"ticket-card-\\"]") !== null)}
+      )
+    end
+
+    test "surfaces an exceptionDetails response as :fatal instead of polling on", %{
+      page: page,
+      fake: fake
+    } do
+      # A JS exception (e.g. an invalid CSS selector that querySelector throws on) must
+      # terminate the wait with the exception rather than collapse to "no match" and
+      # poll forever. probe_truthy classifies *cdp_error* responses as transient
+      # (context torn down mid-navigation) but exceptionDetails as fatal — a regression
+      # that merged the two would silently re-introduce the "30s timeout for any bad
+      # selector" bug.
+      task =
+        Task.async(fn ->
+          Page.wait_for_selector(page, ":::", timeout: 2_000, interval: 10)
+        end)
+
+      assert_receive {:fake_cdp_recv, ^fake, %{"id" => id, "method" => "Runtime.evaluate"}}, 2_000
+
+      exception_details = %{
+        "text" => "Uncaught",
+        "exception" => %{"className" => "DOMException", "description" => "SyntaxError"}
+      }
+
+      FakeCDP.send_text(
+        fake,
+        Jason.encode!(%{"id" => id, "result" => %{"exceptionDetails" => exception_details}})
+      )
+
+      assert {:error, {:evaluate_exception, ^exception_details}} = Task.await(task, 2_000)
+    end
+  end
+
   describe "navigate/3 with response: true" do
     test "reports the main document's status + final URL, correlated by loaderId", %{
       page: page,
@@ -1211,5 +1271,27 @@ defmodule CDPEx.PageTest do
 
   defp send_network_event(fake, method, request_id) do
     FakeCDP.send_text(fake, ~s({"method":"#{method}","params":{"requestId":"#{request_id}"}}))
+  end
+
+  defp assert_wait_for_selector_expression(page, fake, css, expected_js) do
+    task = Task.async(fn -> Page.wait_for_selector(page, css, timeout: 2_000, interval: 10) end)
+
+    assert_receive {:fake_cdp_recv, ^fake,
+                    %{
+                      "id" => id,
+                      "method" => "Runtime.evaluate",
+                      "params" => %{"expression" => expression}
+                    }},
+                   2_000
+
+    assert expression == expected_js
+
+    # Resolve the wait so the task exits cleanly rather than racing teardown.
+    FakeCDP.send_text(
+      fake,
+      ~s({"id":#{id},"result":{"result":{"type":"boolean","value":true}}})
+    )
+
+    assert :ok = Task.await(task, 2_000)
   end
 end

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -149,6 +149,10 @@ defmodule CDPEx.FixtureServer do
           <input id="search" />
         </form>
         <div id="echo-header">#{echo}</div>
+        <!-- Elements for the wait_for_selector attribute-prefix / quote-handling tests. -->
+        <div id="ticket-card-abc">card-abc</div>
+        <div id="ticket-card-def">card-def</div>
+        <div data-name="foo bar">named</div>
       </body>
     </html>
     """

--- a/test/support/fixture_server.ex
+++ b/test/support/fixture_server.ex
@@ -153,6 +153,7 @@ defmodule CDPEx.FixtureServer do
         <div id="ticket-card-abc">card-abc</div>
         <div id="ticket-card-def">card-def</div>
         <div data-name="foo bar">named</div>
+        <div data-label="a'b">named-quote</div>
       </body>
     </html>
     """


### PR DESCRIPTION
## What

Regression tests (and a doc clarification) for `CDPEx.Page.wait_for_selector/3`. **No behavior change** — the only `lib/` edit is a docstring; everything else is test/fixture code.

## Why

A downstream consumer reported that `wait_for_selector` "never matches" a CSS attribute-prefix selector with quotes (`[id^='ticket-card-']`) — it polled to timeout even when the elements existed — and hypothesised a quote/escaping bug in how the selector is interpolated into the injected `Runtime.evaluate` JS.

Investigated and **refuted**:

- `wait_for_selector/3` already passes the selector as a **JSON-encoded argument** (`document.querySelector(#{Jason.encode!(css)}) !== null`), so quotes in the selector reach the page intact. This has been true since the library's first commit — the bug never shipped.
- A JS `querySelector` exception already surfaces as `{:error, {:evaluate_exception, _}}` (fatal) rather than collapsing into a perpetual no-match; a transient `{:cdp_error, _, _}` correctly keeps polling.
- Verified against real Chrome, including a JS-injected-after-load page and three live target pages where the prefix selector resolved in 2–74 ms.

The real subtlety worth pinning is the opposite of the hypothesis: Chrome is *lenient* about some malformed selectors (e.g. an unclosed `[foo` returns `null` rather than throwing), so the exception test deliberately uses a selector that does throw.

## Coverage added

Unit (FakeCDP, wire-level `Runtime.evaluate` expression asserted Chrome-free):
- single-quoted attribute selector (`[id^='ticket-card-']`) encodes unchanged
- double-quoted attribute selector escapes the embedded quotes
- attribute value that itself contains a literal quote (`[data-label="a'b"]`)
- `exceptionDetails` reply ⇒ `{:error, {:evaluate_exception, _}}` is fatal (no further polling)
- a transient `{:cdp_error, _, _}` reply ⇒ keeps polling, then resolves

Integration (real Chrome + fixture): quote-style selectors match, and an invalid selector surfaces as a JS exception.

Doc: `wait_for_selector/3` now names the observable error taxonomy (`:timeout` vs `{:evaluate_exception, _}`) so consumers can branch instead of treating every non-`:ok` as "not found."

## Verification

`mix ci` green (270 unit tests; format/credo/dialyzer/docs clean). Integration suite green against real Chrome. No release needed — this is test/doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)