### PR TITLE
feat(telemetry): announce when the idle wait starts counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `[:cdp_ex, :network_idle, :watching]` telemetry event — fires when `CDPEx.Page.wait_for_network_idle/2`'s helper has finished setting up (subscribed, `Network` enabled, events that arrived during enable discarded) and starts counting in-flight requests. Everything before it is setup, so a request that starts earlier is deliberately not counted. Measurements `%{system_time}`, metadata `%{session_id}` (`nil` for a dedicated page connection). Silent by default like every other CDPEx event; see `CDPEx.Telemetry` (#101).
+
 ## [0.9.0] - 2026-06-14
 
 ### Breaking

--- a/lib/cdp_ex/page.ex
+++ b/lib/cdp_ex/page.ex
@@ -1211,6 +1211,13 @@ defmodule CDPEx.Page do
     with :ok <- subscribe_each(page.conn, @idle_events, remaining(deadline), page.session_id),
          :ok <- ensure_network(page, remaining(deadline)) do
       Enum.each(@idle_events, &drain_events(page.conn, &1))
+
+      # Subscribed is not yet counting: the drain above discards whatever arrived
+      # while enabling, so a request that started before this point is invisible
+      # to the wait. Announce the boundary — it is the only way a caller (or a
+      # test) can know the helper is watching rather than still setting up.
+      Telemetry.network_idle_watching(page.session_id)
+
       ref = Process.monitor(page.conn)
 
       ctx = %{

--- a/lib/cdp_ex/telemetry.ex
+++ b/lib/cdp_ex/telemetry.ex
@@ -54,6 +54,16 @@ defmodule CDPEx.Telemetry do
   of `:stop` — so a gauge built by pairing `:start`/`:stop` should also decrement on
   those errors, or use a counter.
 
+  ### `[:cdp_ex, :network_idle, :watching]`
+
+  `CDPEx.Page.wait_for_network_idle/2`'s helper has subscribed, enabled the Network
+  domain, discarded the events that arrived while enabling, and is now counting
+  in-flight requests. Everything before this point is setup; a request that starts
+  earlier is not counted, so this marks where the wait actually begins.
+
+    * measurements — `%{system_time: System.system_time()}`
+    * metadata — `%{session_id}` (`nil` for a dedicated page connection)
+
   ### `[:cdp_ex, :error]`
 
   A genuine fault — a page's WebSocket closed unexpectedly, the browser connection went
@@ -102,6 +112,16 @@ defmodule CDPEx.Telemetry do
   @spec page(:start | :stop, :telemetry.event_metadata()) :: :ok
   def page(stage, metadata) when stage in [:start, :stop] do
     :telemetry.execute([:cdp_ex, :page, stage], %{system_time: System.system_time()}, metadata)
+  end
+
+  @doc false
+  @spec network_idle_watching(term()) :: :ok
+  def network_idle_watching(session_id) do
+    :telemetry.execute(
+      [:cdp_ex, :network_idle, :watching],
+      %{system_time: System.system_time()},
+      %{session_id: session_id}
+    )
   end
 
   @doc false

--- a/test/cdp_ex/page_test.exs
+++ b/test/cdp_ex/page_test.exs
@@ -1005,6 +1005,22 @@ defmodule CDPEx.PageTest do
   end
 
   describe "wait_for_network_idle/2" do
+    # The idle helper announces the moment it stops setting up and starts
+    # counting; `enable_network_idle/2` waits for that instead of guessing at it
+    # with a sleep, so a slow machine cannot land an event in the setup window.
+    setup do
+      handler = "idle-watching-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler,
+        [:cdp_ex, :network_idle, :watching],
+        &__MODULE__.forward_idle_watching/4,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+    end
+
     test "resolves when nothing is in flight from the call onward", %{page: page, fake: fake} do
       task = Task.async(fn -> Page.wait_for_network_idle(page, idle_time: 100, timeout: 2_000) end)
       enable_network_idle(fake)
@@ -1298,6 +1314,11 @@ defmodule CDPEx.PageTest do
   # `after 0` is sound only where delivery is causally ordered before the caller unblocks —
   # the navigate/#42 call site, where the helper captures the same fan-out that enqueued the
   # observer's copy. Where that ordering is not guaranteed, use `await_cdp_events/3`.
+  @doc false
+  def forward_idle_watching(_event, _measurements, metadata, test_pid) do
+    send(test_pid, {:idle_watching, metadata})
+  end
+
   defp drain_cdp_events(conn, method, acc) do
     receive do
       {:cdp_event, ^conn, ^method, params, _sid} ->
@@ -1331,9 +1352,9 @@ defmodule CDPEx.PageTest do
     if conn, do: for(m <- @idle_methods, do: wait_until_any_subscribed(conn, m))
     assert_receive {:fake_cdp_recv, ^fake, %{"id" => nid, "method" => "Network.enable"}}, 2_000
     FakeCDP.send_text(fake, ~s({"id":#{nid},"result":{}}))
-    # Let the helper drain stale events and enter the receive loop before the caller sends
-    # events, so they land in the loop rather than being swallowed by the pre-loop drain.
-    if conn, do: Process.sleep(50)
+    # Wait for the helper to finish its pre-loop drain and start counting, or an
+    # event sent next would be discarded as setup noise rather than tracked.
+    if conn, do: assert_receive({:idle_watching, _meta}, 2_000)
   end
 
   defp send_network_event(fake, method, request_id) do


### PR DESCRIPTION
Closes the loose end noted in #100.

## The gap

`run_network_idle` subscribes to the idle events, enables the Network domain, then **discards whatever arrived while enabling** (the pre-loop `drain_events`). So "subscribed" is not "counting", and nothing observable marked the difference.

The tests papered over it with `Process.sleep(50)` before sending events. That sleep is exactly what made the #48 observer test flaky in CI: when a loaded runner stretched the setup past 50ms, the event landed in the drain window, the helper counted nothing, and it resolved idle immediately.

## The change

Emit `[:cdp_ex, :network_idle, :watching]` at that boundary, and have the test helper wait for it instead of sleeping.

```elixir
# before
if conn, do: Process.sleep(50)

# after
if conn, do: assert_receive({:idle_watching, _meta}, 2_000)
```

## On adding a public event for this

Worth being straight about the motivation: the event is genuinely meaningful — it is where the wait *begins*, so a request that starts earlier is deliberately not counted, and that is a real thing to measure — but the reason it exists now is that a test could not otherwise know when setup ended. If you would rather not grow the telemetry surface for that, the alternative is a test-only hook, and I would rather ask than assume: the surface is documented as a contract, so this is your call to keep or reshape.

It follows the existing conventions: `%{system_time: ...}` measurements and a `%{session_id}` metadata map, matching the `[:cdp_ex, :page, :start | :stop]` shape, documented in the `CDPEx.Telemetry` moduledoc alongside the others.

## Verification

- page suite **30x** green with `--repeat-until-failure`
- cold `mix ci` (`rm -rf _build/test`) -> 270 pass
- `mix test --only integration` -> **80 pass against real Chrome**, so the event fires on a live browser and not just against FakeCDP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
