### PR TITLE
fix(test): wait for the await_event waiter before pushing frames

### DIFF
--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -269,8 +269,12 @@ defmodule CDPEx.ConnectionTest do
 
   test "await_event with a session gate ignores other sessions", %{conn: conn, fake: fake} do
     # A waiter scoped to session A must NOT resolve on a matching event from B.
+    registered = waiter_count(conn)
+
     task =
       Task.async(fn -> Connection.await_event(conn, &(&1["name"] == "x"), 300, session_id: "A") end)
+
+    await_waiter(conn, registered)
 
     FakeCDP.send_text(
       fake,
@@ -280,10 +284,14 @@ defmodule CDPEx.ConnectionTest do
     assert {:error, {:timeout, :await_event}} = Task.await(task)
 
     # The same matcher resolves when the event is from session A.
+    registered = waiter_count(conn)
+
     task2 =
       Task.async(fn ->
         Connection.await_event(conn, &(&1["name"] == "x"), 2_000, session_id: "A")
       end)
+
+    await_waiter(conn, registered)
 
     FakeCDP.send_text(
       fake,
@@ -294,10 +302,14 @@ defmodule CDPEx.ConnectionTest do
   end
 
   test "await_event resolves when a matching event arrives", %{conn: conn, fake: fake} do
+    registered = waiter_count(conn)
+
     task =
       Task.async(fn ->
         Connection.await_event(conn, &(&1["name"] == "networkAlmostIdle"), 2_000)
       end)
+
+    await_waiter(conn, registered)
 
     # A non-matching event first, then the match.
     FakeCDP.send_text(fake, ~s({"method":"Page.lifecycleEvent","params":{"name":"load"}}))
@@ -470,6 +482,17 @@ defmodule CDPEx.ConnectionTest do
 
   # Poll until `fun` returns true, or fail — for asserting an async state change
   # (here: the connection processing a subscriber's :DOWN) without a fixed sleep.
+  # `await_event/4` registers its matcher inside a GenServer.call, so spawning the
+  # task does not mean the waiter exists yet. An event the connection processes
+  # before that registration lands is delivered to nobody and the awaiter blocks
+  # until its own timeout — which is how these tests failed on a loaded CI runner
+  # while passing everywhere else. Push frames only once the waiter count grew.
+  defp await_waiter(conn, previous_count) do
+    eventually(fn -> waiter_count(conn) > previous_count end)
+  end
+
+  defp waiter_count(conn), do: length(:sys.get_state(conn).waiters)
+
   defp eventually(fun, retries \\ 100) do
     cond do
       fun.() ->

--- a/test/cdp_ex/connection_test.exs
+++ b/test/cdp_ex/connection_test.exs
@@ -380,8 +380,16 @@ defmodule CDPEx.ConnectionTest do
   } do
     ref = Process.monitor(conn)
 
+    registered = waiter_count(conn)
+
     throwing = Task.async(fn -> Connection.await_event(conn, fn _ -> throw(:boom) end, 300) end)
     exiting = Task.async(fn -> Connection.await_event(conn, fn _ -> exit(:boom) end, 300) end)
+
+    # Both matchers must be registered before the frame lands: this test asserts on
+    # timeouts, so a frame that arrives first would leave the matchers unrun and
+    # every assertion still true — passing green even with safe_match's catch
+    # clauses deleted.
+    await_waiter(conn, registered + 1)
 
     # Delivering an event runs both matchers inside the connection process. Without
     # safe_match catching throw/exit, the first one would take the socket owner down.


### PR DESCRIPTION
## The failure

`CDPEx.ConnectionTest` "await_event resolves when a matching event arrives" failed on CI's Elixir 1.15.8 / OTP 26.2 lane while 1.19.5, 1.20.0 and the real-Chrome integration lane all passed:

```
match (=) failed
code:  assert {:ok, %{"name" => "networkAlmostIdle"}} = Task.await(task)
right: {:error, {:timeout, :await_event}}
```

## Why

`await_event/4` registers its matcher **inside** a `GenServer.call` (`connection.ex:147`), so the waiter only exists once that call reaches the connection. The tests spawned the awaiter and immediately pushed frames:

```elixir
task = Task.async(fn -> Connection.await_event(conn, matcher, 2_000) end)
FakeCDP.send_text(fake, ...)   # nothing waits for the task to register
FakeCDP.send_text(fake, ...)
```

If the scheduler has not run the task yet, the connection processes the matching event with no waiter to deliver it to, and the awaiter then blocks until its own timeout. The library behaved correctly the whole time — the test was asserting on an ordering nothing enforced, which is why it only bites on a loaded runner.

## The fix

Wait for the connection's waiter count to grow before sending frames, using the `eventually/2` helper the file already has.

Applied at all three sites, not just the one that failed:

- the session-gate test's **first** waiter — it expects a timeout, so an unregistered waiter made it pass *for the wrong reason* (a vacuous pass)
- the session-gate test's second waiter
- "await_event resolves when a matching event arrives" — the CI failure

## Verification

The race is isolated rather than assumed. Adding a 30ms sleep before the `await_event` call:

| | before this PR | after |
|---|---|---|
| `mix test connection_test.exs:296` with 30ms delay | **fails deterministically**, exact CI error | passes |

Plus: whole file 100x with `--repeat-until-failure` green, and a cold `mix ci` (`rm -rf _build/test`) at 270 pass.

## Unrelated flake found while verifying

`CDPEx.PageTest` "leaves a same-process observe_network/2 subscription and buffered events intact (#48)" (`page_test.exs:1180`) is **independently flaky on main** — it failed one of my full `mix ci` runs with `observer lost its buffered requestWillBeSent event`, and reproduces locally:

```
mix test test/cdp_ex/page_test.exs:1180 --repeat-until-failure 60
```

It has its own synchronization helpers and a different failure mode (mailbox draining after idle resolves), so it needs its own analysis. Not touched here — filing it as a follow-up rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
