### PR TITLE
test(connect): de-flake "leaves Chrome alive on stop" tab-teardown race

### DIFF
--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -139,10 +139,16 @@ defmodule CDPEx.IntegrationTest do
         Enum.map(infos, & &1["targetId"])
       end
 
-      assert eventually(fn -> b_target not in live_targets.() end),
-             "B's session tab should have been closed on the remote by stop(b)"
+      # Poll until B's tab disappears, then re-snapshot once and assert against that
+      # snapshot — a genuine stop/1 regression (tab never closes) then reports what
+      # is still live instead of a bare "got false" timeout.
+      eventually(fn -> b_target not in live_targets.() end)
+      final_live = live_targets.()
 
-      assert a_pre_target in live_targets.(),
+      refute b_target in final_live,
+             "B's session tab should have been closed by stop(b); still live: #{inspect(final_live)}"
+
+      assert a_pre_target in final_live,
              "a pre-existing tab on A must survive B's teardown"
 
       # A still works afterward.

--- a/test/cdp_ex/integration_test.exs
+++ b/test/cdp_ex/integration_test.exs
@@ -128,12 +128,22 @@ defmodule CDPEx.IntegrationTest do
       assert :ok = CDPEx.stop(b)
 
       # ...and it must close only the tabs B opened, leaving pre-existing ones alone.
-      # (Query the live targets through A's own browser connection.)
+      # (Query the live targets through A's own browser connection.) stop(b) returns
+      # once B's transport is torn down, but the remote can take a beat to drop the
+      # closed tab from Target.getTargets — poll rather than snapshot once, or this
+      # races on a loaded runner.
       %{browser_conn: a_conn} = :sys.get_state(a)
-      {:ok, %{"targetInfos" => infos}} = Connection.call(a_conn, "Target.getTargets", %{})
-      live = Enum.map(infos, & &1["targetId"])
-      refute b_target in live, "B's session tab should have been closed on the remote by stop(b)"
-      assert a_pre_target in live, "a pre-existing tab on A must survive B's teardown"
+
+      live_targets = fn ->
+        {:ok, %{"targetInfos" => infos}} = Connection.call(a_conn, "Target.getTargets", %{})
+        Enum.map(infos, & &1["targetId"])
+      end
+
+      assert eventually(fn -> b_target not in live_targets.() end),
+             "B's session tab should have been closed on the remote by stop(b)"
+
+      assert a_pre_target in live_targets.(),
+             "a pre-existing tab on A must survive B's teardown"
 
       # A still works afterward.
       assert {:ok, a_page} = CDPEx.new_page(a, transport: :session)


### PR DESCRIPTION
## What

De-flakes the integration test `connect … connects via http discovery, drives a page, and leaves Chrome alive on stop` (`test/cdp_ex/integration_test.exs:102`). Test-only; no production change.

## Why

`CDPEx.stop(b)` returns once B's transport is torn down, but the remote Chrome can take a beat to drop B's closed session tab from `Target.getTargets`. The test took a **single immediate snapshot** of the target list right after `stop(b)` and asserted B's tab was already gone:

```elixir
{:ok, %{"targetInfos" => infos}} = Connection.call(a_conn, "Target.getTargets", %{})
live = Enum.map(infos, & &1["targetId"])
refute b_target in live, "B's session tab should have been closed on the remote by stop(b)"
```

That races on a loaded runner — it was observed failing in CI on an unrelated PR (#84) and passing on re-run, the classic signature of a teardown-propagation race rather than a real defect (`stop(b)` does close the tab; the remote just hasn't reflected it yet at the moment of the snapshot).

## Fix

Poll via the existing `eventually/2` helper until B's tab disappears (≤ 1s), then assert A's pre-existing tab still survives. The assertion intent is unchanged — B's tab must go, A's must stay.

```elixir
live_targets = fn ->
  {:ok, %{"targetInfos" => infos}} = Connection.call(a_conn, "Target.getTargets", %{})
  Enum.map(infos, & &1["targetId"])
end

assert eventually(fn -> b_target not in live_targets.() end),
       "B's session tab should have been closed on the remote by stop(b)"

assert a_pre_target in live_targets.(),
       "a pre-existing tab on A must survive B's teardown"
```

## Verification

Ran the test 5×/5 green locally against real Chrome; `mix ci` green (270 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)