### PR TITLE
fix(test): wait for the observer's event instead of snapshotting the mailbox

### DIFF
--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -1194,7 +1194,7 @@ defmodule CDPEx.PageTest do
           send(
             test,
             {:caller_done, result, subscribed?(conn, self(), "Network.requestWillBeSent"),
-             drain_cdp_events(conn, "Network.requestWillBeSent", [])}
+             await_cdp_events(conn, "Network.requestWillBeSent")}
           )
         end)
 
@@ -1287,6 +1287,22 @@ defmodule CDPEx.PageTest do
   # enqueued (local sends are synchronous) before the helper sends the {:caller_done, ...}
   # that unblocks the caller, so they are already in the mailbox by the time this runs — no
   # flake window.
+  # Wait for the observer's copy of `method`, then take whatever else has queued.
+  #
+  # `drain_cdp_events/3` is a mailbox snapshot (`after 0`), which is only sound once the
+  # event is known to have been delivered. It is not: the idle helper drops events that
+  # arrive before it enters its counting loop (page.ex, pre-loop drain_events), so an
+  # event landing in that window leaves the helper idle immediately — and the caller then
+  # snapshots its mailbox in the same instant the connection is fanning the copy out.
+  # That lost the event roughly one run in sixty on an idle machine.
+  defp await_cdp_events(conn, method, timeout \\ 2_000) do
+    receive do
+      {:cdp_event, ^conn, ^method, params, _sid} -> drain_cdp_events(conn, method, [params])
+    after
+      timeout -> []
+    end
+  end
+
   defp drain_cdp_events(conn, method, acc) do
     receive do
       {:cdp_event, ^conn, ^method, params, _sid} ->

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -1282,19 +1282,10 @@ defmodule CDPEx.PageTest do
     end
   end
 
-  # Collect every buffered `method` cdp_event currently in this process's mailbox (the
-  # observer's copies), returning their params maps. `after 0` is safe here: the copies are
-  # enqueued (local sends are synchronous) before the helper sends the {:caller_done, ...}
-  # that unblocks the caller, so they are already in the mailbox by the time this runs — no
-  # flake window.
-  # Wait for the observer's copy of `method`, then take whatever else has queued.
-  #
-  # `drain_cdp_events/3` is a mailbox snapshot (`after 0`), which is only sound once the
-  # event is known to have been delivered. It is not: the idle helper drops events that
-  # arrive before it enters its counting loop (page.ex, pre-loop drain_events), so an
-  # event landing in that window leaves the helper idle immediately — and the caller then
-  # snapshots its mailbox in the same instant the connection is fanning the copy out.
-  # That lost the event roughly one run in sixty on an idle machine.
+  # Wait for the observer's copy of `method`, then take whatever else has queued. A
+  # snapshot races here: the idle helper drops events arriving before it enters its
+  # counting loop (page.ex pre-loop drain), so it can resolve in the same instant the
+  # connection is fanning the copy out. That lost the event one run in sixty.
   defp await_cdp_events(conn, method, timeout \\ 2_000) do
     receive do
       {:cdp_event, ^conn, ^method, params, _sid} -> drain_cdp_events(conn, method, [params])
@@ -1303,6 +1294,10 @@ defmodule CDPEx.PageTest do
     end
   end
 
+  # Every buffered `method` cdp_event already in this process's mailbox, as params maps.
+  # `after 0` is sound only where delivery is causally ordered before the caller unblocks —
+  # the navigate/#42 call site, where the helper captures the same fan-out that enqueued the
+  # observer's copy. Where that ordering is not guaranteed, use `await_cdp_events/3`.
   defp drain_cdp_events(conn, method, acc) do
     receive do
       {:cdp_event, ^conn, ^method, params, _sid} ->


### PR DESCRIPTION
Follow-up to #99, which noted this one as independently flaky.

## The failure

`CDPEx.PageTest` "leaves a same-process `observe_network/2` subscription and buffered events intact (#48)" fails roughly **one run in sixty** on an idle machine:

```
observer lost its buffered requestWillBeSent event
code: assert "R1" in ids
```

Reproduce with `mix test test/cdp_ex/page_test.exs:1180 --repeat-until-failure 60`.

## Why

`drain_cdp_events/3` reads the mailbox with `after 0` — a **snapshot**, which is only sound once the event is known to have been delivered. It isn't:

1. The idle helper drops events that arrive before it enters its counting loop (the pre-loop `drain_events` in `page.ex:1213`). Subscribed is not the same as ready to count.
2. A `requestWillBeSent` landing in that window leaves the helper with nothing in flight, so it resolves idle on its already-armed timer almost immediately.
3. `wait_for_network_idle` therefore returns in the same instant the connection is fanning the observer's copy out — and the caller snapshots its mailbox right then, seeing nothing.

The test's `Process.sleep(50)` in `enable_network_idle` is what usually covers step 1; the flake is what happens when the machine hiccups inside it.

## Measured, not guessed

| probe | result |
|---|---|
| 100ms sleep before the drain | 200 runs pass (vs failing within ~60) -> the drain is the proximate cause |
| subscriber count at send time, on a failing run | **2** -> the helper *was* subscribed, so the gap is readiness, not subscription |

## The fix

Wait for the observer's copy (bounded), then drain the rest.

**It keeps the assertion's teeth** — this tolerates delivery latency, not a lost event. Verified by deleting the `requestWillBeSent` send entirely: the test still fails on the same assertion after the timeout, exactly as it should if #48 ever regressed.

500 runs of the test green; cold `mix ci` 270 pass.

## Not addressed here

The underlying "subscribed != ready to count" window in `run_network_idle` is a library-design question (the helper's stale-event drain has no observable "loop entered" signal, which is why the test needs a sleep at all). Out of scope for a flaky-test fix — worth its own issue if you want the helper to expose readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
