### PR TITLE
ci: bump OTP 28.0 → 28.1 so Hex 2.5.0 starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
           - elixir: "1.15.8"
             otp: "26.2"
           - elixir: "1.19.5"
-            otp: "28.0"
+            otp: "28.1"
           - elixir: "1.20.0"
-            otp: "28.0"
+            otp: "28.1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -70,7 +70,7 @@ jobs:
 
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
         with:
-          otp-version: "28.0"
+          otp-version: "28.1"
           elixir-version: "1.19.5"
 
       - name: Install Chrome


### PR DESCRIPTION
## Summary
- Hex 2.5.0 (auto-installed by `setup-beam` on every run) calls `:re.import/1`, which only exists on OTP 28.1+. On our OTP `28.0` jobs, `mix deps.get` crashes at startup — before `mix ci` ever runs.
- Bumps the two `check` matrix rows (Elixir 1.19.5 + 1.20.0) and the `integration` job from `28.0` → `28.1`. The `1.15.8 / 26.2` row is unaffected (Hex only touches `:re.import` on OTP 28).

## Evidence
The failing job's log ([run 28407242782 → check (Elixir 1.20.0 / OTP 28.0)](https://github.com/patrols/cdp_ex/actions/runs/28407242782/job/84459211620)) shows both the setup-beam warning and the crash back-to-back:

```
warning! Erlang/OTP 28.0 detected.
Regexes will be re-compiled from source at runtime, which will cause degraded performance.
This can be fixed by using Erlang OTP 28.1+ or 27-.

...

** (UndefinedFunctionError) function :re.import/1 is undefined or private
    (stdlib 7.0.3) :re.import(...)
    (hex 2.5.0) lib/hex/cooldown.ex:74: Hex.Cooldown.duration_to_seconds/1
    (hex 2.5.0) lib/hex/cooldown.ex:19: Hex.Cooldown.parse_config/1
    (hex 2.5.0) lib/hex/state.ex:269: Hex.State.load_config_value/3
Could not start Hex.
```

This surfaced because Hex 2.5.0 shipped between the last green run (Jun 29) and the re-run (Jul 1). Reproduces on `main`, not specific to any PR — the currently-open dependabot PR #86 just happens to trigger it.

## Test plan
- [ ] All three `check` matrix rows go green
- [ ] `integration (real Chrome)` goes green
- [ ] Dependabot PR #86 rebases and its checks pass afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)